### PR TITLE
Show recipe name in bold & italics

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -271,7 +271,7 @@ class RecipeMarkdownGenerator : Runnable {
             write("""
                 # ${recipeDescriptor.displayName}
                 
-                ** ${recipeDescriptor.name.replace("_".toRegex(), "\\\\_")}**
+                **${recipeDescriptor.name.replace("_".toRegex(), "\\\\_")}**
                 
             """.trimIndent())
             if (!isNullOrEmpty(recipeDescriptor.description)) {


### PR DESCRIPTION
I'm guessing this is what was intended, as now it renders the asterisks instead of applying the styling, as shown on for example: https://docs.openrewrite.org/reference/recipes/java/cleanup/methodparampad