### PR TITLE
Add separate tab to generate a Maven shell command for rapid execution

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -498,7 +498,7 @@ class RecipeMarkdownGenerator : Runnable {
                         {% endcode %}
                         {% endtab %}
     
-                        {% tab title="Maven" %}
+                        {% tab title="Maven POM" %}
                         {% code title="pom.xml" %}
                         ```markup
                         <project>
@@ -517,6 +517,15 @@ class RecipeMarkdownGenerator : Runnable {
                             </plugins>
                           </build>
                         </project>
+                        ```
+                        {% endcode %}
+                        {% endtab %}
+    
+                        {% tab title="Maven Command Line" %}
+                        {% code title="shell" %}
+                        ```shell
+                        mvn org.openrewrite.maven:rewrite-maven-plugin:$mavenPluginVersion:run \
+                          -DactiveRecipes=${recipeDescriptor.name}
                         ```
                         {% endcode %}
                         {% endtab %}
@@ -551,7 +560,7 @@ class RecipeMarkdownGenerator : Runnable {
                         {% endcode %}
                         {% endtab %}
     
-                        {% tab title="Maven" %}
+                        {% tab title="Maven POM" %}
                         {% code title="pom.xml" %}
                         ```markup
                         <project>
@@ -580,11 +589,21 @@ class RecipeMarkdownGenerator : Runnable {
                         ```
                         {% endcode %}
                         {% endtab %}
+    
+                        {% tab title="Maven Command Line" %}
+                        {% code title="shell" %}
+                        ```shell
+                        mvn org.openrewrite.maven:rewrite-maven-plugin:$mavenPluginVersion:run \
+                          -Drewrite.recipeArtifactCoordinates=${origin.groupId}:${origin.artifactId}:${origin.version} \
+                          -DactiveRecipes=${recipeDescriptor.name}
+                        ```
+                        {% endcode %}
+                        {% endtab %}
                         {% endtabs %}
                         
                     """.trimIndent())
                 }
-                writeln("Recipes can also be activated directly from the command line by adding the argument `-Drewrite.activeRecipes${recipeDescriptor.name}`")
+                writeln("Recipes can also be activated directly from the command line by adding the argument `-Drewrite.activeRecipes=${recipeDescriptor.name}`")
             }
 
             if (recipeDescriptor.recipeList.isNotEmpty()) {


### PR DESCRIPTION
Adds a separate tab to each recipe page with a quick Maven shell command.

For a sample recipe: https://docs.openrewrite.org/reference/recipes/java/testing/junit5/junit5bestpractices

It generates an additional tab:
```
{% tab title="Maven Command Line" %}
{% code title="shell" %}
\```shell
mvn org.openrewrite.maven:rewrite-maven-plugin:4.32.0:run \
  -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:1.26.1 \
  -DactiveRecipes=org.openrewrite.java.testing.junit5.JUnit5BestPractices
\```
{% endcode %}
{% endtab %}
```
That allows users to quickly apply a recipe to Maven projects without having to copy and paste the pom.xml snippet into the right place. Would be helpful, without being too distracting I recon.