### PR TITLE
dependency-check false positive identifier on jhipster

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 dependencyCheck {
     analyzers.assemblyEnabled = false
     failBuildOnCVSS = 9.0F
+    suppressionFile = "suppressions.xml"
 }
 
 group = "org.example"

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>
+            <![CDATA[
+        file name: rewrite-jhipster-1.0.0.jar
+        ]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.openrewrite\.recipe/rewrite\-jhipster@.*$</packageUrl>
+        <cpe>cpe:/a:jhipster:jhipster</cpe>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
https://github.com/openrewrite/rewrite-recipe-markdown-generator/actions/runs/1728635566

False-positive identification of rewrite-jhipster being an incorrect or otherwise outdated jhipster dependency.