### PR TITLE
Create a CHANGELOG when building new recipes

### DIFF
--- a/src/main/kotlin/org/openrewrite/ChangedRecipe.kt
+++ b/src/main/kotlin/org/openrewrite/ChangedRecipe.kt
@@ -1,0 +1,21 @@
+package org.openrewrite
+
+import java.util.*
+
+data class ChangedRecipe(
+    val artifactId: String,
+    val name: String,
+    val description: String,
+    val docLink: String,
+    val newOptions: TreeSet<RecipeOption>?,
+    val oldOptions: TreeSet<RecipeOption>?,
+): Comparable<ChangedRecipe> {
+    override fun compareTo(other: ChangedRecipe): Int {
+        if (this.artifactId != other.artifactId) return this.artifactId.compareTo(other.artifactId)
+        if (this.name != other.name) return this.name.compareTo(other.name)
+        if (this.description != other.description) return this.description.compareTo(other.description)
+        if (this.newOptions != other.newOptions) return -1
+        if (this.oldOptions != other.oldOptions) return -1
+        return 0
+    }
+}

--- a/src/main/kotlin/org/openrewrite/MarkdownRecipeArtifact.kt
+++ b/src/main/kotlin/org/openrewrite/MarkdownRecipeArtifact.kt
@@ -1,15 +1,14 @@
 package org.openrewrite
 
-import java.util.TreeSet
+import java.util.TreeMap
 
 data class MarkdownRecipeArtifact (
     val artifactId: String,
     val version: String,
-    val markdownRecipeDescriptors: TreeSet<MarkdownRecipeDescriptor>,
+    val markdownRecipeDescriptors: TreeMap<String, MarkdownRecipeDescriptor>,
 ) : Comparable<MarkdownRecipeArtifact> {
     override fun compareTo(other: MarkdownRecipeArtifact): Int {
         if (this.artifactId != other.artifactId) return this.artifactId.compareTo(other.artifactId)
-        if (this.version != other.version) return this.version.compareTo(other.version)
         if (this.markdownRecipeDescriptors != other.markdownRecipeDescriptors) return -1
         return 0
     }

--- a/src/main/resources/recipeDescriptors.yml
+++ b/src/main/resources/recipeDescriptors.yml
@@ -1,5434 +1,6674 @@
-- artifactId: "rewrite-circleci"
+rewrite-circleci:
+  artifactId: "rewrite-circleci"
+  version: "1.15.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.circleci.InstallOrb:
+      name: "org.openrewrite.circleci.InstallOrb"
+      description: "Install a CircleCI [orb](https://circleci.com/docs/2.0/orb-intro/)\
+        \ if it is not already installed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/circleci/installorb"
+      options:
+      - name: "orbKey"
+        type: "String"
+        required: true
+      - name: "slug"
+        type: "String"
+        required: true
+    org.openrewrite.circleci.UpdateImage:
+      name: "org.openrewrite.circleci.UpdateImage"
+      description: "See the list of [pre-built CircleCI images](https://circleci.com/docs/2.0/circleci-images/)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/circleci/updateimage"
+      options:
+      - name: "image"
+        type: "String"
+        required: true
+rewrite-concourse:
+  artifactId: "rewrite-concourse"
   version: "1.14.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.circleci.InstallOrb"
-    description: "Install a CircleCI [orb](https://circleci.com/docs/2.0/orb-intro/)\
-      \ if it is not already installed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/circleci/installorb"
-    options:
-    - name: "orbKey"
-      type: "String"
-      required: true
-    - name: "slug"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.circleci.UpdateImage"
-    description: "See the list of [pre-built CircleCI images](https://circleci.com/docs/2.0/circleci-images/)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/circleci/updateimage"
-    options:
-    - name: "image"
-      type: "String"
-      required: true
-- artifactId: "rewrite-concourse"
-  version: "1.13.0"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.concourse.ChangeResourceVersion"
-    description: "Pin or unpin a resource to a particular version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/concourse/changeresourceversion"
-    options:
-    - name: "resourceType"
-      type: "String"
-      required: true
-    - name: "version"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.concourse.ChangeValue"
-    description: "Change every value matching the key pattern."
-    docLink: "https://docs.openrewrite.org/reference/recipes/concourse/changevalue"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "keyPath"
-      type: "String"
-      required: true
-    - name: "newValue"
-      type: "String"
-      required: true
-    - name: "oldValue"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.concourse.FindResource"
-    description: "Find a Concourse resource by name."
-    docLink: "https://docs.openrewrite.org/reference/recipes/concourse/findresource"
-    options:
-    - name: "type"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.concourse.UpdateGitResourceUri"
-    description: "Update git resource `source.uri` URI values to point to a new URI\
-      \ value."
-    docLink: "https://docs.openrewrite.org/reference/recipes/concourse/updategitresourceuri"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newURI"
-      type: "String"
-      required: true
-    - name: "oldURIPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.concourse.search.FindPinnedResource"
-    description: "Find resources of a particular type that have pinned versions."
-    docLink: "https://docs.openrewrite.org/reference/recipes/concourse/search/findpinnedresource"
-    options:
-    - name: "resourceType"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.concourse.search.FindPrivilegedResourceType"
-    description: "By default, `resource_type` definitions are unprivileged."
-    docLink: "https://docs.openrewrite.org/reference/recipes/concourse/search/findprivilegedresourcetype"
-    options: []
-- artifactId: "rewrite-core"
+    org.openrewrite.concourse.ChangeResourceVersion:
+      name: "org.openrewrite.concourse.ChangeResourceVersion"
+      description: "Pin or unpin a resource to a particular version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/concourse/changeresourceversion"
+      options:
+      - name: "resourceType"
+        type: "String"
+        required: true
+      - name: "version"
+        type: "String"
+        required: false
+    org.openrewrite.concourse.ChangeValue:
+      name: "org.openrewrite.concourse.ChangeValue"
+      description: "Change every value matching the key pattern."
+      docLink: "https://docs.openrewrite.org/reference/recipes/concourse/changevalue"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "keyPath"
+        type: "String"
+        required: true
+      - name: "newValue"
+        type: "String"
+        required: true
+      - name: "oldValue"
+        type: "String"
+        required: false
+    org.openrewrite.concourse.FindResource:
+      name: "org.openrewrite.concourse.FindResource"
+      description: "Find a Concourse resource by name."
+      docLink: "https://docs.openrewrite.org/reference/recipes/concourse/findresource"
+      options:
+      - name: "type"
+        type: "String"
+        required: true
+    org.openrewrite.concourse.UpdateGitResourceUri:
+      name: "org.openrewrite.concourse.UpdateGitResourceUri"
+      description: "Update git resource `source.uri` URI values to point to a new\
+        \ URI value."
+      docLink: "https://docs.openrewrite.org/reference/recipes/concourse/updategitresourceuri"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newURI"
+        type: "String"
+        required: true
+      - name: "oldURIPattern"
+        type: "String"
+        required: false
+    org.openrewrite.concourse.search.FindPinnedResource:
+      name: "org.openrewrite.concourse.search.FindPinnedResource"
+      description: "Find resources of a particular type that have pinned versions."
+      docLink: "https://docs.openrewrite.org/reference/recipes/concourse/search/findpinnedresource"
+      options:
+      - name: "resourceType"
+        type: "String"
+        required: false
+    org.openrewrite.concourse.search.FindPrivilegedResourceType:
+      name: "org.openrewrite.concourse.search.FindPrivilegedResourceType"
+      description: "By default, `resource_type` definitions are unprivileged."
+      docLink: "https://docs.openrewrite.org/reference/recipes/concourse/search/findprivilegedresourcetype"
+      options: []
+rewrite-core:
+  artifactId: "rewrite-core"
   version: "7.33.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.DeleteSourceFiles"
-    description: "Delete files by source path."
-    docLink: "https://docs.openrewrite.org/reference/recipes/deletesourcefiles"
-    options:
-    - name: "filePattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.FindParseFailures"
-    description: "This recipe explores parse failures after an AST is produced for\
-      \ classifying the types of failures that can occur and prioritizing fixes according\
-      \ to the most common problems."
-    docLink: "https://docs.openrewrite.org/reference/recipes/findparsefailures"
-    options: []
-  - name: "org.openrewrite.FindQuarks"
-    description: "Find instances of type `Quark`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/findquarks"
-    options: []
-  - name: "org.openrewrite.FindSourceFiles"
-    description: "Find files by source path."
-    docLink: "https://docs.openrewrite.org/reference/recipes/findsourcefiles"
-    options:
-    - name: "filePattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.RenameFile"
-    description: "Rename a file while keeping it in the same directory."
-    docLink: "https://docs.openrewrite.org/reference/recipes/renamefile"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: true
-    - name: "fileName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.SetFilePermissions"
-    description: "Set a files read, write and executable permission attributes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/setfilepermissions"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: true
-    - name: "isExecutable"
-      type: "Boolean"
-      required: true
-    - name: "isReadable"
-      type: "Boolean"
-      required: true
-    - name: "isWritable"
-      type: "Boolean"
-      required: true
-  - name: "org.openrewrite.config.CompositeRecipe"
-    description: ""
-    docLink: "https://docs.openrewrite.org/reference/recipes/config/compositerecipe"
-    options: []
-- artifactId: "rewrite-github-actions"
-  version: "1.13.0"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.github.ActionsSetupJavaAdoptOpenJDKToTemurin"
-    description: "Adopt OpenJDK got moved to Eclipse Temurin and won't be updated\
-      \ anymore. It is highly recommended to migrate workflows from adopt to temurin\
-      \ to keep receiving software and security updates. See more details in the [Good-bye\
-      \ AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/github/actionssetupjavaadoptopenjdktotemurin"
-    options: []
-  - name: "org.openrewrite.github.AddCronTrigger"
-    description: "The `schedule` [event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events)\
-      \ allows you to trigger a workflow at a scheduled time."
-    docLink: "https://docs.openrewrite.org/reference/recipes/github/addcrontrigger"
-    options:
-    - name: "cron"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.github.AddManualTrigger"
-    description: "You can manually trigger workflow runs. To trigger specific workflows\
-      \ in a repository, use the `workflow_dispatch` event."
-    docLink: "https://docs.openrewrite.org/reference/recipes/github/addmanualtrigger"
-    options: []
-  - name: "org.openrewrite.github.AutoCancelInProgressWorkflow"
-    description: "When a workflow is already running and would be triggered again,\
-      \ cancel the existing workflow. See [`styfle/cancel-workflow-action`](https://github.com/styfle/cancel-workflow-action)\
-      \ for details."
-    docLink: "https://docs.openrewrite.org/reference/recipes/github/autocancelinprogressworkflow"
-    options:
-    - name: "accessToken"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.github.ChangeDependabotScheduleInterval"
-    description: "Change the schedule interval for a given package-ecosystem in a\
-      \ `dependabot.yml` configuration file. [The available configuration options\
-      \ for dependabot are listed on GitHub](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/github/changedependabotscheduleinterval"
-    options:
-    - name: "interval"
-      type: "String"
-      required: true
-    - name: "packageEcosystem"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.github.DependabotCheckForGithubActionsUpdatesDaily"
-    description: "Set dependabot to check for github-actions updates daily."
-    docLink: "https://docs.openrewrite.org/reference/recipes/github/dependabotcheckforgithubactionsupdatesdaily"
-    options: []
-  - name: "org.openrewrite.github.DependabotCheckForGithubActionsUpdatesWeekly"
-    description: "Set dependabot to check for github-actions updates weekly."
-    docLink: "https://docs.openrewrite.org/reference/recipes/github/dependabotcheckforgithubactionsupdatesweekly"
-    options: []
-  - name: "org.openrewrite.github.SetupJavaCaching"
-    description: "Github actions supports dependency caching on Maven and Gradle projects.\
-      \ See the [blog post](https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/github/setupjavacaching"
-    options: []
-- artifactId: "rewrite-gradle"
-  version: "7.32.1"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.gradle.ActivateStyle"
-    description: "Sets the specified style as active. Once the style has been set,\
-      \ future recipes will use the specified style for any changes they make. This\
-      \ recipe does not reformat anything on its own. Prefers to set the `activeStyle()`\
-      \ method in the `rewrite` DSL in a build.gradle.If no `rewrite` DSL can be found\
-      \ to update, will instead place a \"systemProp.rewrite.activeStyles\" entry\
-      \ within the project's gradle.properties. Styles can be provided by rewrite\
-      \ itself, defined in a rewrite.yml, or provided by recipe modules."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/activatestyle"
-    options:
-    - name: "fullyQualifiedStyleName"
-      type: "String"
-      required: true
-    - name: "overwriteExistingStyles"
-      type: "boolean"
-      required: false
-  - name: "org.openrewrite.gradle.AddDelegatesToGradleApi"
-    description: "The Gradle API has methods which accept `groovy.lang.Closure`. Typically,\
-      \ there is an overload which accepts an `org.gradle.api.Action`.This recipe\
-      \ takes the type declared as the receiver of the `Action` overload and adds\
-      \ an appropriate `@groovy.lang.DelegatesTo` annotation to the `Closure` overload."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/adddelegatestogradleapi"
-    options: []
-  - name: "org.openrewrite.gradle.AddGradleWrapper"
-    description: "Add a Gradle wrapper where one does not exist."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/addgradlewrapper"
-    options:
-    - name: "distribution"
-      type: "String"
-      required: false
-    - name: "version"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.ChangeDependencyArtifactId"
-    description: "Change the artifactId of a specified Gradle dependency. "
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyartifactid"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newArtifactId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.ChangeDependencyClassifier"
-    description: "Finds dependencies declared in `build.gradle` files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyclassifier"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newClassifier"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.ChangeDependencyConfiguration"
-    description: "Finds dependencies declared in `build.gradle` files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyconfiguration"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newConfiguration"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.ChangeDependencyExtension"
-    description: "Finds dependencies declared in `build.gradle` files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyextension"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newExtension"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.ChangeDependencyGroupId"
-    description: "Change the group id of a specified Gradle dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencygroupid"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newGroupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.ChangeDependencyVersion"
-    description: "Finds dependencies declared in `build.gradle` files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyversion"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newVersion"
-      type: "String"
-      required: true
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.gradle.ChangeJavaCompatibility"
-    description: "Find and updates the Java compatibility for the Gradle project"
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changejavacompatibility"
-    options:
-    - name: "compatibilityType"
-      type: "String"
-      required: true
-    - name: "newVersion"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.DependencyUseMapNotation"
-    description: "In Gradle, dependencies can be expressed as a `String` like `\"\
-      groupId:artifactId:version\"`, or equivalently as a `Map` like `group: 'groupId',\
-      \ name: 'artifactId', version: 'version'`. This recipe replaces dependencies\
-      \ represented as `Strings` with an equivalent dependency represented as a `Map`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/dependencyusemapnotation"
-    options: []
-  - name: "org.openrewrite.gradle.DependencyUseStringNotation"
-    description: "In Gradle, dependencies can be expressed as a `String` like `\"\
-      groupId:artifactId:version\"`, or equivalently as a `Map` like `group: 'groupId',\
-      \ name: 'artifactId', version: 'version'`. This recipe replaces dependencies\
-      \ represented as `Maps` with an equivalent dependency represented as a `String`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/dependencyusestringnotation"
-    options: []
-  - name: "org.openrewrite.gradle.RemoveGradleDependency"
-    description: "Removes a single dependency from the dependencies section of the\
-      \ `build.gradle`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/removegradledependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.RemoveRepository"
-    description: "Removes a repository from Gradle build scripts. Named repositories\
-      \ include \"jcenter\", \"mavenCentral\", \"mavenLocal\", and \"google\""
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/removerepository"
-    options:
-    - name: "repository"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.UpdateGradleWrapper"
-    description: "Update the version of Gradle used in an existing Gradle wrapper."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/updategradlewrapper"
-    options:
-    - name: "distribution"
-      type: "String"
-      required: false
-    - name: "version"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.UpgradePluginVersion"
-    description: "Update a Gradle plugin by id to a later version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/upgradepluginversion"
-    options:
-    - name: "newVersion"
-      type: "String"
-      required: true
-    - name: "pluginIdPattern"
-      type: "String"
-      required: true
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.gradle.search.FindDependency"
-    description: "Finds dependencies declared in `build.gradle` files. See the [reference](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph)\
-      \ on Gradle configurations or the diagram below for a description of what configuration\
-      \ to use. A project's compile and runtime classpath is based on these configurations.\n\
-      \n<img alt=\"Gradle compile classpath\" src=\"https://docs.gradle.org/current/userguide/img/java-library-ignore-deprecated-main.png\"\
-      \ width=\"200px\"/>\n A project's test classpath is based on these configurations.\n\
-      \n<img alt=\"Gradle test classpath\" src=\"https://docs.gradle.org/current/userguide/img/java-library-ignore-deprecated-test.png\"\
-      \ width=\"200px\"/>"
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/search/finddependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.search.FindDependencyHandler"
-    description: "Find the dependency handler containing any number of dependency\
-      \ definitions."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/search/finddependencyhandler"
-    options: []
-  - name: "org.openrewrite.gradle.search.FindPlugin"
-    description: "Find a Gradle plugin by id."
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/search/findplugin"
-    options:
-    - name: "pluginId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.gradle.security.UseHttpsForRepositories"
-    description: "Use HTTPS for repository urls"
-    docLink: "https://docs.openrewrite.org/reference/recipes/gradle/security/usehttpsforrepositories"
-    options: []
-- artifactId: "rewrite-groovy"
-  version: "7.33.0"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.groovy.format.OmitParenthesesForLastArgumentLambda"
-    description: "Groovy allows a shorthand syntax that allows a closure to be placed\
-      \ outside of parentheses."
-    docLink: "https://docs.openrewrite.org/reference/recipes/groovy/format/omitparenthesesforlastargumentlambda"
-    options: []
-  - name: "org.openrewrite.groovy.format.OmitParenthesesFormat"
-    description: "Format tabs and indents in Java code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/groovy/format/omitparenthesesformat"
-    options: []
-- artifactId: "rewrite-hcl"
-  version: "7.32.1"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.hcl.DeleteContent"
-    description: "Delete HCL content by path."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/deletecontent"
-    options:
-    - name: "contentPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.hcl.MoveContentToFile"
-    description: "Move content to another HCL file, deleting it in the original file."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/movecontenttofile"
-    options:
-    - name: "contentPath"
-      type: "String"
-      required: true
-    - name: "destinationPath"
-      type: "String"
-      required: true
-    - name: "fromPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.hcl.format.AutoFormat"
-    description: "Format HCL code using a standard comprehensive set of HCL formatting\
-      \ recipes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/autoformat"
-    options: []
-  - name: "org.openrewrite.hcl.format.BlankLines"
-    description: "Add and/or remove blank lines."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/blanklines"
-    options: []
-  - name: "org.openrewrite.hcl.format.NormalizeFormat"
-    description: "Move whitespace to the outermost AST element possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/normalizeformat"
-    options: []
-  - name: "org.openrewrite.hcl.format.RemoveTrailingWhitespace"
-    description: "Remove any extra trailing whitespace from the end of each line."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/removetrailingwhitespace"
-    options: []
-  - name: "org.openrewrite.hcl.format.Spaces"
-    description: "Format whitespace in HCL code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/spaces"
-    options: []
-  - name: "org.openrewrite.hcl.format.TabsAndIndents"
-    description: "Format tabs and indents in HCL code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/tabsandindents"
-    options: []
-  - name: "org.openrewrite.hcl.search.FindContent"
-    description: "Find HCL content by path."
-    docLink: "https://docs.openrewrite.org/reference/recipes/hcl/search/findcontent"
-    options:
-    - name: "contentPath"
-      type: "String"
-      required: true
-- artifactId: "rewrite-java"
-  version: "7.33.0"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.AddApache2LicenseHeader"
-    description: "Adds the Apache Software License Version 2.0 to Java source files\
-      \ which are missing a license header."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/addapache2licenseheader"
-    options: []
-  - name: "org.openrewrite.java.AddLicenseHeader"
-    description: "Adds license headers to Java source files when missing. Does not\
-      \ override existing license headers."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/addlicenseheader"
-    options:
-    - name: "licenseText"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.AddOrUpdateAnnotationAttribute"
-    description: "Some annotations accept arguments. This recipe sets an existing\
-      \ argument to the specified value, or adds the argument if it is not already\
-      \ set."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/addorupdateannotationattribute"
-    options:
-    - name: "addOnly"
-      type: "Boolean"
-      required: true
-    - name: "annotationType"
-      type: "String"
-      required: true
-    - name: "attributeName"
-      type: "String"
-      required: false
-    - name: "attributeValue"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.ChangeMethodAccessLevel"
-    description: "Change the access level (public, protected, private, package private)\
-      \ of a method."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/changemethodaccesslevel"
-    options:
-    - name: "matchOverrides"
-      type: "Boolean"
-      required: false
-    - name: "methodPattern"
-      type: "String"
-      required: true
-    - name: "newAccessLevel"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.ChangeMethodName"
-    description: "Rename a method."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/changemethodname"
-    options:
-    - name: "ignoreDefinition"
-      type: "Boolean"
-      required: false
-    - name: "matchOverrides"
-      type: "Boolean"
-      required: false
-    - name: "methodPattern"
-      type: "String"
-      required: true
-    - name: "newMethodName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.ChangeMethodTargetToStatic"
-    description: "Change method invocations to static method calls."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/changemethodtargettostatic"
-    options:
-    - name: "fullyQualifiedTargetTypeName"
-      type: "String"
-      required: true
-    - name: "matchOverrides"
-      type: "Boolean"
-      required: false
-    - name: "matchUnknownTypes"
-      type: "Boolean"
-      required: false
-    - name: "methodPattern"
-      type: "String"
-      required: true
-    - name: "returnType"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.ChangeMethodTargetToVariable"
-    description: "Change method invocations to method calls on a variable."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/changemethodtargettovariable"
-    options:
-    - name: "matchOverrides"
-      type: "Boolean"
-      required: false
-    - name: "methodPattern"
-      type: "String"
-      required: true
-    - name: "variableName"
-      type: "String"
-      required: true
-    - name: "variableType"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.ChangePackage"
-    description: "A recipe that will rename a package name in package statements,\
-      \ imports, and fully-qualified types."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/changepackage"
-    options:
-    - name: "newPackageName"
-      type: "String"
-      required: true
-    - name: "oldPackageName"
-      type: "String"
-      required: true
-    - name: "recursive"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.ChangeStaticFieldToMethod"
-    description: "Migrate accesses to a static field to invocations of a static method."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/changestaticfieldtomethod"
-    options:
-    - name: "newClassName"
-      type: "String"
-      required: false
-    - name: "newMethodName"
-      type: "String"
-      required: true
-    - name: "newTarget"
-      type: "String"
-      required: false
-    - name: "oldClassName"
-      type: "String"
-      required: true
-    - name: "oldFieldName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.ChangeType"
-    description: "Change a given type to another."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/changetype"
-    options:
-    - name: "ignoreDefinition"
-      type: "Boolean"
-      required: false
-    - name: "newFullyQualifiedTypeName"
-      type: "String"
-      required: true
-    - name: "oldFullyQualifiedTypeName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.DeleteMethodArgument"
-    description: "Delete an argument from method invocations."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/deletemethodargument"
-    options:
-    - name: "argumentIndex"
-      type: "int"
-      required: true
-    - name: "methodPattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.DoesNotUseRewriteSkip"
-    description: "The annotation provides a mechanism to skip a whole source file\
-      \ from consideration"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/doesnotuserewriteskip"
-    options: []
-  - name: "org.openrewrite.java.NoStaticImport"
-    description: "Removes static imports and replaces them with qualified references.\
-      \ For example, `emptyList()` becomes `Collections.emptyList()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/nostaticimport"
-    options:
-    - name: "methodPattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.OrderImports"
-    description: "Group and order imports."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/orderimports"
-    options:
-    - name: "removeUnused"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.RandomizeId"
-    description: "Scramble the IDs. This was intended as a utility to test _en masse_\
-      \ different techniques for UUID generation and compare their relative performance\
-      \ outside of a microbenchmark."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/randomizeid"
-    options: []
-  - name: "org.openrewrite.java.RecipeExceptionDemonstration"
-    description: "Show how recipe exceptions are rendered in various forms of OpenRewrite\
-      \ tooling."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/recipeexceptiondemonstration"
-    options:
-    - name: "throwOnApplicableTest"
-      type: "Boolean"
-      required: false
-    - name: "throwOnApplicableTestVisitor"
-      type: "Boolean"
-      required: false
-    - name: "throwOnMethodPattern"
-      type: "String"
-      required: false
-    - name: "throwOnSingleSourceApplicableTest"
-      type: "Boolean"
-      required: false
-    - name: "throwOnSingleSourceApplicableTestVisitor"
-      type: "Boolean"
-      required: false
-    - name: "throwOnVisitAll"
-      type: "Boolean"
-      required: false
-    - name: "throwOnVisitAllVisitor"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.RecipeMarkupDemonstration"
-    description: "Tooling may decide to elide or display differently markup of different\
-      \ levels."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/recipemarkupdemonstration"
-    options:
-    - name: "level"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.RemoveAnnotation"
-    description: "Remove matching annotations wherever they occur."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/removeannotation"
-    options:
-    - name: "annotationPattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.RemoveImplements"
-    description: "Removes `implements` clauses from classes implementing the specified\
-      \ interface. Removes `@Overrides` annotations from methods which no longer override\
-      \ anything."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/removeimplements"
-    options:
-    - name: "filter"
-      type: "String"
-      required: true
-    - name: "interfaceType"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.RemoveObjectsIsNull"
-    description: "Replace calls to `Objects.isNull(..)` and `Objects.nonNull(..)`\
-      \ with a simple null check. Using these methods outside of stream predicates\
-      \ is not idiomatic."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/removeobjectsisnull"
-    options: []
-  - name: "org.openrewrite.java.RemoveUnusedImports"
-    description: "Remove imports for types that are not referenced."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/removeunusedimports"
-    options: []
-  - name: "org.openrewrite.java.ReorderMethodArguments"
-    description: "Reorder method arguments into the specified order."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/reordermethodarguments"
-    options:
-    - name: "ignoreDefinition"
-      type: "Boolean"
-      required: false
-    - name: "methodPattern"
-      type: "String"
-      required: true
-    - name: "newParameterNames"
-      type: "String[]"
-      required: true
-    - name: "oldParameterNames"
-      type: "String[]"
-      required: false
-  - name: "org.openrewrite.java.ReplaceConstant"
-    description: "Replace a named constant with a literal value when you wish to remove\
-      \ the old constant."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/replaceconstant"
-    options:
-    - name: "constantName"
-      type: "String"
-      required: true
-    - name: "literalValue"
-      type: "String"
-      required: true
-    - name: "owningType"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.SimplifyMethodChain"
-    description: "Simplify `a.b().c()` to `a.d()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/simplifymethodchain"
-    options:
-    - name: "methodPatternChain"
-      type: "List"
-      required: true
-    - name: "newMethodName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.UpdateSourcePositions"
-    description: "Calculate start position and length for every AST element."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/updatesourcepositions"
-    options: []
-  - name: "org.openrewrite.java.UseStaticImport"
-    description: "Removes unnecessary receiver types from static method invocations.\
-      \ For example, `Collections.emptyList()` becomes `emptyList()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/usestaticimport"
-    options:
-    - name: "methodPattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.cleanup.AddSerialVersionUidToSerializable"
-    description: "A `serialVersionUID` field is strongly recommended in all `Serializable`\
-      \ classes. If this is not defined on a `Serializable` class, the compiler will\
-      \ generate this value. If a change is later made to the class, the generated\
-      \ value will change and attempts to deserialize the class will fail."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/addserialversionuidtoserializable"
-    options: []
-  - name: "org.openrewrite.java.cleanup.AtomicPrimitiveEqualsUsesGet"
-    description: "`AtomicBoolean#equals(Object)`, `AtomicInteger#equals(Object)` and\
-      \ `AtomicLong#equals(Object)` are only equal to their instance. This recipe\
-      \ converts `a.equals(b)` to `a.get() == b.get()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/atomicprimitiveequalsusesget"
-    options: []
-  - name: "org.openrewrite.java.cleanup.AvoidBoxedBooleanExpressions"
-    description: "Under certain conditions the `java.lang.Boolean` type is used as\
-      \ an expression, and it may throw a `NullPointerException` if the value is null."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/avoidboxedbooleanexpressions"
-    options: []
-  - name: "org.openrewrite.java.cleanup.BigDecimalRoundingConstantsToEnums"
-    description: "Convert `BigDecimal` rounding constants to the equivalent `RoundingMode`\
-      \ enum."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/bigdecimalroundingconstantstoenums"
-    options: []
-  - name: "org.openrewrite.java.cleanup.BooleanChecksNotInverted"
-    description: "It is needlessly complex to invert the result of a boolean comparison.\
-      \ The opposite comparison should be made instead."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/booleanchecksnotinverted"
-    options: []
-  - name: "org.openrewrite.java.cleanup.CaseInsensitiveComparisonsDoNotChangeCase"
-    description: "Remove `String#toLowerCase()` or `String#toUpperCase()` from `String#equalsIgnoreCase(..)`\
-      \ comparisons."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/caseinsensitivecomparisonsdonotchangecase"
-    options: []
-  - name: "org.openrewrite.java.cleanup.CatchClauseOnlyRethrows"
-    description: "A `catch` clause that only rethrows the caught exception is unnecessary.\
-      \ Letting the exception bubble up as normal achieves the same result with less\
-      \ code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/catchclauseonlyrethrows"
-    options: []
-  - name: "org.openrewrite.java.cleanup.Cleanup"
-    description: "Automatically cleanup code, e.g. remove unnecessary parentheses,\
-      \ simplify expressions."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/cleanup"
-    options: []
-  - name: "org.openrewrite.java.cleanup.CombineSemanticallyEqualCatchBlocks"
-    description: "Combine catches in a try that contain semantically equivalent blocks.\
-      \ No change will be made when a caught exception exists if combing catches may\
-      \ change application behavior or type attribution is missing."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/combinesemanticallyequalcatchblocks"
-    options: []
-  - name: "org.openrewrite.java.cleanup.CommonStaticAnalysis"
-    description: "Resolve common static analysis issues discovered through 3rd party\
-      \ tools."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/commonstaticanalysis"
-    options: []
-  - name: "org.openrewrite.java.cleanup.CompareEnumsWithEqualityOperator"
-    description: "Replaces `Enum equals(java.lang.Object)` with `Enum == java.lang.Object`.\
-      \ An `!Enum equals(java.lang.Object)` will change to `!=`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/compareenumswithequalityoperator"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ControlFlowIndentation"
-    description: "Program flow control statements like `if`, `while`, and `for` can\
-      \ omit curly braces when they apply to only a single statement. This recipe\
-      \ ensures that any statements which follow that statement are correctly indented\
-      \ to show they are not part of the flow control statement."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/controlflowindentation"
-    options: []
-  - name: "org.openrewrite.java.cleanup.CovariantEquals"
-    description: "Checks that classes and records which define a covariant `equals()`\
-      \ method also override method `equals(Object)`. Covariant `equals()` means a\
-      \ method that is similar to `equals(Object)`, but with a covariant parameter\
-      \ type (any subtype of `Object`)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/covariantequals"
-    options: []
-  - name: "org.openrewrite.java.cleanup.DefaultComesLast"
-    description: "Ensure the `default` case comes last after all the cases in a switch\
-      \ statement."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/defaultcomeslast"
-    options: []
-  - name: "org.openrewrite.java.cleanup.EmptyBlock"
-    description: "Remove empty blocks that effectively do nothing."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/emptyblock"
-    options: []
-  - name: "org.openrewrite.java.cleanup.EqualsAvoidsNull"
-    description: "Checks that any combination of String literals is on the left side\
-      \ of an `equals()` comparison. Also checks for String literals assigned to some\
-      \ field (such as `someString.equals(anotherString = \"text\"))`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/equalsavoidsnull"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ExplicitCharsetOnStringGetBytes"
-    description: "This makes the behavior of the code platform neutral. It will not\
-      \ override any existing explicit encodings, even if they don't match the default\
-      \ encoding option."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/explicitcharsetonstringgetbytes"
-    options:
-    - name: "encoding"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.cleanup.ExplicitInitialization"
-    description: "Checks if any class or object member is explicitly initialized to\
-      \ default for its type value (`null` for object references, zero for numeric\
-      \ types and `char` and `false` for `boolean`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/explicitinitialization"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ExplicitLambdaArgumentTypes"
-    description: "Adds explicit types on lambda arguments, which are otherwise optional.\
-      \ This can make the code clearer and easier to read. This does not add explicit\
-      \ types on arguments when the lambda has one or two parameters and does not\
-      \ have a block body, as things are considered more readable in those cases.\
-      \ For example, `stream.map((a, b) -> a.length);` will not have explicit types\
-      \ added."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/explicitlambdaargumenttypes"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ExternalizableHasNoArgsConstructor"
-    description: "`Externalizable` classes handle both serialization and deserialization\
-      \ and must have a no-args constructor for the deserialization process."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/externalizablehasnoargsconstructor"
-    options: []
-  - name: "org.openrewrite.java.cleanup.FallThrough"
-    description: "Checks for fall-through in switch statements, adding `break` statements\
-      \ in locations where a case contains Java code but does not have a `break`,\
-      \ `return`, `throw`, or `continue` statement."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/fallthrough"
-    options: []
-  - name: "org.openrewrite.java.cleanup.FinalClass"
-    description: "Adds the `final` modifier to classes that expose no public or package-private\
-      \ constructors."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/finalclass"
-    options: []
-  - name: "org.openrewrite.java.cleanup.FinalizeLocalVariables"
-    description: "Adds the `final` modifier keyword to local variables which are not\
-      \ reassigned."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/finalizelocalvariables"
-    options: []
-  - name: "org.openrewrite.java.cleanup.FixSerializableFields"
-    description: "The fields of a class that implements `Serializable` must also implement\
-      \ `Serializable` or be marked as `transient`.\n\nThis recipe will look for any\
-      \ classes that directly or indirectly implement `Serializable` and for any member\
-      \ fields that are not serializable it will do one of two things:\n\n- If a non-serializable\
-      \ field has a type that is represented by a `SourceFile` within the same project,\
-      \ that SourceFile will be changed to implement `Serializable`.\n\n- If a non-serializable\
-      \ field has a type that is not represented as a `SourceFile`, the field will\
-      \ be marked as `transient`\n\nNOTE: If `markAllAsTransient` is set to `true`,\
-      \ this recipe will mark all non-serializable fields as `transient`.\n\nNOTE:\
-      \ Any fullyQualified names listed in the `fullyQualifiedExclusions` will be\
-      \ marked as transient, even if that SourceFile exists in the same project.\n\
-      \nNOTE: This recipe does NOT recursively modify newly `Serilazable` classes\
-      \ to cut down on the graph of SourceFiles that may be impacted during a recipe\
-      \ run."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/fixserializablefields"
-    options:
-    - name: "fullyQualifiedExclusions"
-      type: "List"
-      required: false
-    - name: "markAllAsTransient"
-      type: "Boolean"
-      required: true
-  - name: "org.openrewrite.java.cleanup.FixStringFormatExpressions"
-    description: "Fix `String#format` and `String#formatted` expressions by replacing\
-      \ `\\n` newline characters with `%n` and removing any unused arguments. Note\
-      \ this recipe is scoped to only transform format expressions which do not specify\
-      \ the argument index."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/fixstringformatexpressions"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ForLoopControlVariablePostfixOperators"
-    description: "Replace `for` loop control variables using pre-increment (`++i`)\
-      \ or pre-decrement (`--i`) operators with their post-increment (`i++`) or post-decrement\
-      \ (`i++`) notation equivalents."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/forloopcontrolvariablepostfixoperators"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ForLoopIncrementInUpdate"
-    description: "The increment should be moved to the loop's increment clause if\
-      \ possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/forloopincrementinupdate"
-    options: []
-  - name: "org.openrewrite.java.cleanup.HiddenField"
-    description: "Refactor local variables or parameters which shadow a field defined\
-      \ in the same class."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/hiddenfield"
-    options: []
-  - name: "org.openrewrite.java.cleanup.HideUtilityClassConstructor"
-    description: "Ensures utility classes (classes containing only static methods\
-      \ or fields in their API) do not have a public constructor."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/hideutilityclassconstructor"
-    options: []
-  - name: "org.openrewrite.java.cleanup.IndexOfChecksShouldUseAStartPosition"
-    description: "Replaces `indexOf(String)` in binary operations if the compared\
-      \ value is an int and not less than 1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/indexofchecksshoulduseastartposition"
-    options: []
-  - name: "org.openrewrite.java.cleanup.IndexOfReplaceableByContains"
-    description: "Checking if a value is included in a `String` or `List` using `indexOf(value)>-1`\
-      \ or `indexOf(value)>=0` can be replaced with `contains(value)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/indexofreplaceablebycontains"
-    options: []
-  - name: "org.openrewrite.java.cleanup.IndexOfShouldNotCompareGreaterThanZero"
-    description: "Replaces `String#indexOf(String) > 0` and `List#indexOf(Object)\
-      \ > 0` with `>=1`. Checking `indexOf` against `>0` ignores the first element,\
-      \ whereas `>-1` is inclusive of the first element. For clarity, `>=1` is used,\
-      \ because `>0` and `>=1` are semantically equal. Using `>0` may appear to be\
-      \ a mistake with the intent of including all elements. If the intent is to check\
-      \ whether a value in included in a `String` or `List`, the `String#contains(String)`\
-      \ or `List#contains(Object)` methods may be better options altogether."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/indexofshouldnotcomparegreaterthanzero"
-    options: []
-  - name: "org.openrewrite.java.cleanup.InlineVariable"
-    description: "Inline variables when they are immediately used to return or throw."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/inlinevariable"
-    options: []
-  - name: "org.openrewrite.java.cleanup.IsEmptyCallOnCollections"
-    description: "Also check for _not_ `isEmpty()` when testing for not equal to zero\
-      \ size."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/isemptycalloncollections"
-    options: []
-  - name: "org.openrewrite.java.cleanup.JavaApiBestPractices"
-    description: "Use the Java standard library in a way that is most idiomatic."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/javaapibestpractices"
-    options: []
-  - name: "org.openrewrite.java.cleanup.LambdaBlockToExpression"
-    description: "Single-line statement lambdas returning a value can be replaced\
-      \ with expression lambdas."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/lambdablocktoexpression"
-    options: []
-  - name: "org.openrewrite.java.cleanup.LowercasePackage"
-    description: "By convention all Java package names should contain only lowercase\
-      \ letters, numbers, and dashes. This recipe converts any uppercase letters in\
-      \ package names to be lowercase."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/lowercasepackage"
-    options: []
-  - name: "org.openrewrite.java.cleanup.MethodNameCasing"
-    description: "Method names should comply with a naming convention."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/methodnamecasing"
-    options:
-    - name: "includeTestSources"
-      type: "Boolean"
-      required: false
-    - name: "renamePublicMethods"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.cleanup.MethodParamPad"
-    description: "Fixes whitespace padding between the identifier of a method definition\
-      \ or method invocation and the left parenthesis of the parameter list. For example,\
-      \ when configured to remove spacing, `someMethodInvocation (x);` becomes `someMethodInvocation(x)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/methodparampad"
-    options: []
-  - name: "org.openrewrite.java.cleanup.MinimumSwitchCases"
-    description: "`switch` statements are useful when many code paths branch depending\
-      \ on the value of a single expression. For just one or two code paths, the code\
-      \ will be more readable with `if` statements."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/minimumswitchcases"
-    options: []
-  - name: "org.openrewrite.java.cleanup.MissingOverrideAnnotation"
-    description: "Adds `@Override` to methods overriding superclass methods or implementing\
-      \ interface methods. Annotating methods improves readability by showing the\
-      \ author's intent to override. Additionally, when annotated, the compiler will\
-      \ emit an error when a signature of the overridden method does not match the\
-      \ superclass method."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/missingoverrideannotation"
-    options:
-    - name: "ignoreAnonymousClassMethods"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.cleanup.ModifierOrder"
-    description: "Modifiers should be declared in the correct order as recommended\
-      \ by the JLS."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/modifierorder"
-    options: []
-  - name: "org.openrewrite.java.cleanup.MultipleVariableDeclarations"
-    description: "Places each variable declaration in its own statement and on its\
-      \ own line. Using one variable declaration per line encourages commenting and\
-      \ can increase readability."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/multiplevariabledeclarations"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NeedBraces"
-    description: "Adds missing braces around code such as single-line `if`, `for`,\
-      \ `while`, and `do-while` block bodies."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/needbraces"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NestedEnumsAreNotStatic"
-    description: "Remove static modifier from nested enum types since they are implicitly\
-      \ static."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nestedenumsarenotstatic"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NewStringBuilderBufferWithCharArgument"
-    description: "Instantiating a `StringBuilder` or a `StringBuffer` with a `Character`\
-      \ results in the `int` representation of the character being used for the initial\
-      \ size."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/newstringbuilderbufferwithcharargument"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoDoubleBraceInitialization"
-    description: "Replace `List`, `Map`, and `Set` double brace initialization with\
-      \ an initialization block."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nodoublebraceinitialization"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoEmptyCollectionWithRawType"
-    description: "Replaces `Collections#EMPTY_..` with methods that return generic\
-      \ types."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/noemptycollectionwithrawtype"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoEqualityInForCondition"
-    description: "Testing for loop termination using an equality operator (`==` and\
-      \ `!=`) is dangerous, because it could set up an infinite loop. Using a relational\
-      \ operator instead makes it harder to accidentally write an infinite loop."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/noequalityinforcondition"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoFinalizer"
-    description: "Finalizers are deprecated. Use of `finalize()` can lead to performance\
-      \ issues, deadlocks, hangs, and other undesirable behavior."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nofinalizer"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoPrimitiveWrappersForToStringOrCompareTo"
-    description: "Primitive wrappers should not be instantiated only for `#toString()`\
-      \ or `#compareTo(..)` invocations."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/noprimitivewrappersfortostringorcompareto"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoRedundantJumpStatements"
-    description: "Jump statements such as return and continue let you change the default\
-      \ flow of program execution, but jump statements that direct the control flow\
-      \ to the original direction are just a waste of keystrokes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/noredundantjumpstatements"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoToStringOnStringType"
-    description: "Remove unnecessary `String#toString()` invocations on objects which\
-      \ are already a string."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/notostringonstringtype"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoValueOfOnStringType"
-    description: "Replace unnecessary `String#valueOf(..)` method invocations with\
-      \ the argument directly. This occurs when the argument to `String#valueOf(arg)`\
-      \ is a string literal, such as `String.valueOf(\"example\")`. Or, when the `String#valueOf(..)`\
-      \ invocation is used in a concatenation, such as `\"example\" + String.valueOf(\"\
-      example\")`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/novalueofonstringtype"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoWhitespaceAfter"
-    description: "Removes unnecessary whitespace appearing after a token. A linebreak\
-      \ after a token is allowed unless `allowLineBreaks` is set to `false`, in which\
-      \ case it will be removed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nowhitespaceafter"
-    options: []
-  - name: "org.openrewrite.java.cleanup.NoWhitespaceBefore"
-    description: "Removes unnecessary whitespace preceding a token. A linebreak before\
-      \ a token will be removed unless `allowLineBreaks` is set to `true`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nowhitespacebefore"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ObjectFinalizeCallsSuper"
-    description: "Overrides of `Object#finalize()` should call super."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/objectfinalizecallssuper"
-    options: []
-  - name: "org.openrewrite.java.cleanup.OperatorWrap"
-    description: "Fixes line wrapping policies on operators."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/operatorwrap"
-    options: []
-  - name: "org.openrewrite.java.cleanup.PadEmptyForLoopComponents"
-    description: "Fixes padding on empty `for` loop iterators and initializers to\
-      \ match Checkstyle policies."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/pademptyforloopcomponents"
-    options: []
-  - name: "org.openrewrite.java.cleanup.PrimitiveWrapperClassConstructorToValueOf"
-    description: "The constructor of all primitive types has been deprecated in favor\
-      \ of using the static factory method `valueOf` available for each of the primitive\
-      \ type wrappers."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/primitivewrapperclassconstructortovalueof"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RedundantFileCreation"
-    description: "Remove unnecessary intermediate creations of files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/redundantfilecreation"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ReferentialEqualityToObjectEquals"
-    description: "Using `==` or `!=` compares object references, not the equality\
-      \ of two objects. This modifies code where both sides of a binary operation\
-      \ (`==` or `!=`) override `Object.equals(Object obj)` except when the comparison\
-      \ is within an overridden `Object.equals(Object obj)` method declaration itself.WARNING,\
-      \ The resulting transformation must be carefully reviewed since any modifications\
-      \ change the programs semantics."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/referentialequalitytoobjectequals"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveCallsToSystemGc"
-    description: "Removes calls to `System.gc()` and `Runtime.gc()`. When to invoke\
-      \ garbage collection is best left to the JVM."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removecallstosystemgc"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveEmptyJavaDocParameters"
-    description: "Removes `@params`, `@return`, and `@throws` with no description\
-      \ from JavaDocs."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeemptyjavadocparameters"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveExtraSemicolons"
-    description: "Optional semicolons at the end of try-with-resources are also removed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeextrasemicolons"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveJavaDocAuthorTag"
-    description: "Removes author tags from JavaDocs to reduce code maintenance."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removejavadocauthortag"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveRedundantTypeCast"
-    description: "Removes unnecessary type casts. Does not currently check casts in\
-      \ lambdas, class constructors, and method invocations."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeredundanttypecast"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveUnneededAssertion"
-    description: "Remove unneeded assertions like `assert true`, `assertTrue(true)`,\
-      \ or `assertFalse(false)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunneededassertion"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveUnneededBlock"
-    description: "Flatten blocks into inline statements when possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunneededblock"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveUnusedLocalVariables"
-    description: "If a local variable is declared but not used, it is dead code and\
-      \ should be removed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunusedlocalvariables"
-    options:
-    - name: "ignoreVariablesNamed"
-      type: "String[]"
-      required: false
-  - name: "org.openrewrite.java.cleanup.RemoveUnusedPrivateFields"
-    description: "If a private field is declared but not used in the program, it can\
-      \ be considered dead code and should therefore be removed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunusedprivatefields"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RemoveUnusedPrivateMethods"
-    description: "`private` methods that are never executed are dead code and should\
-      \ be removed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunusedprivatemethods"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RenameExceptionInEmptyCatch"
-    description: "Renames caught exceptions in empty catch blocks to `ignored`. `ignored`\
-      \ will be incremented by 1 if a namespace conflict exists."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/renameexceptioninemptycatch"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RenameLocalVariablesToCamelCase"
-    description: "Reformat local variable and method parameter names to camelCase\
-      \ to comply with Java naming convention. The recipe will not rename variables\
-      \ declared in for loop controls or catches with a single character. The first\
-      \ character is set to lower case and existing capital letters are preserved.\
-      \ Special characters that are allowed in java field names `$` and `_` are removed.\
-      \ If a special character is removed the next valid alpha-numeric will be capitalized.\
-      \ Currently, does not support renaming members of classes. The recipe will not\
-      \ rename a variable if the result already exists in the class, conflicts with\
-      \ a java reserved keyword, or the result is blank."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/renamelocalvariablestocamelcase"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RenameMethodsNamedHashcodeEqualOrTostring"
-    description: "Methods should not be named `hashcode`, `equal`, or `tostring`.\
-      \ Any of these are confusing as they appear to be intended as overridden methods\
-      \ from the `Object` base class, despite being case-insensitive."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/renamemethodsnamedhashcodeequalortostring"
-    options: []
-  - name: "org.openrewrite.java.cleanup.RenamePrivateFieldsToCamelCase"
-    description: "Reformat private field names to camelCase to comply with Java naming\
-      \ convention. The recipe will not rename fields with default, protected or public\
-      \ access modifiers.The recipe will not rename private constants.The first character\
-      \ is set to lower case and existing capital letters are preserved. Special characters\
-      \ that are allowed in java field names `$` and `_` are removed. If a special\
-      \ character is removed the next valid alphanumeric will be capitalized. The\
-      \ recipe will not rename a field if the result already exists in the class,\
-      \ conflicts with a java reserved keyword, or the result is blank."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/renameprivatefieldstocamelcase"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ReplaceDuplicateStringLiterals"
-    description: "Replaces `String` literals with a length of 5 or greater repeated\
-      \ a minimum of 3 times. Qualified `String` literals include final Strings, method\
-      \ invocations, and new class invocations. Adds a new `private static final String`\
-      \ or uses an existing equivalent class field. A new variable name will be generated\
-      \ based on the literal value if an existing field does not exist. The generated\
-      \ name will append a numeric value to the variable name if a name already exists\
-      \ in the compilation unit."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/replaceduplicatestringliterals"
-    options:
-    - name: "includeTestSources"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.cleanup.ReplaceLambdaWithMethodReference"
-    description: "Replaces the single statement lambdas `o -> o instanceOf X`, `o\
-      \ -> (A) o`, `o -> System.out.println(o)`, `o -> o != null`, `o -> o == null`\
-      \ with the equivalent method reference."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/replacelambdawithmethodreference"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ReplaceStackWithDeque"
-    description: "From the Javadoc of `Stack`:\n> A more complete and consistent set\
-      \ of LIFO stack operations is provided by the Deque interface and its implementations,\
-      \ which should be used in preference to this class."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/replacestackwithdeque"
-    options: []
-  - name: "org.openrewrite.java.cleanup.ReplaceThreadRunWithThreadStart"
-    description: "`Thread.run()` should not be called directly."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/replacethreadrunwiththreadstart"
-    options: []
-  - name: "org.openrewrite.java.cleanup.SimplifyBooleanExpression"
-    description: "Checks for over-complicated boolean expressions. Finds code like\
-      \ `if (b == true)`, `b || true`, `!false`, etc."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifybooleanexpression"
-    options: []
-  - name: "org.openrewrite.java.cleanup.SimplifyBooleanReturn"
-    description: "Simplifies Boolean expressions by removing redundancies, e.g.: `a\
-      \ && true` simplifies to `a`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifybooleanreturn"
-    options: []
-  - name: "org.openrewrite.java.cleanup.SimplifyCompoundStatement"
-    description: "Fixes or removes useless compound statements. For example, removing\
-      \ `b &= true`, and replacing `b &= false` with `b = false`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifycompoundstatement"
-    options: []
-  - name: "org.openrewrite.java.cleanup.SimplifyConsecutiveAssignments"
-    description: "Combine consecutive assignments into a single statement where possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifyconsecutiveassignments"
-    options: []
-  - name: "org.openrewrite.java.cleanup.SimplifyConstantIfBranchExecution"
-    description: "Checks for if expressions that are always `true` or `false` and\
-      \ simplifies them."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifyconstantifbranchexecution"
-    options: []
-  - name: "org.openrewrite.java.cleanup.StaticMethodNotFinal"
-    description: "Static methods do not need to be declared final because they cannot\
-      \ be overridden."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/staticmethodnotfinal"
-    options: []
-  - name: "org.openrewrite.java.cleanup.StringLiteralEquality"
-    description: "`String.equals()` should be used when checking value equality on\
-      \ String literals. Using `==` or `!=` compares object references, not the actual\
-      \ value of the Strings. This only modifies code where at least one side of the\
-      \ binary operation (`==` or `!=`) is a String literal, such as `\"someString\"\
-      \ == someVariable;`. This is to prevent inadvertently changing code where referential\
-      \ equality is the user's intent."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/stringliteralequality"
-    options: []
-  - name: "org.openrewrite.java.cleanup.TypecastParenPad"
-    description: "Fixes whitespace padding between a typecast type identifier and\
-      \ the enclosing left and right parenthesis. For example, when configured to\
-      \ remove spacing, `( int ) 0L;` becomes `(int) 0L;`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/typecastparenpad"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UnnecessaryCatch"
-    description: "A refactoring operation may result in a checked exception that is\
-      \ no longer thrown from a `try` block. This recipe will find and remove unnecessary\
-      \ catch blocks."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessarycatch"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UnnecessaryCloseInTryWithResources"
-    description: "Remove unnecessary `AutoCloseable#close()` statements in try-with-resources."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessarycloseintrywithresources"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UnnecessaryExplicitTypeArguments"
-    description: "When explicit type arguments are inferrable by the compiler, they\
-      \ may be removed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessaryexplicittypearguments"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UnnecessaryParentheses"
-    description: "Removes unnecessary parentheses from code where extra parentheses\
-      \ pairs are redundant."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessaryparentheses"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UnnecessaryPrimitiveAnnotations"
-    description: "Remove `@Nullable` and `@CheckForNull` annotations from primitives\
-      \ since they can't be null."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessaryprimitiveannotations"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UnnecessaryThrows"
-    description: "Remove unnecessary `throws` declarations. This recipe will only\
-      \ remove unused, checked exception if:\n\n- The declaring class or the method\
-      \ declaration is `final`.\n- The method declaration is `static` or `private`.\n\
-      - If the method overriding a method declaration in a super class and the super\
-      \ does not throw the exception.\n- If the method is `public` or `protected`\
-      \ and the exception is not documented via a JavaDoc as a `@throws` tag."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessarythrows"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UnwrapRepeatableAnnotations"
-    description: "Java 8 introduced the concept of `@Repeatable` annotations, making\
-      \ the wrapper annotation unnecessary."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unwraprepeatableannotations"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UpperCaseLiteralSuffixes"
-    description: "Using upper case literal suffixes for declaring literals is less\
-      \ ambiguous, e.g., `1l` versus `1L`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/uppercaseliteralsuffixes"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseAsBuilder"
-    description: "When an API has been designed as a builder, use it that way rather\
-      \ than as a series of setter calls."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/useasbuilder"
-    options:
-    - name: "builderCreator"
-      type: "String"
-      required: false
-    - name: "builderType"
-      type: "String"
-      required: true
-    - name: "immutable"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.cleanup.UseCollectionInterfaces"
-    description: "Use `Deque`, `List`, `Map`, `ConcurrentMap`, `Queue`, and `Set`\
-      \ instead of implemented collections. Replaces the return type of public method\
-      \ declarations and the variable type public variable declarations."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usecollectioninterfaces"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseDiamondOperator"
-    description: "The diamond operator (`<>`) should be used. Java 7 introduced the\
-      \ diamond operator (<>) to reduce the verbosity of generics code. For instance,\
-      \ instead of having to declare a List's type in both its declaration and its\
-      \ constructor, you can now simplify the constructor declaration with `<>`, and\
-      \ the compiler will infer the type."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usediamondoperator"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseForEachRemoveInsteadOfSetRemoveAll"
-    description: "Using `java.util.Collection#forEach(Set::remove)` rather than `java.util.Set#removeAll(java.util.Collection)`\
-      \ may improve performance due to a possible O(n^2) complexity."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/useforeachremoveinsteadofsetremoveall"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseJavaStyleArrayDeclarations"
-    description: "Change C-Style array declarations `int i[];` to `int[] i;`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usejavastylearraydeclarations"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseLambdaForFunctionalInterface"
-    description: "Instead of anonymous class declarations, use a lambda where possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/uselambdaforfunctionalinterface"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseListSort"
-    description: "The `java.util.Collections#sort(..)` implementation defers to the\
-      \ `java.util.List#sort(Comparator)`, replaced it with the `java.util.List#sort(Comparator)`\
-      \ implementation for better readability."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/uselistsort"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseMapContainsKey"
-    description: "`map.keySet().contains(a)` can be simplified to `map.containsKey(a)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usemapcontainskey"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseStandardCharset"
-    description: "Replaces `Charset.forName(java.lang.String)` with the equivalent\
-      \ `StandardCharset` constant."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usestandardcharset"
-    options: []
-  - name: "org.openrewrite.java.cleanup.UseStringReplace"
-    description: "When `String::replaceAll` is used, the first argument should be\
-      \ a real regular expression. If it’s not the case, `String::replace` does exactly\
-      \ the same thing as `String::replaceAll` without the performance drawback of\
-      \ the regex."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usestringreplace"
-    options: []
-  - name: "org.openrewrite.java.cleanup.WhileInsteadOfFor"
-    description: "When only the condition expression is defined in a for loop, and\
-      \ the initialization and increment expressions are missing, a while loop should\
-      \ be used instead to increase readability."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/whileinsteadoffor"
-    options: []
-  - name: "org.openrewrite.java.cleanup.WriteOctalValuesAsDecimal"
-    description: "Developers may not recognize octal values as such, mistaking them\
-      \ instead for decimal values."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/writeoctalvaluesasdecimal"
-    options: []
-  - name: "org.openrewrite.java.controlflow.ControlFlowVisualization"
-    description: "Visualize the control flow of a Java program."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/controlflow/controlflowvisualization"
-    options:
-    - name: "includeDotfile"
-      type: "boolean"
-      required: true
-  - name: "org.openrewrite.java.format.AutoFormat"
-    description: "Format Java code using a standard comprehensive set of Java formatting\
-      \ recipes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/autoformat"
-    options: []
-  - name: "org.openrewrite.java.format.BlankLines"
-    description: "Add and/or remove blank lines."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/blanklines"
-    options: []
-  - name: "org.openrewrite.java.format.EmptyNewlineAtEndOfFile"
-    description: "Some tools work better when files end with an empty line."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/emptynewlineatendoffile"
-    options: []
-  - name: "org.openrewrite.java.format.NormalizeFormat"
-    description: "Move whitespace to the outermost AST element possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/normalizeformat"
-    options: []
-  - name: "org.openrewrite.java.format.NormalizeLineBreaks"
-    description: "Consistently use either Windows style (CRLF) or Linux style (LF)\
-      \ line breaks. If no `GeneralFormatStyle` is specified this will use whichever\
-      \ style of line endings are more common."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/normalizelinebreaks"
-    options: []
-  - name: "org.openrewrite.java.format.NormalizeTabsOrSpaces"
-    description: "Consistently use either tabs or spaces in indentation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/normalizetabsorspaces"
-    options: []
-  - name: "org.openrewrite.java.format.RemoveTrailingWhitespace"
-    description: "Remove any extra trailing whitespace from the end of each line."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/removetrailingwhitespace"
-    options: []
-  - name: "org.openrewrite.java.format.SingleLineComments"
-    description: "Write `// hi` instead of `//hi`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/singlelinecomments"
-    options: []
-  - name: "org.openrewrite.java.format.Spaces"
-    description: "Format whitespace in Java code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/spaces"
-    options: []
-  - name: "org.openrewrite.java.format.TabsAndIndents"
-    description: "Format tabs and indents in Java code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/tabsandindents"
-    options: []
-  - name: "org.openrewrite.java.format.WrappingAndBraces"
-    description: "Format line wraps and braces in Java code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/format/wrappingandbraces"
-    options: []
-  - name: "org.openrewrite.java.recipes.ExecutionContextParameterName"
-    description: "Visitors that are parameterized with `ExecutionContext` should use\
-      \ the parameter name `ctx`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/recipes/executioncontextparametername"
-    options: []
-  - name: "org.openrewrite.java.recipes.PublicGetVisitor"
-    description: "It would be a breaking API change to increase the visibility of\
-      \ the method by default, but any recipe can increase visibility of the `Recipe`\
-      \ class. Making them public makes recipes easier to use in other recipes in\
-      \ unexpected ways."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/recipes/publicgetvisitor"
-    options: []
-  - name: "org.openrewrite.java.recipes.SetDefaultEstimatedEffortPerOccurrence"
-    description: "Retrofit recipes with a deafult estimated effort per occurrence."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/recipes/setdefaultestimatedeffortperoccurrence"
-    options: []
-  - name: "org.openrewrite.java.search.FindAnnotations"
-    description: "Find all annotations matching the annotation pattern."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findannotations"
-    options:
-    - name: "annotationPattern"
-      type: "String"
-      required: true
-    - name: "matchMetaAnnotations"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.search.FindDeprecatedClasses"
-    description: "Find uses of deprecated classes, optionally ignoring those classes\
-      \ that are inside deprecated scopes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/finddeprecatedclasses"
-    options:
-    - name: "ignoreDeprecatedScopes"
-      type: "Boolean"
-      required: false
-    - name: "matchInherited"
-      type: "Boolean"
-      required: false
-    - name: "typePattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.search.FindDeprecatedFields"
-    description: "Find uses of deprecated fields in any API."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/finddeprecatedfields"
-    options:
-    - name: "ignoreDeprecatedScopes"
-      type: "Boolean"
-      required: false
-    - name: "typePattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.search.FindDeprecatedMethods"
-    description: "Find uses of deprecated methods in any API."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/finddeprecatedmethods"
-    options:
-    - name: "ignoreDeprecatedScopes"
-      type: "Boolean"
-      required: false
-    - name: "methodPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.search.FindDeprecatedUses"
-    description: "Find deprecated uses of methods, fields, and types. Optionally ignore\
-      \ those classes that are inside deprecated scopes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/finddeprecateduses"
-    options:
-    - name: "ignoreDeprecatedScopes"
-      type: "Boolean"
-      required: false
-    - name: "matchInherited"
-      type: "Boolean"
-      required: false
-    - name: "typePattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.search.FindEmptyClasses"
-    description: "Find empty classes without annotations that do not implement an\
-      \ interface or extend a class."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findemptyclasses"
-    options: []
-  - name: "org.openrewrite.java.search.FindEmptyMethods"
-    description: "Find methods with empty bodies and single public no arg constructors."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findemptymethods"
-    options:
-    - name: "matchOverrides"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.search.FindFields"
-    description: "Find uses of a field."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findfields"
-    options:
-    - name: "fieldName"
-      type: "String"
-      required: true
-    - name: "fullyQualifiedTypeName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.search.FindFieldsOfType"
-    description: "Finds declared fields matching a particular class name."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findfieldsoftype"
-    options:
-    - name: "fullyQualifiedTypeName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.search.FindFlowBetweenMethods"
-    description: "Takes two patterns for the start/end methods to find flow between."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findflowbetweenmethods"
-    options:
-    - name: "endMatchOverrides"
-      type: "Boolean"
-      required: false
-    - name: "endMethodPattern"
-      type: "String"
-      required: true
-    - name: "flow"
-      type: "String"
-      required: true
-    - name: "startMatchOverrides"
-      type: "Boolean"
-      required: false
-    - name: "startMethodPattern"
-      type: "String"
-      required: true
-    - name: "target"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.search.FindImports"
-    description: "Locates source files that have imports matching the given type pattern,\
-      \ regardless of whether that import is used in the code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findimports"
-    options:
-    - name: "typePattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.search.FindLiterals"
-    description: "Find literals matching a pattern."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findliterals"
-    options:
-    - name: "pattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.search.FindMethods"
-    description: "Find method usages by pattern."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findmethods"
-    options:
-    - name: "flow"
-      type: "String"
-      required: false
-    - name: "matchOverrides"
-      type: "Boolean"
-      required: false
-    - name: "methodPattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.search.FindMissingTypes"
-    description: "This is a diagnostic recipe to highlight where ASTs are missing\
-      \ type attribution information."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findmissingtypes"
-    options: []
-  - name: "org.openrewrite.java.search.FindRepeatableAnnotations"
-    description: "Java 8 introduced the concept of `@Repeatable` annotations."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findrepeatableannotations"
-    options: []
-  - name: "org.openrewrite.java.search.FindSecrets"
-    description: "Find secrets stored in plain text in code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findsecrets"
-    options: []
-  - name: "org.openrewrite.java.search.FindText"
-    description: "Find occurrences of regular expression based patterns in comments\
-      \ and literals."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findtext"
-    options:
-    - name: "patterns"
-      type: "List"
-      required: true
-  - name: "org.openrewrite.java.search.FindTypes"
-    description: "Find type references by name."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findtypes"
-    options:
-    - name: "checkAssignability"
-      type: "Boolean"
-      required: false
-    - name: "fullyQualifiedTypeName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.search.PotentiallyDeadCode"
-    description: "Method definitions that are defined in this project and aren't used."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/potentiallydeadcode"
-    options: []
-  - name: "org.openrewrite.java.search.ResultOfMethodCallIgnored"
-    description: "Find locations where the result of the method call is being ignored."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/resultofmethodcallignored"
-    options:
-    - name: "methodPattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.search.UriCreatedWithHttpScheme"
-    description: "This is a sample recipe demonstrating a simple application of local\
-      \ data flow analysis."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/search/uricreatedwithhttpscheme"
-    options: []
-- artifactId: "rewrite-java-security"
-  version: "1.18.0"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.security.FindTextDirectionChanges"
-    description: "Finds unicode control characters which can change the direction\
-      \ text is displayed in. These control characters can alter how source code is\
-      \ presented to a human reader without affecting its interpretation by tools\
-      \ like compilers. So a malicious patch could pass code review while introducing\
-      \ vulnerabilities. Note that text direction-changing unicode control characters\
-      \ aren't inherently malicious. These characters can appear for legitimate reasons\
-      \ in code written in or dealing with right-to-left languages. See: https://trojansource.codes/"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/findtextdirectionchanges"
-    options: []
-  - name: "org.openrewrite.java.security.JavaSecurityBestPractices"
-    description: "Applies security best practices to Java code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/javasecuritybestpractices"
-    options: []
-  - name: "org.openrewrite.java.security.PartialPathTraversalVulnerability"
-    description: "Replaces `dir.getCanonicalPath().startsWith(parent.getCanonicalPath()`,\
-      \ which is vulnerable to partial path traversal attacks, with the more secure\
-      \ `dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())`.\n\
-      \nTo demonstrate this vulnerability, consider `\"/usr/outnot\".startsWith(\"\
-      /usr/out\")`. The check is bypassed although `/outnot` is not under the `/out`\
-      \ directory. It's important to understand that the terminating slash may be\
-      \ removed when using various `String` representations of the `File` object.\
-      \ For example, on Linux, `println(new File(\"/var\"))` will print `/var`, but\
-      \ `println(new File(\"/var\", \"/\")` will print `/var/`; however, `println(new\
-      \ File(\"/var\", \"/\").getCanonicalPath())` will print `/var`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/partialpathtraversalvulnerability"
-    options: []
-  - name: "org.openrewrite.java.security.RegularExpressionDenialOfService"
-    description: ""
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/regularexpressiondenialofservice"
-    options: []
-  - name: "org.openrewrite.java.security.SecureRandom"
-    description: "Use cryptographically secure Pseudo Random Number Generation in\
-      \ the \"main\" source set. Replaces instantiation of `java.util.Random` with\
-      \ `java.security.SecureRandom`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/securerandom"
-    options: []
-  - name: "org.openrewrite.java.security.SecureRandomPrefersDefaultSeed"
-    description: "Remove `SecureRandom#setSeed(*)` method invocations having constant\
-      \ or predictable arguments."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/securerandomprefersdefaultseed"
-    options: []
-  - name: "org.openrewrite.java.security.SecureTempFileCreation"
-    description: "`java.io.File.createTempFile()` has exploitable default file permissions.\
-      \ This recipe migrates to the more secure `java.nio.file.Files.createTempFile()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/securetempfilecreation"
-    options: []
-  - name: "org.openrewrite.java.security.UseFilesCreateTempDirectory"
-    description: "Use `Files#createTempDirectory` when the sequence `File#createTempFile(..)`->`File#delete()`->`File#mkdir()`\
-      \ is used for creating a temp directory."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/usefilescreatetempdirectory"
-    options: []
-  - name: "org.openrewrite.java.security.XmlParserXXEVulnerability"
-    description: "Avoid exposing dangerous features of the XML parser by setting XMLInputFactory\
-      \ `IS_SUPPORTING_EXTERNAL_ENTITIES` and `SUPPORT_DTD` properties to `false`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/xmlparserxxevulnerability"
-    options: []
-  - name: "org.openrewrite.java.security.ZipSlip"
-    description: "Zip slip is an arbitrary file overwrite critical vulnerability,\
-      \ which typically results in remote command execution. A fuller description\
-      \ of this vulnerability is available in the [Snyk documentation](https://snyk.io/research/zip-slip-vulnerability)\
-      \ on it."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/zipslip"
-    options:
-    - name: "debug"
-      type: "boolean"
-      required: true
-  - name: "org.openrewrite.java.security.marshalling.SecureJacksonDefaultTyping"
-    description: "See the [blog post](https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062)\
-      \ on this subject."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/marshalling/securejacksondefaulttyping"
-    options: []
-  - name: "org.openrewrite.java.security.marshalling.SecureSnakeYamlConstructor"
-    description: "See the [paper](https://github.com/mbechler/marshalsec) on this\
-      \ subject."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/marshalling/securesnakeyamlconstructor"
-    options: []
-  - name: "org.openrewrite.java.security.search.FindJacksonDefaultTypeMapping"
-    description: "`ObjectMapper#enableTypeMapping(..)` can lead to vulnerable deserialization."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/search/findjacksondefaulttypemapping"
-    options: []
-  - name: "org.openrewrite.java.security.search.FindVulnerableJacksonJsonTypeInfo"
-    description: "Identify where attackers can deserialize gadgets into a target field."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/search/findvulnerablejacksonjsontypeinfo"
-    options: []
-  - name: "org.openrewrite.java.security.spring.CsrfProtection"
-    description: "Cross-Site Request Forgery (CSRF) is a type of attack that occurs\
-      \ when a malicious web site, email, blog, instant message, or program causes\
-      \ a user's web browser to perform an unwanted action on a trusted site when\
-      \ the user is authenticated. See the full [OWASP cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/spring/csrfprotection"
-    options:
-    - name: "onlyIfSecurityConfig"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.security.spring.PreventClickjacking"
-    description: "The `frame-ancestors` directive can be used in a Content-Security-Policy\
-      \ HTTP response header to indicate whether or not a browser should be allowed\
-      \ to render a page in a `<frame>` or `<iframe>`. Sites can use this to avoid\
-      \ Clickjacking attacks by ensuring that their content is not embedded into other\
-      \ sites."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/security/spring/preventclickjacking"
-    options:
-    - name: "onlyIfSecurityConfig"
-      type: "Boolean"
-      required: false
-- artifactId: "rewrite-jhipster"
-  version: "1.13.0"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.jhipster.FixCwe338"
-    description: "Use a cryptographically strong pseudo-random number generator (PRNG)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/jhipster/fixcwe338"
-    options: []
-- artifactId: "rewrite-json"
-  version: "7.32.1"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.json.ChangeKey"
-    description: "Change a JSON mapping entry key leaving the value intact."
-    docLink: "https://docs.openrewrite.org/reference/recipes/json/changekey"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newKey"
-      type: "String"
-      required: true
-    - name: "oldKeyPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.json.ChangeValue"
-    description: "Change a JSON mapping entry value leaving the key intact."
-    docLink: "https://docs.openrewrite.org/reference/recipes/json/changevalue"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "oldKeyPath"
-      type: "String"
-      required: true
-    - name: "value"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.json.DeleteKey"
-    description: "Delete a JSON mapping entry key."
-    docLink: "https://docs.openrewrite.org/reference/recipes/json/deletekey"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "keyPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.json.search.FindKey"
-    description: "Find JSON object members by JsonPath expression."
-    docLink: "https://docs.openrewrite.org/reference/recipes/json/search/findkey"
-    options:
-    - name: "key"
-      type: "String"
-      required: true
-- artifactId: "rewrite-kubernetes"
-  version: "1.24.0"
-  markdownRecipeDescriptors:
-  - name: "org.openrewrite.kubernetes.AddConfiguration"
-    description: "Add default required configuration when it is missing."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/addconfiguration"
-    options:
-    - name: "apiVersion"
-      type: "String"
-      required: false
-    - name: "configurationPath"
-      type: "String"
-      required: true
-    - name: "resourceKind"
-      type: "String"
-      required: true
-    - name: "value"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.kubernetes.ImagePullPolicyAlways"
-    description: "Ensures the latest version of a tag is deployed each time."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/imagepullpolicyalways"
-    options: []
-  - name: "org.openrewrite.kubernetes.KubernetesBestPractices"
-    description: "Applies best practices to Kubernetes manifests."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/kubernetesbestpractices"
-    options: []
-  - name: "org.openrewrite.kubernetes.LifecycleRuleOnStorageBucket"
-    description: "When defining a rule, you can specify any set of conditions for\
-      \ any action. The following configuration defines a rule to delete all objects\
-      \ older than 7 days in a bucket."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/lifecycleruleonstoragebucket"
-    options: []
-  - name: "org.openrewrite.kubernetes.LimitContainerCapabilities"
-    description: "Limiting the admission of containers with capabilities ensures that\
-      \ only a small number of containers have extended capabilities outside the default\
-      \ range."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/limitcontainercapabilities"
-    options: []
-  - name: "org.openrewrite.kubernetes.MissingCpuLimits"
-    description: "A system without managed quotas could eventually collapse due to\
-      \ inadequate resources for the tasks it bares."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingcpulimits"
-    options: []
-  - name: "org.openrewrite.kubernetes.MissingCpuRequest"
-    description: "If a container is created in a namespace that has a default CPU\
-      \ limit, and the container does not specify its own CPU limit, then the container\
-      \ is assigned the default CPU limit."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingcpurequest"
-    options: []
-  - name: "org.openrewrite.kubernetes.MissingMemoryLimits"
-    description: "With no limit set, kubectl allocates more and more memory to the\
-      \ container until it runs out."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingmemorylimits"
-    options: []
-  - name: "org.openrewrite.kubernetes.MissingMemoryRequest"
-    description: "A container is guaranteed to have as much memory as it requests,\
-      \ but is not allowed to use more memory than the limit set. This configuration\
-      \ may save resources and prevent an attack on an exploited container."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingmemoryrequest"
-    options: []
-  - name: "org.openrewrite.kubernetes.MissingPodLivenessProbe"
-    description: "The kubelet uses liveness probes to know when to schedule restarts\
-      \ for containers. Restarting a container in a deadlock state can help to make\
-      \ the application more available, despite bugs."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingpodlivenessprobe"
-    options: []
-  - name: "org.openrewrite.kubernetes.MissingPodReadinessProbe"
-    description: "Using the Readiness Probe ensures teams define what actions need\
-      \ to be taken to prevent failure and ensure recovery in case of unexpected errors."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingpodreadinessprobe"
-    options: []
-  - name: "org.openrewrite.kubernetes.NoHostIPCSharing"
-    description: "Preventing sharing of host PID/IPC namespace, networking, and ports\
-      \ ensures proper isolation between Docker containers and the underlying host."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/nohostipcsharing"
-    options: []
-  - name: "org.openrewrite.kubernetes.NoHostNetworkSharing"
-    description: "When using the host network mode for a container, that container’\
-      s network stack is not isolated from the Docker host, so the container shares\
-      \ the host’s networking namespace and does not get its own IP-address allocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/nohostnetworksharing"
-    options: []
-  - name: "org.openrewrite.kubernetes.NoHostProcessIdSharing"
-    description: "Sharing the host process ID namespace breaks the isolation between\
-      \ container images and can make processes visible to other containers in the\
-      \ pod. This includes all information in the /proc directory, which can sometimes\
-      \ include passwords or keys, passed as environment variables."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/nohostprocessidsharing"
-    options: []
-  - name: "org.openrewrite.kubernetes.NoPrivilegeEscalation"
-    description: "Does not allow a process to gain more privileges than its parent\
-      \ process."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/noprivilegeescalation"
-    options: []
-  - name: "org.openrewrite.kubernetes.NoPrivilegedContainers"
-    description: "Privileged containers are containers that have all of the root capabilities\
-      \ of a host machine, allowing access to resources that are not accessible in\
-      \ ordinary containers."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/noprivilegedcontainers"
-    options: []
-  - name: "org.openrewrite.kubernetes.NoRootContainers"
-    description: "Containers that run as root frequently have more permissions than\
-      \ their workload requires which, in case of compromise, could help an attacker\
-      \ further their exploits."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/norootcontainers"
-    options: []
-  - name: "org.openrewrite.kubernetes.ReadOnlyRootFilesystem"
-    description: "Using an immutable root filesystem and a verified boot mechanism\
-      \ prevents against attackers from \"owning\" the machine through permanent local\
-      \ changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/readonlyrootfilesystem"
-    options: []
-  - name: "org.openrewrite.kubernetes.UpdateContainerImageName"
-    description: "Search for image names that match patterns and replace the components\
-      \ of the name with new values."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/updatecontainerimagename"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "imageToFind"
-      type: "String"
-      required: true
-    - name: "imageToUpdate"
-      type: "String"
-      required: false
-    - name: "includeInitContainers"
-      type: "boolean"
-      required: false
-    - name: "repoToFind"
-      type: "String"
-      required: false
-    - name: "repoToUpdate"
-      type: "String"
-      required: false
-    - name: "tagToFind"
-      type: "String"
-      required: false
-    - name: "tagToUpdate"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.kubernetes.rbac.AddRuleToRole"
-    description: "Add RBAC rules to ClusterRoles or namespaced Roles."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/rbac/addruletorole"
-    options:
-    - name: "apiGroups"
-      type: "Set"
-      required: true
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "rbacResourceName"
-      type: "String"
-      required: true
-    - name: "rbacResourceType"
-      type: "String"
-      required: true
-    - name: "resourceNames"
-      type: "Set"
-      required: false
-    - name: "resources"
-      type: "Set"
-      required: true
-    - name: "verbs"
-      type: "Set"
-      required: true
-  - name: "org.openrewrite.kubernetes.resource.CapResourceValueToMaximum"
-    description: "Cap resource values that exceed a specific maximum."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/resource/capresourcevaluetomaximum"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "resourceLimit"
-      type: "String"
-      required: true
-    - name: "resourceType"
-      type: "String"
-      required: true
-    - name: "resourceValueType"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.kubernetes.resource.FindExceedsResourceRatio"
-    description: "Find resource manifests that have requests to limits ratios beyond\
-      \ a specific maximum."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/resource/findexceedsresourceratio"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "ratioLimit"
-      type: "String"
-      required: true
-    - name: "resourceType"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.kubernetes.resource.FindExceedsResourceValue"
-    description: "Find resource manifests that have limits set beyond a specific maximum."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/resource/findexceedsresourcevalue"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "resourceLimit"
-      type: "String"
-      required: true
-    - name: "resourceType"
-      type: "String"
-      required: true
-    - name: "resourceValueType"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.kubernetes.search.FindAnnotation"
-    description: "Find annotations that optionally match a given regex."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findannotation"
-    options:
-    - name: "annotationName"
-      type: "String"
-      required: true
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "value"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.kubernetes.search.FindDisallowedImageTags"
-    description: "The set of image tags to find which are considered disallowed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/finddisallowedimagetags"
-    options:
-    - name: "disallowedTags"
-      type: "Set"
-      required: true
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "includeInitContainers"
-      type: "boolean"
-      required: false
-  - name: "org.openrewrite.kubernetes.search.FindImage"
-    description: "The image name to search for in containers and initContainers."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findimage"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "imageName"
-      type: "String"
-      required: true
-    - name: "imageTag"
-      type: "String"
-      required: false
-    - name: "includeInitContainers"
-      type: "boolean"
-      required: false
-    - name: "repository"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.kubernetes.search.FindMissingDigest"
-    description: "Find instances of a container name that fails to specify a digest."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findmissingdigest"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "includeInitContainers"
-      type: "boolean"
-      required: false
-  - name: "org.openrewrite.kubernetes.search.FindMissingOrInvalidAnnotation"
-    description: "Find annotations that optionally match a given value."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findmissingorinvalidannotation"
-    options:
-    - name: "annotationName"
-      type: "String"
-      required: true
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "value"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.kubernetes.search.FindMissingOrInvalidLabel"
-    description: "Find labels that optionally match a given regex."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findmissingorinvalidlabel"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "labelName"
-      type: "String"
-      required: true
-    - name: "value"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.kubernetes.search.FindNonTlsIngress"
-    description: "Find Ingress resources that don't disallow HTTP or don't have TLS\
-      \ configured."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findnontlsingress"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.kubernetes.search.FindResourceMissingConfiguration"
-    description: "Find Kubernetes resources with missing configuration."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findresourcemissingconfiguration"
-    options:
-    - name: "configurationPath"
-      type: "String"
-      required: true
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "resourceKind"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.kubernetes.services.FindServiceExternalIPs"
-    description: "Find any `Service` whose `externalIP` list contains, or does not\
-      \ contain, one of a list of IPs."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/services/findserviceexternalips"
-    options:
-    - name: "externalIPs"
-      type: "Set"
-      required: true
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "findMissing"
-      type: "boolean"
-      required: false
-  - name: "org.openrewrite.kubernetes.services.FindServicesByType"
-    description: "Type of Kubernetes `Service` to find."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/services/findservicesbytype"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "serviceType"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.kubernetes.services.UpdateServiceExternalIP"
-    description: "Swap out an IP address with another one in `Service` `externalIP`\
-      \ settings."
-    docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/services/updateserviceexternalip"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "ipToFind"
-      type: "String"
-      required: true
-    - name: "ipToUpdate"
-      type: "String"
-      required: true
-- artifactId: "rewrite-logging-frameworks"
+    org.openrewrite.DeleteSourceFiles:
+      name: "org.openrewrite.DeleteSourceFiles"
+      description: "Delete files by source path."
+      docLink: "https://docs.openrewrite.org/reference/recipes/deletesourcefiles"
+      options:
+      - name: "filePattern"
+        type: "String"
+        required: true
+    org.openrewrite.FindParseFailures:
+      name: "org.openrewrite.FindParseFailures"
+      description: "This recipe explores parse failures after an AST is produced for\
+        \ classifying the types of failures that can occur and prioritizing fixes\
+        \ according to the most common problems."
+      docLink: "https://docs.openrewrite.org/reference/recipes/findparsefailures"
+      options: []
+    org.openrewrite.FindQuarks:
+      name: "org.openrewrite.FindQuarks"
+      description: "Find instances of type `Quark`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/findquarks"
+      options: []
+    org.openrewrite.FindSourceFiles:
+      name: "org.openrewrite.FindSourceFiles"
+      description: "Find files by source path."
+      docLink: "https://docs.openrewrite.org/reference/recipes/findsourcefiles"
+      options:
+      - name: "filePattern"
+        type: "String"
+        required: true
+    org.openrewrite.RenameFile:
+      name: "org.openrewrite.RenameFile"
+      description: "Rename a file while keeping it in the same directory."
+      docLink: "https://docs.openrewrite.org/reference/recipes/renamefile"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: true
+      - name: "fileName"
+        type: "String"
+        required: true
+    org.openrewrite.SetFilePermissions:
+      name: "org.openrewrite.SetFilePermissions"
+      description: "Set a files read, write and executable permission attributes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/setfilepermissions"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: true
+      - name: "isExecutable"
+        type: "Boolean"
+        required: true
+      - name: "isReadable"
+        type: "Boolean"
+        required: true
+      - name: "isWritable"
+        type: "Boolean"
+        required: true
+    org.openrewrite.config.CompositeRecipe:
+      name: "org.openrewrite.config.CompositeRecipe"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/config/compositerecipe"
+      options: []
+rewrite-github-actions:
+  artifactId: "rewrite-github-actions"
   version: "1.14.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.logging.ParameterizedLogging"
-    description: "Transform logging statements using concatenation for messages and\
-      \ variables into a parameterized format. For example, `logger.info(\"hi \" +\
-      \ userName)` becomes `logger.info(\"hi {}\", userName)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/parameterizedlogging"
-    options:
-    - name: "methodPattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.logging.PrintStackTraceToLogError"
-    description: "When a logger is present, log exceptions rather than calling `printStackTrace()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/printstacktracetologerror"
-    options:
-    - name: "addLogger"
-      type: "Boolean"
-      required: false
-    - name: "loggerName"
-      type: "String"
-      required: false
-    - name: "loggingFramework"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.logging.SystemErrToLogging"
-    description: "Replace `System.err` print statements with a logger."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/systemerrtologging"
-    options:
-    - name: "addLogger"
-      type: "Boolean"
-      required: false
-    - name: "loggerName"
-      type: "String"
-      required: false
-    - name: "loggingFramework"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.logging.SystemOutToLogging"
-    description: "Replace `System.out` print statements with a logger."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/systemouttologging"
-    options:
-    - name: "addLogger"
-      type: "Boolean"
-      required: false
-    - name: "level"
-      type: "String"
-      required: false
-    - name: "loggerName"
-      type: "String"
-      required: false
-    - name: "loggingFramework"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.logging.SystemPrintToLogging"
-    description: "Replace `System.out` and `System.err` print statements with a logger."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/systemprinttologging"
-    options:
-    - name: "addLogger"
-      type: "Boolean"
-      required: false
-    - name: "level"
-      type: "String"
-      required: false
-    - name: "loggerName"
-      type: "String"
-      required: false
-    - name: "loggingFramework"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.logging.log4j.Log4j1ToLog4j2"
-    description: "Migrates Log4j 1.x to Log4j 2.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/log4j/log4j1tolog4j2"
-    options: []
-  - name: "org.openrewrite.java.logging.log4j.ParameterizedLogging"
-    description: "Log4j 2.x supports parameterized logging, which can significantly\
-      \ boost logging performance for disabled logging statements."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/log4j/parameterizedlogging"
-    options: []
-  - name: "org.openrewrite.java.logging.log4j.PrependRandomName"
-    description: "To make finding the callsite of a logging statement easier in code\
-      \ search."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/log4j/prependrandomname"
-    options: []
-  - name: "org.openrewrite.java.logging.logback.Log4jAppenderToLogback"
-    description: "Migrates custom Log4j 2.x Appender components to `logback-classic`.\
-      \ This recipe operates on the following assumptions: 1.) The contents of the\
-      \ `append()` method remains unchanged. 2.) The `requiresLayout()` method is\
-      \ not used in logback and can be removed. 3.) In logback, the `stop()` method\
-      \ is the equivalent of log4j's close() method. For more details, see this page\
-      \ from logback: [`Migration from log4j`](http://logback.qos.ch/manual/migrationFromLog4j.html)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/logback/log4jappendertologback"
-    options: []
-  - name: "org.openrewrite.java.logging.logback.Log4jLayoutToLogback"
-    description: "Migrates custom Log4j 2.x Layout components to `logback-classic`.\
-      \ This recipe operates on the following assumptions: 1.) A logback-classic layout\
-      \ must extend the `LayoutBase<ILoggingEvent>` class. 2.) log4j's `format()`\
-      \ is renamed to `doLayout()` in a logback-classic layout. 3.) LoggingEvent `getRenderedMessage()`\
-      \ is converted to LoggingEvent `getMessage()`. 4.) The log4j ignoresThrowable()\
-      \ method is not needed and has no equivalent in logback-classic. 5.) The activateOptions()\
-      \ method merits further discussion. In log4j, a layout will have its activateOptions()\
-      \ method invoked by log4j configurators, that is PropertyConfigurator or DOMConfigurator\
-      \ just after all the options of the layout have been set. Thus, the layout will\
-      \ have an opportunity to check that its options are coherent and if so, proceed\
-      \ to fully initialize itself. 6.) In logback-classic, layouts must implement\
-      \ the LifeCycle interface which includes a method called start(). The start()\
-      \ method is the equivalent of log4j's activateOptions() method. For more details,\
-      \ see this page from logback: [`Migration from log4j`](http://logback.qos.ch/manual/migrationFromLog4j.html)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/logback/log4jlayouttologback"
-    options: []
-  - name: "org.openrewrite.java.logging.logback.Log4jToLogback"
-    description: "Migrates usage of Apache Log4j 2.x to using `logback` as an SLF4J\
-      \ implementation directly. Note, this currently does not modify `log4j.properties`\
-      \ files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/logback/log4jtologback"
-    options: []
-  - name: "org.openrewrite.java.logging.slf4j.ConvertLogMessageMessageOnlyToLogMessageAndThrowable"
-    description: "Convert `Logger#error|warn(throwable#message)` to `Logger#error|warn(<log-message>,\
-      \ e)` invocations having only the error's message as the parameter, to a log\
-      \ statement with message and throwable"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/convertlogmessagemessageonlytologmessageandthrowable"
-    options:
-    - name: "logMessage"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.logging.slf4j.Log4j1ToSlf4j1"
-    description: "Transforms usages of Log4j 1.x to leveraging SLF4J 1.x directly.\
-      \ Note, this currently does not modify `log4j.properties` files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/log4j1toslf4j1"
-    options: []
-  - name: "org.openrewrite.java.logging.slf4j.Log4j2ToSlf4j1"
-    description: "Transforms usages of Log4j 2.x to leveraging SLF4J 1.x directly.\
-      \ Note, this currently does not modify `log4j.properties` files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/log4j2toslf4j1"
-    options: []
-  - name: "org.openrewrite.java.logging.slf4j.Log4jToSlf4j"
-    description: "Migrates usage of Apache Log4j to using SLF4J directly. Use of the\
-      \ traditional Log4j to SLF4J bridge can result in loss of performance, as the\
-      \ Log4j messages must be formatted before they can be passed to SLF4J. Note,\
-      \ this currently does not modify `log4j.properties` files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/log4jtoslf4j"
-    options: []
-  - name: "org.openrewrite.java.logging.slf4j.LoggersNamedForEnclosingClass"
-    description: "Ensure `LoggerFactory#getLogger(Class)` is called with the enclosing\
-      \ class as argument."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/loggersnamedforenclosingclass"
-    options: []
-  - name: "org.openrewrite.java.logging.slf4j.ParameterizedLogging"
-    description: "SLF4J supports parameterized logging, which can significantly boost\
-      \ logging performance for disabled logging statements."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/parameterizedlogging"
-    options: []
-  - name: "org.openrewrite.java.logging.slf4j.Slf4jLogShouldBeConstant"
-    description: "Logging statements shouldn't begin with `String#format`, calls to\
-      \ `toString()`, etc."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/slf4jlogshouldbeconstant"
-    options: []
-- artifactId: "rewrite-maven"
-  version: "7.32.1"
+    org.openrewrite.github.ActionsSetupJavaAdoptOpenJDKToTemurin:
+      name: "org.openrewrite.github.ActionsSetupJavaAdoptOpenJDKToTemurin"
+      description: "Adopt OpenJDK got moved to Eclipse Temurin and won't be updated\
+        \ anymore. It is highly recommended to migrate workflows from adopt to temurin\
+        \ to keep receiving software and security updates. See more details in the\
+        \ [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/github/actionssetupjavaadoptopenjdktotemurin"
+      options: []
+    org.openrewrite.github.AddCronTrigger:
+      name: "org.openrewrite.github.AddCronTrigger"
+      description: "The `schedule` [event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events)\
+        \ allows you to trigger a workflow at a scheduled time."
+      docLink: "https://docs.openrewrite.org/reference/recipes/github/addcrontrigger"
+      options:
+      - name: "cron"
+        type: "String"
+        required: true
+    org.openrewrite.github.AddManualTrigger:
+      name: "org.openrewrite.github.AddManualTrigger"
+      description: "You can manually trigger workflow runs. To trigger specific workflows\
+        \ in a repository, use the `workflow_dispatch` event."
+      docLink: "https://docs.openrewrite.org/reference/recipes/github/addmanualtrigger"
+      options: []
+    org.openrewrite.github.AutoCancelInProgressWorkflow:
+      name: "org.openrewrite.github.AutoCancelInProgressWorkflow"
+      description: "When a workflow is already running and would be triggered again,\
+        \ cancel the existing workflow. See [`styfle/cancel-workflow-action`](https://github.com/styfle/cancel-workflow-action)\
+        \ for details."
+      docLink: "https://docs.openrewrite.org/reference/recipes/github/autocancelinprogressworkflow"
+      options:
+      - name: "accessToken"
+        type: "String"
+        required: false
+    org.openrewrite.github.ChangeDependabotScheduleInterval:
+      name: "org.openrewrite.github.ChangeDependabotScheduleInterval"
+      description: "Change the schedule interval for a given package-ecosystem in\
+        \ a `dependabot.yml` configuration file. [The available configuration options\
+        \ for dependabot are listed on GitHub](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/github/changedependabotscheduleinterval"
+      options:
+      - name: "interval"
+        type: "String"
+        required: true
+      - name: "packageEcosystem"
+        type: "String"
+        required: true
+    org.openrewrite.github.DependabotCheckForGithubActionsUpdatesDaily:
+      name: "org.openrewrite.github.DependabotCheckForGithubActionsUpdatesDaily"
+      description: "Set dependabot to check for github-actions updates daily."
+      docLink: "https://docs.openrewrite.org/reference/recipes/github/dependabotcheckforgithubactionsupdatesdaily"
+      options: []
+    org.openrewrite.github.DependabotCheckForGithubActionsUpdatesWeekly:
+      name: "org.openrewrite.github.DependabotCheckForGithubActionsUpdatesWeekly"
+      description: "Set dependabot to check for github-actions updates weekly."
+      docLink: "https://docs.openrewrite.org/reference/recipes/github/dependabotcheckforgithubactionsupdatesweekly"
+      options: []
+    org.openrewrite.github.SetupJavaCaching:
+      name: "org.openrewrite.github.SetupJavaCaching"
+      description: "Github actions supports dependency caching on Maven and Gradle\
+        \ projects. See the [blog post](https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/github/setupjavacaching"
+      options: []
+rewrite-gradle:
+  artifactId: "rewrite-gradle"
+  version: "7.33.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.maven.AddCommentToMavenDependency"
-    description: "Adds a comment as the first element in a `Maven` dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/addcommenttomavendependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "commentText"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "xPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.AddDependency"
-    description: "Add a maven dependency to a `pom.xml` file in the correct scope\
-      \ based on where it is used."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/adddependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "classifier"
-      type: "String"
-      required: false
-    - name: "familyPattern"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "onlyIfUsing"
-      type: "String"
-      required: true
-    - name: "optional"
-      type: "Boolean"
-      required: false
-    - name: "releasesOnly"
-      type: "Boolean"
-      required: false
-    - name: "scope"
-      type: "String"
-      required: false
-    - name: "type"
-      type: "String"
-      required: false
-    - name: "version"
-      type: "String"
-      required: true
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.AddManagedDependency"
-    description: "Add a managed maven dependency to a pom.xml file."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/addmanageddependency"
-    options:
-    - name: "addToRootPom"
-      type: "Boolean"
-      required: false
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "classifier"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "onlyIfUsing"
-      type: "String"
-      required: false
-    - name: "releasesOnly"
-      type: "Boolean"
-      required: false
-    - name: "scope"
-      type: "String"
-      required: false
-    - name: "type"
-      type: "String"
-      required: false
-    - name: "version"
-      type: "String"
-      required: true
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.AddPlugin"
-    description: "Add the specified Maven plugin to the pom.xml."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/addplugin"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "dependencies"
-      type: "String"
-      required: false
-    - name: "executions"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "version"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.AddPluginDependency"
-    description: "Adds the specified dependencies to a Maven plugin. Will not add\
-      \ the plugin if it does not already exist in the pom."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/addplugindependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "pluginArtifactId"
-      type: "String"
-      required: true
-    - name: "pluginGroupId"
-      type: "String"
-      required: true
-    - name: "version"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.AddProperty"
-    description: "Add a new property to the Maven project property."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/addproperty"
-    options:
-    - name: "key"
-      type: "String"
-      required: true
-    - name: "preserveExistingValue"
-      type: "Boolean"
-      required: false
-    - name: "trustParent"
-      type: "Boolean"
-      required: false
-    - name: "value"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.ChangeDependencyClassifier"
-    description: "Add or alter the classifier of the specified dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changedependencyclassifier"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newClassifier"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId"
-    description: "Change the groupId, artifactId and/or the version of a specified\
-      \ Maven dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changedependencygroupidandartifactid"
-    options:
-    - name: "newArtifactId"
-      type: "String"
-      required: false
-    - name: "newGroupId"
-      type: "String"
-      required: false
-    - name: "newVersion"
-      type: "String"
-      required: false
-    - name: "oldArtifactId"
-      type: "String"
-      required: true
-    - name: "oldGroupId"
-      type: "String"
-      required: true
-    - name: "overrideManagedVersion"
-      type: "Boolean"
-      required: false
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.ChangeDependencyScope"
-    description: "Add or alter the scope of the specified dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changedependencyscope"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newScope"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId"
-    description: "Change the groupId, artifactId and optionally the version of a specified\
-      \ Maven managed dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changemanageddependencygroupidandartifactid"
-    options:
-    - name: "newArtifactId"
-      type: "String"
-      required: true
-    - name: "newGroupId"
-      type: "String"
-      required: true
-    - name: "newVersion"
-      type: "String"
-      required: false
-    - name: "oldArtifactId"
-      type: "String"
-      required: true
-    - name: "oldGroupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.ChangePackaging"
-    description: "Sets the packaging type of Maven projects. Either adds the packaging\
-      \ tag if it is missing or changes its context if present."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changepackaging"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "packaging"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.ChangeParentPom"
-    description: "Change the parent pom of a Maven pom.xml. Identifies the parent\
-      \ pom to be changed by its groupId and artifactId."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changeparentpom"
-    options:
-    - name: "allowVersionDowngrades"
-      type: "boolean"
-      required: false
-    - name: "newArtifactId"
-      type: "String"
-      required: false
-    - name: "newGroupId"
-      type: "String"
-      required: false
-    - name: "newVersion"
-      type: "String"
-      required: true
-    - name: "oldArtifactId"
-      type: "String"
-      required: true
-    - name: "oldGroupId"
-      type: "String"
-      required: true
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.ChangePluginConfiguration"
-    description: "Apply the specified configuration to a Maven plugin. Will not add\
-      \ the plugin if it does not already exist in the pom."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changepluginconfiguration"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "configuration"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.ChangePluginDependencies"
-    description: "Applies the specified dependencies to a Maven plugin. Will not add\
-      \ the plugin if it does not already exist in the pom."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changeplugindependencies"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "dependencies"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.ChangePluginExecutions"
-    description: "Apply the specified executions to a Maven plugin. Will not add the\
-      \ plugin if it does not already exist in the pom."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changepluginexecutions"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "executions"
-      type: "String"
-      required: false
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.ChangePropertyValue"
-    description: "Changes the specified Maven project property value leaving the key\
-      \ intact."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/changepropertyvalue"
-    options:
-    - name: "addIfMissing"
-      type: "Boolean"
-      required: false
-    - name: "key"
-      type: "String"
-      required: true
-    - name: "newValue"
-      type: "String"
-      required: true
-    - name: "trustParent"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.maven.ExcludeDependency"
-    description: "Exclude specified dependency from any dependency that transitively\
-      \ includes it."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/excludedependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "scope"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.ManageDependencies"
-    description: "Make existing dependencies managed by moving their version to be\
-      \ specified in the dependencyManagement section of the POM."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/managedependencies"
-    options:
-    - name: "addToRootPom"
-      type: "Boolean"
-      required: false
-    - name: "artifactPattern"
-      type: "String"
-      required: false
-    - name: "groupPattern"
-      type: "String"
-      required: true
-    - name: "skipModelUpdate"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.maven.OrderPomElements"
-    description: "Order POM elements according to the [recommended](http://maven.apache.org/developers/conventions/code.html#pom-code-convention)\
-      \ order."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/orderpomelements"
-    options: []
-  - name: "org.openrewrite.maven.RemoveDependency"
-    description: "Removes a single dependency from the <dependencies> section of the\
-      \ pom.xml."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/removedependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "scope"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.RemoveExclusion"
-    description: "Remove a single exclusion from on a particular dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/removeexclusion"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "exclusionArtifactId"
-      type: "String"
-      required: true
-    - name: "exclusionGroupId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.RemoveManagedDependency"
-    description: "Removes a single managed dependency from the <dependencyManagement><dependencies>\
-      \ section of the pom.xml."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/removemanageddependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "scope"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.RemovePlugin"
-    description: "Remove the specified Maven plugin from the pom.xml."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/removeplugin"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.RemoveProperty"
-    description: "Removes the specified Maven project property from the pom.xml."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/removeproperty"
-    options:
-    - name: "propertyName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.RemoveRedundantDependencyVersions"
-    description: "Remove explicitly-specified dependency versions when a parent POM's\
-      \ dependencyManagement specifies the version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/removeredundantdependencyversions"
-    options:
-    - name: "artifactPattern"
-      type: "String"
-      required: false
-    - name: "groupPattern"
-      type: "String"
-      required: false
-    - name: "onlyIfVersionsMatch"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.maven.UpgradeDependencyVersion"
-    description: "Upgrade the version of a dependency by specifying a group or group\
-      \ and artifact using Node Semver advanced range selectors, allowing more precise\
-      \ control over version updates to patch or minor releases."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/upgradedependencyversion"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newVersion"
-      type: "String"
-      required: true
-    - name: "overrideManagedVersion"
-      type: "Boolean"
-      required: false
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.UpgradeParentVersion"
-    description: "Set the parent pom version number according to a node-style semver\
-      \ selector or to a specific version number."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/upgradeparentversion"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newVersion"
-      type: "String"
-      required: true
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.UpgradePluginVersion"
-    description: "Upgrade the version of a plugin using Node Semver advanced range\
-      \ selectors, allowing more precise control over version updates to patch or\
-      \ minor releases."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/upgradepluginversion"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-    - name: "newVersion"
-      type: "String"
-      required: true
-    - name: "trustParent"
-      type: "Boolean"
-      required: false
-    - name: "versionPattern"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.cleanup.DependencyManagementDependencyRequiresVersion"
-    description: "If they don't have a version, they can't possibly affect dependency\
-      \ resolution anywhere, and can be safely removed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/cleanup/dependencymanagementdependencyrequiresversion"
-    options: []
-  - name: "org.openrewrite.maven.search.DependencyInsight"
-    description: "Find direct and transitive dependencies matching a group, artifact,\
-      \ and scope. Results include dependencies that either directly match or transitively\
-      \ include a matching dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/dependencyinsight"
-    options:
-    - name: "artifactIdPattern"
-      type: "String"
-      required: true
-    - name: "groupIdPattern"
-      type: "String"
-      required: true
-    - name: "scope"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.search.FindDependency"
-    description: "Finds first-order dependency uses, i.e. dependencies that are defined\
-      \ directly in a project."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/finddependency"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.search.FindPlugin"
-    description: "Finds a Maven plugin within a pom.xml."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/findplugin"
-    options:
-    - name: "artifactId"
-      type: "String"
-      required: true
-    - name: "groupId"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.search.FindProperties"
-    description: "Finds the specified Maven project properties within a pom.xml."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/findproperties"
-    options:
-    - name: "propertyPattern"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.maven.security.UseHttpsForRepositories"
-    description: "Use HTTPS for repository urls"
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/security/usehttpsforrepositories"
-    options: []
-  - name: "org.openrewrite.maven.utilities.ListDependencies"
-    description: "List all the dependencies in a scope and add to a text file."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/utilities/listdependencies"
-    options:
-    - name: "scope"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.maven.utilities.PrintMavenAsDot"
-    description: "The DOT language format is specified [here](https://graphviz.org/doc/info/lang.html)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/utilities/printmavenasdot"
-    options: []
-- artifactId: "rewrite-micronaut"
-  version: "1.18.0"
+    org.openrewrite.gradle.ActivateStyle:
+      name: "org.openrewrite.gradle.ActivateStyle"
+      description: "Sets the specified style as active. Once the style has been set,\
+        \ future recipes will use the specified style for any changes they make. This\
+        \ recipe does not reformat anything on its own. Prefers to set the `activeStyle()`\
+        \ method in the `rewrite` DSL in a build.gradle.If no `rewrite` DSL can be\
+        \ found to update, will instead place a \"systemProp.rewrite.activeStyles\"\
+        \ entry within the project's gradle.properties. Styles can be provided by\
+        \ rewrite itself, defined in a rewrite.yml, or provided by recipe modules."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/activatestyle"
+      options:
+      - name: "fullyQualifiedStyleName"
+        type: "String"
+        required: true
+      - name: "overwriteExistingStyles"
+        type: "boolean"
+        required: false
+    org.openrewrite.gradle.AddDelegatesToGradleApi:
+      name: "org.openrewrite.gradle.AddDelegatesToGradleApi"
+      description: "The Gradle API has methods which accept `groovy.lang.Closure`.\
+        \ Typically, there is an overload which accepts an `org.gradle.api.Action`.This\
+        \ recipe takes the type declared as the receiver of the `Action` overload\
+        \ and adds an appropriate `@groovy.lang.DelegatesTo` annotation to the `Closure`\
+        \ overload."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/adddelegatestogradleapi"
+      options: []
+    org.openrewrite.gradle.AddGradleWrapper:
+      name: "org.openrewrite.gradle.AddGradleWrapper"
+      description: "Add a Gradle wrapper where one does not exist."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/addgradlewrapper"
+      options:
+      - name: "distribution"
+        type: "String"
+        required: false
+      - name: "version"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.AddProperty:
+      name: "org.openrewrite.gradle.AddProperty"
+      description: "Add a property to the `gradle.properties` file."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/addproperty"
+      options:
+      - name: "key"
+        type: "String"
+        required: true
+      - name: "overwrite"
+        type: "Boolean"
+        required: true
+      - name: "value"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.ChangeDependencyArtifactId:
+      name: "org.openrewrite.gradle.ChangeDependencyArtifactId"
+      description: "Change the artifactId of a specified Gradle dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyartifactid"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newArtifactId"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.ChangeDependencyClassifier:
+      name: "org.openrewrite.gradle.ChangeDependencyClassifier"
+      description: "Finds dependencies declared in `build.gradle` files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyclassifier"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newClassifier"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.ChangeDependencyConfiguration:
+      name: "org.openrewrite.gradle.ChangeDependencyConfiguration"
+      description: "Finds dependencies declared in `build.gradle` files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyconfiguration"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newConfiguration"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.ChangeDependencyExtension:
+      name: "org.openrewrite.gradle.ChangeDependencyExtension"
+      description: "Finds dependencies declared in `build.gradle` files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyextension"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newExtension"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.ChangeDependencyGroupId:
+      name: "org.openrewrite.gradle.ChangeDependencyGroupId"
+      description: "Change the group id of a specified Gradle dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencygroupid"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newGroupId"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.ChangeDependencyVersion:
+      name: "org.openrewrite.gradle.ChangeDependencyVersion"
+      description: "Finds dependencies declared in `build.gradle` files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changedependencyversion"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newVersion"
+        type: "String"
+        required: true
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.gradle.ChangeJavaCompatibility:
+      name: "org.openrewrite.gradle.ChangeJavaCompatibility"
+      description: "Find and updates the Java compatibility for the Gradle project."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/changejavacompatibility"
+      options:
+      - name: "compatibilityType"
+        type: "String"
+        required: true
+      - name: "newVersion"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.DependencyUseMapNotation:
+      name: "org.openrewrite.gradle.DependencyUseMapNotation"
+      description: "In Gradle, dependencies can be expressed as a `String` like `\"\
+        groupId:artifactId:version\"`, or equivalently as a `Map` like `group: 'groupId',\
+        \ name: 'artifactId', version: 'version'`. This recipe replaces dependencies\
+        \ represented as `Strings` with an equivalent dependency represented as a\
+        \ `Map`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/dependencyusemapnotation"
+      options: []
+    org.openrewrite.gradle.DependencyUseStringNotation:
+      name: "org.openrewrite.gradle.DependencyUseStringNotation"
+      description: "In Gradle, dependencies can be expressed as a `String` like `\"\
+        groupId:artifactId:version\"`, or equivalently as a `Map` like `group: 'groupId',\
+        \ name: 'artifactId', version: 'version'`. This recipe replaces dependencies\
+        \ represented as `Maps` with an equivalent dependency represented as a `String`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/dependencyusestringnotation"
+      options: []
+    org.openrewrite.gradle.RemoveGradleDependency:
+      name: "org.openrewrite.gradle.RemoveGradleDependency"
+      description: "Removes a single dependency from the dependencies section of the\
+        \ `build.gradle`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/removegradledependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.RemoveRepository:
+      name: "org.openrewrite.gradle.RemoveRepository"
+      description: "Removes a repository from Gradle build scripts. Named repositories\
+        \ include \"jcenter\", \"mavenCentral\", \"mavenLocal\", and \"google\"."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/removerepository"
+      options:
+      - name: "repository"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.UpdateGradleWrapper:
+      name: "org.openrewrite.gradle.UpdateGradleWrapper"
+      description: "Update the version of Gradle used in an existing Gradle wrapper."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/updategradlewrapper"
+      options:
+      - name: "distribution"
+        type: "String"
+        required: false
+      - name: "version"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.plugins.AddGradleEnterprise:
+      name: "org.openrewrite.gradle.plugins.AddGradleEnterprise"
+      description: "Add the Gradle Enterprise plugin to `settings.gradle(.kts)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/plugins/addgradleenterprise"
+      options:
+      - name: "version"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.plugins.UpgradePluginVersion:
+      name: "org.openrewrite.gradle.plugins.UpgradePluginVersion"
+      description: "Update a Gradle plugin by id to a later version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/plugins/upgradepluginversion"
+      options:
+      - name: "newVersion"
+        type: "String"
+        required: true
+      - name: "pluginIdPattern"
+        type: "String"
+        required: true
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.gradle.search.EnableGradleParallelExecution:
+      name: "org.openrewrite.gradle.search.EnableGradleParallelExecution"
+      description: "Most builds consist of more than one project and some of those\
+        \ projects are usually independent of one another. Yet Gradle will only run\
+        \ one task at a time by default, regardless of the project structure. By using\
+        \ the `--parallel` switch, you can force Gradle to execute tasks in parallel\
+        \ as long as those tasks are in different projects. See the [Gradle performance\
+        \ documentation](https://docs.gradle.org/current/userguide/performance.html#parallel_execution)\
+        \ for more."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/search/enablegradleparallelexecution"
+      options: []
+    org.openrewrite.gradle.search.FindDependency:
+      name: "org.openrewrite.gradle.search.FindDependency"
+      description: "Finds dependencies declared in `build.gradle` files. See the [reference](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph)\
+        \ on Gradle configurations or the diagram below for a description of what\
+        \ configuration to use. A project's compile and runtime classpath is based\
+        \ on these configurations.\n\n<img alt=\"Gradle compile classpath\" src=\"\
+        https://docs.gradle.org/current/userguide/img/java-library-ignore-deprecated-main.png\"\
+        \ width=\"200px\"/>\n A project's test classpath is based on these configurations.\n\
+        \n<img alt=\"Gradle test classpath\" src=\"https://docs.gradle.org/current/userguide/img/java-library-ignore-deprecated-test.png\"\
+        \ width=\"200px\"/>."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/search/finddependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.search.FindDependencyHandler:
+      name: "org.openrewrite.gradle.search.FindDependencyHandler"
+      description: "Find the dependency handler containing any number of dependency\
+        \ definitions."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/search/finddependencyhandler"
+      options: []
+    org.openrewrite.gradle.search.FindGradleProject:
+      name: "org.openrewrite.gradle.search.FindGradleProject"
+      description: "Gradle projects are those with `build.gradle` or `build.gradle.kts`\
+        \ files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/search/findgradleproject"
+      options: []
+    org.openrewrite.gradle.search.FindPlugins:
+      name: "org.openrewrite.gradle.search.FindPlugins"
+      description: "Find a Gradle plugin by id."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/search/findplugins"
+      options:
+      - name: "pluginId"
+        type: "String"
+        required: true
+    org.openrewrite.gradle.security.UseHttpsForRepositories:
+      name: "org.openrewrite.gradle.security.UseHttpsForRepositories"
+      description: "Use HTTPS for repository urls."
+      docLink: "https://docs.openrewrite.org/reference/recipes/gradle/security/usehttpsforrepositories"
+      options: []
+rewrite-groovy:
+  artifactId: "rewrite-groovy"
+  version: "7.33.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.micronaut.BeanPropertyCapitalizationStrategy"
-    description: "As of Micronaut 3.x property names for getters like `getXForwarded()`\
-      \ are de-capitalized from `XForwarded` to `xForwarded`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/beanpropertycapitalizationstrategy"
-    options: []
-  - name: "org.openrewrite.java.micronaut.CopyNonInheritedAnnotations"
-    description: "As of Micronaut 3.x only [annotations](https://github.com/micronaut-projects/micronaut-core/blob/3.0.x/src/main/docs/guide/appendix/breaks.adoc#annotation-inheritance)\
-      \ that are explicitly meta-annotated with `@Inherited` are inherited from parent\
-      \ classes and interfaces."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/copynoninheritedannotations"
-    options: []
-  - name: "org.openrewrite.java.micronaut.FixDeprecatedExceptionHandlerConstructors"
-    description: "Adds `ErrorResponseProcessor` argument to deprecated no-arg `ExceptionHandler`\
-      \ constructors."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/fixdeprecatedexceptionhandlerconstructors"
-    options: []
-  - name: "org.openrewrite.java.micronaut.Micronaut2to3Migration"
-    description: "This recipe will apply changes required for migrating from Micronaut\
-      \ 2 to Micronaut 3."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/micronaut2to3migration"
-    options: []
-  - name: "org.openrewrite.java.micronaut.OncePerRequestHttpServerFilterToHttpServerFilter"
-    description: "Starting in Micronaut 3.0 all filters are executed once per request.\
-      \ Directly implement `HttpServerFilter` instead of extending `OncePerRequestHttpServerFilter`\
-      \ and replace any usages of `micronaut.once` attributes with a custom attribute\
-      \ name."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/onceperrequesthttpserverfiltertohttpserverfilter"
-    options: []
-  - name: "org.openrewrite.java.micronaut.ProviderImplementationsToMicronautFactories"
-    description: "As of Micronaut 3.x the `@Factory` annotation is required for creating\
-      \ beans from `javax.inject.Provider get()` implementations."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/providerimplementationstomicronautfactories"
-    options: []
-  - name: "org.openrewrite.java.micronaut.SubclassesReturnedFromFactoriesNotInjectable"
-    description: "As of Micronaut 3.x It is no longer possible to inject the internal\
-      \ implementation type from beans produced via factories. Factory method return\
-      \ types are changed to reflect the resolved return type if the method returns\
-      \ a single non-null type that does not match the method declaration return type."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/subclassesreturnedfromfactoriesnotinjectable"
-    options: []
-  - name: "org.openrewrite.java.micronaut.TypeRequiresIntrospection"
-    description: "In Micronaut 2.x a reflection-based strategy was used to retrieve\
-      \ that information if the class was not annotated with `@Introspected`. As of\
-      \ Micronaut 3.x it is required to annotate classes with `@Introspected` that\
-      \ are used in this way."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/typerequiresintrospection"
-    options: []
-  - name: "org.openrewrite.java.micronaut.UpgradeMicronautGradlePropertiesVersion"
-    description: "Set the gradle.properties version number according to a node-style\
-      \ semver selector or to a specific version number."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/upgrademicronautgradlepropertiesversion"
-    options:
-    - name: "newVersion"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.micronaut.UpgradeMicronautMavenPropertyVersion"
-    description: "Set the maven micronaut.version property according to a node-style\
-      \ semver selector or to a specific version number."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/upgrademicronautmavenpropertyversion"
-    options:
-    - name: "newVersion"
-      type: "String"
-      required: true
-- artifactId: "rewrite-migrate-java"
-  version: "1.13.0"
+    org.openrewrite.groovy.format.OmitParenthesesForLastArgumentLambda:
+      name: "org.openrewrite.groovy.format.OmitParenthesesForLastArgumentLambda"
+      description: "Groovy allows a shorthand syntax that allows a closure to be placed\
+        \ outside of parentheses."
+      docLink: "https://docs.openrewrite.org/reference/recipes/groovy/format/omitparenthesesforlastargumentlambda"
+      options: []
+    org.openrewrite.groovy.format.OmitParenthesesFormat:
+      name: "org.openrewrite.groovy.format.OmitParenthesesFormat"
+      description: "Format tabs and indents in Java code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/groovy/format/omitparenthesesformat"
+      options: []
+rewrite-hcl:
+  artifactId: "rewrite-hcl"
+  version: "7.33.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.migrate.AddJDeprScanPlugin"
-    description: "JDeprScan scans class files for uses of deprecated APIs."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/addjdeprscanplugin"
-    options:
-    - name: "release"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.migrate.AddSuppressionForIllegalReflectionWarningsPlugin"
-    description: "Adds a maven jar plugin that's configured to suppress Illegal Reflection\
-      \ Warnings."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/addsuppressionforillegalreflectionwarningsplugin"
-    options:
-    - name: "version"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.migrate.ChangeJavaxAnnotationToJakarta"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation. Excludes `javax.annotation.processing`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/changejavaxannotationtojakarta"
-    options: []
-  - name: "org.openrewrite.java.migrate.Java8toJava11"
-    description: "This recipe will apply changes commonly needed when migrating from\
-      \ Java 8 to Java 11."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/java8tojava11"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaVersion11"
-    description: "Change maven.compiler.source and maven.compiler.target values to\
-      \ 11."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaversion11"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaVersion17"
-    description: "Change maven.compiler.source and maven.compiler.target values to\
-      \ 17."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaversion17"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxActivationMigrationToJakartaActivation"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxactivationmigrationtojakartaactivation"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxAnnotationMigrationToJakartaAnnotation"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxannotationmigrationtojakartaannotation"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxAnnotationPackageToJakarta"
-    description: "Change type of classes in the `javax.annotation` package to jakarta."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxannotationpackagetojakarta"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxAnnotationSecurityPackageToJakarta"
-    description: "Change type of classes in the `javax.annotation.security` package\
-      \ to jakarta."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxannotationsecuritypackagetojakarta"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxAnnotationSqlPackageToJakarta"
-    description: "Change type of classes in the `javax.annotation.sql` package to\
-      \ jakarta."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxannotationsqlpackagetojakarta"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxBatchMigrationToJakartaBatch"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxbatchmigrationtojakartabatch"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxDecoratorToJakartaDecorator"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxdecoratortojakartadecorator"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxEjbToJakartaEjb"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxejbtojakartaejb"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxElToJakartaEl"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxeltojakartael"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxEnterpriseToJakartaEnterprise"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxenterprisetojakartaenterprise"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxFacesToJakartaFaces"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxfacestojakartafaces"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxInjectMigrationToJakartaInject"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxinjectmigrationtojakartainject"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxInterceptorToJakartaInterceptor"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxinterceptortojakartainterceptor"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxJmsToJakartaJms"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxjmstojakartajms"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxJsonToJakartaJson"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxjsontojakartajson"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxJwsToJakartaJws"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxjwstojakartajws"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxMailToJakartaMail"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxmailtojakartamail"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxMigrationToJakarta"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxmigrationtojakarta"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxPeristenceXmlToJakartaPersistenceXml"
-    description: ""
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxperistencexmltojakartapersistencexml"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxPersistenceToJakartaPersistence"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxpersistencetojakartapersistence"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxResourceToJakartaResource"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxresourcetojakartaresource"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxSecurityToJakartaSecurity"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxsecuritytojakartasecurity"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxServletToJakartaServlet"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxservlettojakartaservlet"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxTransactionMigrationToJakartaTransaction"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxtransactionmigrationtojakartatransaction"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxValidationMigrationToJakartaValidation"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxvalidationmigrationtojakartavalidation"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxWebsocketToJakartaWebsocket"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxwebsockettojakartawebsocket"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxWsToJakartaWs"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxwstojakartaws"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxXmlBindMigrationToJakartaXmlBind"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxxmlbindmigrationtojakartaxmlbind"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxXmlSoapToJakartaXmlSoap"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxxmlsoaptojakartaxmlsoap"
-    options: []
-  - name: "org.openrewrite.java.migrate.JavaxXmlWsMigrationToJakartaXmlWs"
-    description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
-      \ relocation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaxxmlwsmigrationtojakartaxmlws"
-    options: []
-  - name: "org.openrewrite.java.migrate.UpgradeJava17"
-    description: "This recipe will apply changes commonly needed when migrating to\
-      \ Java 17, including intermediate versions."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/upgradejava17"
-    options: []
-  - name: "org.openrewrite.java.migrate.UseJavaUtilBase64"
-    description: "The `sun.misc` package became is not intended for use beyond Java\
-      \ 9. `java.util.Base64` was introduced in Java 8 for general use."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/usejavautilbase64"
-    options: []
-  - name: "org.openrewrite.java.migrate.apache.commons.codec.ApacheBase64ToJavaBase64"
-    description: "Migrate `apache.commons.codec.binary.Base64#encodeBase64` to `java.util.Base64.Encoder#encodeBase64`,\
-      \ `apache.commons.codec.binary.Base64#encodeBase64String` to `java.util.Base64.Encoder#encodeToString`,\
-      \ and `apache.commons.codec.binary.Base64#decodeBase64` to `java.util.Base64.Decoder#decode`"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/codec/apachebase64tojavabase64"
-    options: []
-  - name: "org.openrewrite.java.migrate.apache.commons.io.ApacheFileUtilsToJavaFiles"
-    description: "Migrate `apache.commons.io.FileUtils` to `java.nio.file.Files`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/apachefileutilstojavafiles"
-    options: []
-  - name: "org.openrewrite.java.migrate.apache.commons.io.ApacheIOUtilsUseExplicitCharset"
-    description: "This convert deprecated `IOUtils` method invocations with their\
-      \ charset specific equivalent, e.g. converts `IOUtils.readLines(inputStream);`\
-      \ to `IOUtils.readLines(inputStream, StandardCharsets.UTF_8);`"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/apacheioutilsuseexplicitcharset"
-    options:
-    - name: "encoding"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.migrate.apache.commons.io.RelocateApacheCommonsIo"
-    description: "The deployment of `org.apache.commons:commons-io` [was a publishing\
-      \ mistake around 2012](https://issues.sonatype.org/browse/MVNCENTRAL-244) which\
-      \ was corrected by changing the deployment GAV to be located under `commons-io:commons-io`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/relocateapachecommonsio"
-    options: []
-  - name: "org.openrewrite.java.migrate.apache.commons.io.UseStandardCharsets"
-    description: "Migrate `org.apache.commons.io.Charsets` to `java.nio.charset.StandardCharsets`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/usestandardcharsets"
-    options: []
-  - name: "org.openrewrite.java.migrate.apache.commons.io.UseSystemLineSeparator"
-    description: "Migrate `IOUtils.LINE_SEPARATOR` to `System.lineSeparator()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/usesystemlineseparator"
-    options: []
-  - name: "org.openrewrite.java.migrate.cobertura.RemoveCoberturaMavenPlugin"
-    description: "This recipe will remove Cobertura, as it is not compatible with\
-      \ Java 11."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/cobertura/removecoberturamavenplugin"
-    options: []
-  - name: "org.openrewrite.java.migrate.concurrent.JavaConcurrentAPIs"
-    description: "Certain Java concurrent APIs have become deprecated and their usages\
-      \ changed, necessitating usage changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/javaconcurrentapis"
-    options: []
-  - name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicBooleanWeakCompareAndSetToWeakCompareAndSetPlain"
-    description: "`AtomicBoolean#weakCompareAndSet(boolean, boolean)` was deprecated\
-      \ in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicbooleanweakcompareandsettoweakcompareandsetplain"
-    options: []
-  - name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicIntegerArrayWeakCompareAndSetToWeakCompareAndSetPlain"
-    description: "`AtomicIntegerArray#weakCompareAndSet(int, int, int)` was deprecated\
-      \ in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicintegerarrayweakcompareandsettoweakcompareandsetplain"
-    options: []
-  - name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicIntegerWeakCompareAndSetToWeakCompareAndSetPlain"
-    description: "`AtomicInteger#weakCompareAndSet(int, int)` was deprecated in Java\
-      \ 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicintegerweakcompareandsettoweakcompareandsetplain"
-    options: []
-  - name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicLongArrayWeakCompareAndSetToWeakCompareAndSetPlain"
-    description: "`AtomicLongArray#weakCompareAndSet(int, long, long)` was deprecated\
-      \ in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomiclongarrayweakcompareandsettoweakcompareandsetplain"
-    options: []
-  - name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicLongWeakCompareAndSetToWeakCompareAndSetPlain"
-    description: "`AtomicLong#weakCompareAndSet(long, long)` was deprecated in Java\
-      \ 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomiclongweakcompareandsettoweakcompareandsetplain"
-    options: []
-  - name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicReferenceArrayWeakCompareAndSetToWeakCompareAndSetPlain"
-    description: "`AtomicReferenceArray#weakCompareAndSet(int, T, T)` was deprecated\
-      \ in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicreferencearrayweakcompareandsettoweakcompareandsetplain"
-    options: []
-  - name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicReferenceWeakCompareAndSetToWeakCompareAndSetPlain"
-    description: "`AtomicReference#weakCompareAndSet(T, T)` was deprecated in Java\
-      \ 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicreferenceweakcompareandsettoweakcompareandsetplain"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuava"
-    description: "Guava filled in important gaps in the Java standard library and\
-      \ still does. But at least some of Guava's API surface area is covered by the\
-      \ Java standard library now, and some projects may be able to remove Guava altogether\
-      \ if they migrate to standard library for these functions."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguava"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaAtomicsNewReference"
-    description: "Prefer the Java standard library over third-party usage of Guava\
-      \ in simple cases like this."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavaatomicsnewreference"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaCreateTempDir"
-    description: "Replaces Guava `Files#createTempDir()` with Java `Files#createTempDirectory(..)`.\
-      \ Transformations are limited to scopes throwing or catching `java.io.IOException`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavacreatetempdir"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaDirectExecutor"
-    description: "`Executor` is a SAM-compatible interface, so `Runnable::run` is\
-      \ just as succinct as `MoreExecutors.directExecutor()` but without the third-party\
-      \ library requirement."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavadirectexecutor"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaImmutableListOf"
-    description: "Replaces `ImmutableList.of(..)` if the returned type is immediately\
-      \ down-cast."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavaimmutablelistof"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaImmutableMapOf"
-    description: "Replaces `ImmutableMap.of(..)` if the returned type is immediately\
-      \ down-cast."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavaimmutablemapof"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaImmutableSetOf"
-    description: "Replaces `ImmutableSet.of(..)` if the returned type is immediately\
-      \ down-cast.\n  Java 9 introduced `List#of(..)`, `Map#of(..)`, `Set#of(..)`\
-      \ which is similar to `ImmutableList#of(..)`, `ImmutableMap#of(..)`, `ImmutableSet#of(..)`,\
-      \ but has a subtle difference.\n  As per the Java 9 documentation, [`Set.of`\
-      \ provides an unspecified iteration order on the set of elements and is subject\
-      \ to change](https://docs.oracle.com/javase/9/docs/api/java/util/Set.html),\
-      \ whereas [Guava `ImmutableSet` preserves the order from construction time](https://github.com/google/guava/wiki/ImmutableCollectionsExplained#how).\n\
-      \  This is worth pointing out in case your usage calls for iteration order being\
-      \ important."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavaimmutablesetof"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaListsNewArrayList"
-    description: "Prefer the Java standard library over third-party usage of Guava\
-      \ in simple cases like this."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavalistsnewarraylist"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaListsNewCopyOnWriteArrayList"
-    description: "Prefer the Java standard library over third-party usage of Guava\
-      \ in simple cases like this."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavalistsnewcopyonwritearraylist"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaListsNewLinkedList"
-    description: "Prefer the Java standard library over third-party usage of Guava\
-      \ in simple cases like this."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavalistsnewlinkedlist"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaMapsNewLinkedHashMap"
-    description: "Prefer the Java standard library over third-party usage of Guava\
-      \ in simple cases like this."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavamapsnewlinkedhashmap"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaSetsNewConcurrentHashSet"
-    description: "Prefer the Java standard library over third-party usage of Guava\
-      \ in simple cases like this."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavasetsnewconcurrenthashset"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaSetsNewHashSet"
-    description: "Prefer the Java standard library over third-party usage of Guava\
-      \ in simple cases like this."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavasetsnewhashset"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.NoGuavaSetsNewLinkedHashSet"
-    description: "Prefer the Java standard library over third-party usage of Guava\
-      \ in simple cases like this."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavasetsnewlinkedhashset"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferCharCompare"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefercharcompare"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferIntegerCompare"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegercompare"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferIntegerCompareUnsigned"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegercompareunsigned"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferIntegerDivideUnsigned"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegerdivideunsigned"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferIntegerParseUnsignedInt"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegerparseunsignedint"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferIntegerRemainderUnsigned"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegerremainderunsigned"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsSynchronizedNavigableMap"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilcollectionssynchronizednavigablemap"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsUnmodifiableNavigableMap"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilcollectionsunmodifiablenavigablemap"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferJavaUtilFunction"
-    description: "Guava's `Function` extends `java.util.function.Function`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilfunction"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsEquals"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilobjectsequals"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsHashCode"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilobjectshashcode"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferJavaUtilPredicate"
-    description: "Guava's `Predicate` extends `java.util.function.Predicate`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilpredicate"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferJavaUtilSupplier"
-    description: "Guava's `Supplier` extends `java.util.function.Supplier`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilsupplier"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferLongCompare"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongcompare"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferLongCompareUnsigned"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongcompareunsigned"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferLongDivideUnsigned"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongdivideunsigned"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferLongParseUnsignedLong"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongparseunsignedlong"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferLongRemainderUnsigned"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongremainderunsigned"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferMathAddExact"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefermathaddexact"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferMathMultiplyExact"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefermathmultiplyexact"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferMathSubtractExact"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefermathsubtractexact"
-    options: []
-  - name: "org.openrewrite.java.migrate.guava.PreferShortCompare"
-    description: "This method exists in the Java standard library now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefershortcompare"
-    options: []
-  - name: "org.openrewrite.java.migrate.jacoco.UpgradeJaCoCoMavenPluginVersion"
-    description: "This recipe will upgrade the JaCoCo Maven plugin to a more recent\
-      \ version compatible with Java 11."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jacoco/upgradejacocomavenpluginversion"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.AddInjectDependencies"
-    description: "This recipe will add the necessary Inject dependencies for those\
-      \ projects migrating to Java 11."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addinjectdependencies"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.AddJaxbDependencies"
-    description: "This recipe will add the necessary JAXB dependencies for those projects\
-      \ migrating to Java 11."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addjaxbdependencies"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.AddJaxbRuntime"
-    description: "This recipe will add a JAXB run-time dependency to any maven project\
-      \ that has a transitive dependency on JAXB."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addjaxbruntime"
-    options:
-    - name: "runtime"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.migrate.javax.AddJaxwsDependencies"
-    description: "This recipe will add the necessary JAX-WS dependencies for those\
-      \ projects migrating to Java 11."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addjaxwsdependencies"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.AddJaxwsRuntime"
-    description: "This recipe will add a JAX-WS run-time dependency to any maven project\
-      \ that has a transitive dependency on JAX-WS APIs."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addjaxwsruntime"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.JavaxLangModelUtil"
-    description: "Certain `javax.lang.model.util` APIs have become deprecated and\
-      \ their usages changed, necessitating usage changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/javaxlangmodelutil"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.JavaxManagementMonitorAPIs"
-    description: "Certain `javax.management.monitor` APIs have become deprecated and\
-      \ their usages changed, necessitating usage changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/javaxmanagementmonitorapis"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.JavaxXmlStreamAPIs"
-    description: "Certain `javax.xml.stream` APIs have become deprecated and their\
-      \ usages changed, necessitating usage changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/javaxxmlstreamapis"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateAbstractAnnotationValueVisitor6To9"
-    description: "`AbstractAnnotationValueVisitor6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateabstractannotationvaluevisitor6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateAbstractElementVisitor6To9"
-    description: "`AbstractElementVisitor6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateabstractelementvisitor6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateAbstractTypeVisitor6To9"
-    description: "`AbstractTypeVisitor6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateabstracttypevisitor6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateCounterMonitorSetThreshholdToSetInitThreshold"
-    description: "`CounterMonitor#setThreshhold` has been deprecated in JMX 1.2."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratecountermonitorsetthreshholdtosetinitthreshold"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateElementKindVisitor6To9"
-    description: "`ElementKindVisitor6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateelementkindvisitor6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateElementScanner6To9"
-    description: "`ElementScanner6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateelementscanner6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateSimpleAnnotationValueVisitor6To9"
-    description: "`SimpleAnnotationValueVisitor6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratesimpleannotationvaluevisitor6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateSimpleElementVisitor6To9"
-    description: "`SimpleElementVisitor6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratesimpleelementvisitor6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateSimpleTypeVisitor6To9"
-    description: "`SimpleTypeVisitor6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratesimpletypevisitor6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateTypeKindVisitor6To9"
-    description: "`TypeKindVisitor6` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratetypekindvisitor6to9"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateXMLEventFactoryNewInstanceToNewFactory"
-    description: "`javax.xml.stream.XMLEventFactory#newInstance` has been deprecated\
-      \ in Java 7."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratexmleventfactorynewinstancetonewfactory"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateXMLInputFactoryNewInstanceToNewFactory"
-    description: "`javax.xml.stream.XMLInputFactory#newInstance` has been deprecated\
-      \ Java 7."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratexmlinputfactorynewinstancetonewfactory"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.MigrateXMLOutputFactoryNewInstanceToNewFactory"
-    description: "`javax.xml.stream.XMLOutputFactory#newInstance` has been deprecated\
-      \ Java 7."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratexmloutputfactorynewinstancetonewfactory"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.ReplaceJavaxJaxbWithJakarta"
-    description: "This recipe will replace the legacy `javax-api` artifact with the\
-      \ Jakarta EE equivalent."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/replacejavaxjaxbwithjakarta"
-    options: []
-  - name: "org.openrewrite.java.migrate.javax.ReplaceJavaxJaxwsWithJakarta"
-    description: "This recipe will replace the legacy javax `jaxws-api` artifact with\
-      \ the Jakarta EE equivalent. The jakarta JAX-WS API 2.3.x is part of JakartaEE\
-      \ 8 and still uses `javax` packaging."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/replacejavaxjaxwswithjakarta"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.JavaLangAPIs"
-    description: "Certain Java lang APIs have become deprecated and their usages changed,\
-      \ necessitating usage changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/javalangapis"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterOrDigitToIsJavaIdentifierPart"
-    description: "`Character#isJavaLetterOrDigit(char)` was deprecated in Java 1.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migratecharacterisjavaletterordigittoisjavaidentifierpart"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterToIsJavaIdentifierStart"
-    description: "`Character#isJavaLetter(char)` was deprecated in Java 1.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migratecharacterisjavalettertoisjavaidentifierstart"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateCharacterIsSpaceToIsWhitespace"
-    description: "`Character#isSpace(char)` was deprecated in Java 1.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migratecharacterisspacetoiswhitespace"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateClassLoaderDefineClass"
-    description: "`ClassLoader#defineClass(byte[], int, int)` was deprecated in Java\
-      \ 1.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateclassloaderdefineclass"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateClassNewInstanceToGetDeclaredConstructorNewInstance"
-    description: "`Class#newInstance()` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateclassnewinstancetogetdeclaredconstructornewinstance"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateRuntimeVersionMajorToFeature"
-    description: "`Runtime.Version#major()` was deprecated in Java 10."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateruntimeversionmajortofeature"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateRuntimeVersionMinorToInterim"
-    description: "`Runtime.Version#minor()` was deprecated in Java 10."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateruntimeversionminortointerim"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateRuntimeVersionSecurityToUpdate"
-    description: "`Runtime.Version#security()` was deprecated in Java 10."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateruntimeversionsecuritytoupdate"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.MigrateSecurityManagerMulticast"
-    description: "`SecurityManager#checkMulticast(InetAddress, byte)` was deprecated\
-      \ in Java 1.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migratesecuritymanagermulticast"
-    options: []
-  - name: "org.openrewrite.java.migrate.lang.StringFormatted"
-    description: "Call `String#formatted(Object...)` on first argument to `String#format(String,\
-      \ Object...)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/stringformatted"
-    options: []
-  - name: "org.openrewrite.java.migrate.logging.JavaLoggingAPIs"
-    description: "Certain Java logging APIs have become deprecated and their usages\
-      \ changed, necessitating usage changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/javaloggingapis"
-    options: []
-  - name: "org.openrewrite.java.migrate.logging.MigrateGetLoggingMXBeanToGetPlatformMXBean"
-    description: "`LogManager#getLoggingMXBean()` was deprecated in Java 9."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migrategetloggingmxbeantogetplatformmxbean"
-    options: []
-  - name: "org.openrewrite.java.migrate.logging.MigrateInterfaceLoggingMXBeanToPlatformLoggingMXBean"
-    description: "`java.util.logging.LoggingMXBean` has been deprecated."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migrateinterfaceloggingmxbeantoplatformloggingmxbean"
-    options: []
-  - name: "org.openrewrite.java.migrate.logging.MigrateLogRecordSetMillisToSetInstant"
-    description: "`LogRecord#setMillis(long)` has been deprecated."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migratelogrecordsetmillistosetinstant"
-    options: []
-  - name: "org.openrewrite.java.migrate.logging.MigrateLoggerGlobalToGetGlobal"
-    description: "The preferred way to get the global logger object is via the call\
-      \ `Logger#getGlobal()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migrateloggerglobaltogetglobal"
-    options: []
-  - name: "org.openrewrite.java.migrate.logging.MigrateLoggerLogrbToUseResourceBundle"
-    description: "`java.util.logging.Logger#logrb(.., String bundleName, ..)` has\
-      \ been deprecated."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migrateloggerlogrbtouseresourcebundle"
-    options: []
-  - name: "org.openrewrite.java.migrate.lombok.LombokValToFinalVar"
-    description: "Replace `lombok.val` with `final var` on projects using Java 11\
-      \ or higher."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lombok/lombokvaltofinalvar"
-    options: []
-  - name: "org.openrewrite.java.migrate.metrics.SimplifyMicrometerMeterTags"
-    description: "Use the simplest method to add new tags."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/metrics/simplifymicrometermetertags"
-    options: []
-  - name: "org.openrewrite.java.migrate.net.JavaNetAPIs"
-    description: "Certain Java networking APIs have become deprecated and their usages\
-      \ changed, necessitating usage changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/javanetapis"
-    options: []
-  - name: "org.openrewrite.java.migrate.net.MigrateHttpURLConnectionHttpServerErrorToHttpInternalError"
-    description: "`java.net.HttpURLConnection.HTTP_SERVER_ERROR` has been deprecated."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migratehttpurlconnectionhttpservererrortohttpinternalerror"
-    options: []
-  - name: "org.openrewrite.java.migrate.net.MigrateMulticastSocketGetTTLToGetTimeToLive"
-    description: "`java.net.MulticastSocket#getTTL()` has been deprecated."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migratemulticastsocketgetttltogettimetolive"
-    options: []
-  - name: "org.openrewrite.java.migrate.net.MigrateMulticastSocketSetTTLToSetTimeToLive"
-    description: "`java.net.MulticastSocket#setTTL(byte)` has been deprecated."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migratemulticastsocketsetttltosettimetolive"
-    options: []
-  - name: "org.openrewrite.java.migrate.net.MigrateURLDecoderDecode"
-    description: "`java.net.URLDecoder#decode(String)` is platform-dependent. It's\
-      \ advised to specify an encoding."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migrateurldecoderdecode"
-    options: []
-  - name: "org.openrewrite.java.migrate.net.MigrateURLEncoderEncode"
-    description: "`java.net.URLEncoder#encode(String)` is platform-dependent. It's\
-      \ advised to specify an encoding."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migrateurlencoderencode"
-    options: []
-  - name: "org.openrewrite.java.migrate.search.AboutJavaVersion"
-    description: "A diagnostic for studying the applicability of Java version constraints."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/search/aboutjavaversion"
-    options:
-    - name: "whenUsesType"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.migrate.sql.JavaSqlAPIs"
-    description: "Certain Java sql APIs have become deprecated and their usages changed,\
-      \ necessitating usage changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/sql/javasqlapis"
-    options: []
-  - name: "org.openrewrite.java.migrate.sql.MigrateDriverManagerSetLogStream"
-    description: "`DriverManager#setLogStream(java.io.PrintStream)` was deprecated\
-      \ in Java 1.2."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/sql/migratedrivermanagersetlogstream"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.JavaUtilAPIs"
-    description: "Certain java util APIs have been introduced and are favored over\
-      \ previous APIs."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/javautilapis"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.MigrateCollectionsSingletonList"
-    description: "Replaces `Collections.singletonList(<args>)))` with `List.Of(<args>)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionssingletonlist"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.MigrateCollectionsSingletonMap"
-    description: "Replaces `Collections.singletonMap(<args>)))` with `Map.Of(<args>)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionssingletonmap"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.MigrateCollectionsSingletonSet"
-    description: "Replaces `Collections.singleton(<args>)))` with `Set.Of(<args>)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionssingletonset"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.MigrateCollectionsUnmodifiableList"
-    description: "Replaces `unmodifiableList(java.util.Arrays asList(<args>))` with\
-      \ `List.Of(<args>)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionsunmodifiablelist"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.MigrateCollectionsUnmodifiableSet"
-    description: "Replaces `unmodifiableSet(java.util.Set(java.util.Arrays asList(<args>)))`\
-      \ with `Set.Of(<args>)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionsunmodifiableset"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.OptionalNotEmptyToIsPresent"
-    description: "Replace negated Optional.isEmpty() calls with Optional.isPresent()\
-      \ in Java 11 and above."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/optionalnotemptytoispresent"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.OptionalNotPresentToIsEmpty"
-    description: "Replace negated Optional.isPresent() calls with Optional.isEmpty()\
-      \ in Java 11 and above."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/optionalnotpresenttoisempty"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.UseEnumSetOf"
-    description: "Replaces `Set of(..)` with `EnumSet of(..)` if the arguments are\
-      \ enums."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/useenumsetof"
-    options: []
-  - name: "org.openrewrite.java.migrate.util.UseMapOf"
-    description: "This succinct syntax was introduced in Java 10."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/usemapof"
-    options: []
-  - name: "org.openrewrite.java.migrate.wro4j.UpgradeWro4jMavenPluginVersion"
-    description: "This recipe will upgrade Wro4j to a more recent version compatible\
-      \ with Java 11."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/wro4j/upgradewro4jmavenpluginversion"
-    options: []
-- artifactId: "rewrite-properties"
-  version: "7.32.1"
+    org.openrewrite.hcl.DeleteContent:
+      name: "org.openrewrite.hcl.DeleteContent"
+      description: "Delete HCL content by path."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/deletecontent"
+      options:
+      - name: "contentPath"
+        type: "String"
+        required: true
+    org.openrewrite.hcl.MoveContentToFile:
+      name: "org.openrewrite.hcl.MoveContentToFile"
+      description: "Move content to another HCL file, deleting it in the original\
+        \ file."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/movecontenttofile"
+      options:
+      - name: "contentPath"
+        type: "String"
+        required: true
+      - name: "destinationPath"
+        type: "String"
+        required: true
+      - name: "fromPath"
+        type: "String"
+        required: true
+    org.openrewrite.hcl.format.AutoFormat:
+      name: "org.openrewrite.hcl.format.AutoFormat"
+      description: "Format HCL code using a standard comprehensive set of HCL formatting\
+        \ recipes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/autoformat"
+      options: []
+    org.openrewrite.hcl.format.BlankLines:
+      name: "org.openrewrite.hcl.format.BlankLines"
+      description: "Add and/or remove blank lines."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/blanklines"
+      options: []
+    org.openrewrite.hcl.format.NormalizeFormat:
+      name: "org.openrewrite.hcl.format.NormalizeFormat"
+      description: "Move whitespace to the outermost AST element possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/normalizeformat"
+      options: []
+    org.openrewrite.hcl.format.RemoveTrailingWhitespace:
+      name: "org.openrewrite.hcl.format.RemoveTrailingWhitespace"
+      description: "Remove any extra trailing whitespace from the end of each line."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/removetrailingwhitespace"
+      options: []
+    org.openrewrite.hcl.format.Spaces:
+      name: "org.openrewrite.hcl.format.Spaces"
+      description: "Format whitespace in HCL code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/spaces"
+      options: []
+    org.openrewrite.hcl.format.TabsAndIndents:
+      name: "org.openrewrite.hcl.format.TabsAndIndents"
+      description: "Format tabs and indents in HCL code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/format/tabsandindents"
+      options: []
+    org.openrewrite.hcl.search.FindContent:
+      name: "org.openrewrite.hcl.search.FindContent"
+      description: "Find HCL content by path."
+      docLink: "https://docs.openrewrite.org/reference/recipes/hcl/search/findcontent"
+      options:
+      - name: "contentPath"
+        type: "String"
+        required: true
+rewrite-java:
+  artifactId: "rewrite-java"
+  version: "7.33.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.properties.AddProperty"
-    description: "Adds a new property to a property file at the bottom of the file\
-      \ if it's missing. Whitespace before and after the `=` must be included in the\
-      \ property and value."
-    docLink: "https://docs.openrewrite.org/reference/recipes/properties/addproperty"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "property"
-      type: "String"
-      required: true
-    - name: "value"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.properties.ChangePropertyKey"
-    description: "Change a property key leaving the value intact."
-    docLink: "https://docs.openrewrite.org/reference/recipes/properties/changepropertykey"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newPropertyKey"
-      type: "String"
-      required: true
-    - name: "oldPropertyKey"
-      type: "String"
-      required: true
-    - name: "relaxedBinding"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.properties.ChangePropertyValue"
-    description: "Change a property value leaving the key intact."
-    docLink: "https://docs.openrewrite.org/reference/recipes/properties/changepropertyvalue"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newValue"
-      type: "String"
-      required: true
-    - name: "oldValue"
-      type: "String"
-      required: false
-    - name: "propertyKey"
-      type: "String"
-      required: true
-    - name: "relaxedBinding"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.properties.DeleteProperty"
-    description: "Deletes key/value pairs from properties files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/properties/deleteproperty"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "propertyKey"
-      type: "String"
-      required: true
-    - name: "relaxedBinding"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.properties.search.FindProperties"
-    description: "Finds occurrences of a property key."
-    docLink: "https://docs.openrewrite.org/reference/recipes/properties/search/findproperties"
-    options:
-    - name: "propertyKey"
-      type: "String"
-      required: true
-    - name: "relaxedBinding"
-      type: "Boolean"
-      required: false
-- artifactId: "rewrite-quarkus"
-  version: "1.13.0"
+    org.openrewrite.java.AddApache2LicenseHeader:
+      name: "org.openrewrite.java.AddApache2LicenseHeader"
+      description: "Adds the Apache Software License Version 2.0 to Java source files\
+        \ which are missing a license header."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/addapache2licenseheader"
+      options: []
+    org.openrewrite.java.AddLicenseHeader:
+      name: "org.openrewrite.java.AddLicenseHeader"
+      description: "Adds license headers to Java source files when missing. Does not\
+        \ override existing license headers."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/addlicenseheader"
+      options:
+      - name: "licenseText"
+        type: "String"
+        required: true
+    org.openrewrite.java.AddOrUpdateAnnotationAttribute:
+      name: "org.openrewrite.java.AddOrUpdateAnnotationAttribute"
+      description: "Some annotations accept arguments. This recipe sets an existing\
+        \ argument to the specified value, or adds the argument if it is not already\
+        \ set."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/addorupdateannotationattribute"
+      options:
+      - name: "addOnly"
+        type: "Boolean"
+        required: true
+      - name: "annotationType"
+        type: "String"
+        required: true
+      - name: "attributeName"
+        type: "String"
+        required: false
+      - name: "attributeValue"
+        type: "String"
+        required: true
+    org.openrewrite.java.ChangeMethodAccessLevel:
+      name: "org.openrewrite.java.ChangeMethodAccessLevel"
+      description: "Change the access level (public, protected, private, package private)\
+        \ of a method."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/changemethodaccesslevel"
+      options:
+      - name: "matchOverrides"
+        type: "Boolean"
+        required: false
+      - name: "methodPattern"
+        type: "String"
+        required: true
+      - name: "newAccessLevel"
+        type: "String"
+        required: true
+    org.openrewrite.java.ChangeMethodName:
+      name: "org.openrewrite.java.ChangeMethodName"
+      description: "Rename a method."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/changemethodname"
+      options:
+      - name: "ignoreDefinition"
+        type: "Boolean"
+        required: false
+      - name: "matchOverrides"
+        type: "Boolean"
+        required: false
+      - name: "methodPattern"
+        type: "String"
+        required: true
+      - name: "newMethodName"
+        type: "String"
+        required: true
+    org.openrewrite.java.ChangeMethodTargetToStatic:
+      name: "org.openrewrite.java.ChangeMethodTargetToStatic"
+      description: "Change method invocations to static method calls."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/changemethodtargettostatic"
+      options:
+      - name: "fullyQualifiedTargetTypeName"
+        type: "String"
+        required: true
+      - name: "matchOverrides"
+        type: "Boolean"
+        required: false
+      - name: "matchUnknownTypes"
+        type: "Boolean"
+        required: false
+      - name: "methodPattern"
+        type: "String"
+        required: true
+      - name: "returnType"
+        type: "String"
+        required: false
+    org.openrewrite.java.ChangeMethodTargetToVariable:
+      name: "org.openrewrite.java.ChangeMethodTargetToVariable"
+      description: "Change method invocations to method calls on a variable."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/changemethodtargettovariable"
+      options:
+      - name: "matchOverrides"
+        type: "Boolean"
+        required: false
+      - name: "methodPattern"
+        type: "String"
+        required: true
+      - name: "variableName"
+        type: "String"
+        required: true
+      - name: "variableType"
+        type: "String"
+        required: true
+    org.openrewrite.java.ChangePackage:
+      name: "org.openrewrite.java.ChangePackage"
+      description: "A recipe that will rename a package name in package statements,\
+        \ imports, and fully-qualified types."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/changepackage"
+      options:
+      - name: "newPackageName"
+        type: "String"
+        required: true
+      - name: "oldPackageName"
+        type: "String"
+        required: true
+      - name: "recursive"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.ChangeStaticFieldToMethod:
+      name: "org.openrewrite.java.ChangeStaticFieldToMethod"
+      description: "Migrate accesses to a static field to invocations of a static\
+        \ method."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/changestaticfieldtomethod"
+      options:
+      - name: "newClassName"
+        type: "String"
+        required: false
+      - name: "newMethodName"
+        type: "String"
+        required: true
+      - name: "newTarget"
+        type: "String"
+        required: false
+      - name: "oldClassName"
+        type: "String"
+        required: true
+      - name: "oldFieldName"
+        type: "String"
+        required: true
+    org.openrewrite.java.ChangeType:
+      name: "org.openrewrite.java.ChangeType"
+      description: "Change a given type to another."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/changetype"
+      options:
+      - name: "ignoreDefinition"
+        type: "Boolean"
+        required: false
+      - name: "newFullyQualifiedTypeName"
+        type: "String"
+        required: true
+      - name: "oldFullyQualifiedTypeName"
+        type: "String"
+        required: true
+    org.openrewrite.java.DeleteMethodArgument:
+      name: "org.openrewrite.java.DeleteMethodArgument"
+      description: "Delete an argument from method invocations."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/deletemethodargument"
+      options:
+      - name: "argumentIndex"
+        type: "int"
+        required: true
+      - name: "methodPattern"
+        type: "String"
+        required: true
+    org.openrewrite.java.DoesNotUseRewriteSkip:
+      name: "org.openrewrite.java.DoesNotUseRewriteSkip"
+      description: "The annotation provides a mechanism to skip a whole source file\
+        \ from consideration"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/doesnotuserewriteskip"
+      options: []
+    org.openrewrite.java.NoStaticImport:
+      name: "org.openrewrite.java.NoStaticImport"
+      description: "Removes static imports and replaces them with qualified references.\
+        \ For example, `emptyList()` becomes `Collections.emptyList()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/nostaticimport"
+      options:
+      - name: "methodPattern"
+        type: "String"
+        required: true
+    org.openrewrite.java.OrderImports:
+      name: "org.openrewrite.java.OrderImports"
+      description: "Group and order imports."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/orderimports"
+      options:
+      - name: "removeUnused"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.RandomizeId:
+      name: "org.openrewrite.java.RandomizeId"
+      description: "Scramble the IDs. This was intended as a utility to test _en masse_\
+        \ different techniques for UUID generation and compare their relative performance\
+        \ outside of a microbenchmark."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/randomizeid"
+      options: []
+    org.openrewrite.java.RecipeExceptionDemonstration:
+      name: "org.openrewrite.java.RecipeExceptionDemonstration"
+      description: "Show how recipe exceptions are rendered in various forms of OpenRewrite\
+        \ tooling."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/recipeexceptiondemonstration"
+      options:
+      - name: "throwOnApplicableTest"
+        type: "Boolean"
+        required: false
+      - name: "throwOnApplicableTestVisitor"
+        type: "Boolean"
+        required: false
+      - name: "throwOnMethodPattern"
+        type: "String"
+        required: false
+      - name: "throwOnSingleSourceApplicableTest"
+        type: "Boolean"
+        required: false
+      - name: "throwOnSingleSourceApplicableTestVisitor"
+        type: "Boolean"
+        required: false
+      - name: "throwOnVisitAll"
+        type: "Boolean"
+        required: false
+      - name: "throwOnVisitAllVisitor"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.RecipeMarkupDemonstration:
+      name: "org.openrewrite.java.RecipeMarkupDemonstration"
+      description: "Tooling may decide to elide or display differently markup of different\
+        \ levels."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/recipemarkupdemonstration"
+      options:
+      - name: "level"
+        type: "String"
+        required: true
+    org.openrewrite.java.RemoveAnnotation:
+      name: "org.openrewrite.java.RemoveAnnotation"
+      description: "Remove matching annotations wherever they occur."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/removeannotation"
+      options:
+      - name: "annotationPattern"
+        type: "String"
+        required: true
+    org.openrewrite.java.RemoveImplements:
+      name: "org.openrewrite.java.RemoveImplements"
+      description: "Removes `implements` clauses from classes implementing the specified\
+        \ interface. Removes `@Overrides` annotations from methods which no longer\
+        \ override anything."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/removeimplements"
+      options:
+      - name: "filter"
+        type: "String"
+        required: true
+      - name: "interfaceType"
+        type: "String"
+        required: true
+    org.openrewrite.java.RemoveObjectsIsNull:
+      name: "org.openrewrite.java.RemoveObjectsIsNull"
+      description: "Replace calls to `Objects.isNull(..)` and `Objects.nonNull(..)`\
+        \ with a simple null check. Using these methods outside of stream predicates\
+        \ is not idiomatic."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/removeobjectsisnull"
+      options: []
+    org.openrewrite.java.RemoveUnusedImports:
+      name: "org.openrewrite.java.RemoveUnusedImports"
+      description: "Remove imports for types that are not referenced."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/removeunusedimports"
+      options: []
+    org.openrewrite.java.ReorderMethodArguments:
+      name: "org.openrewrite.java.ReorderMethodArguments"
+      description: "Reorder method arguments into the specified order."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/reordermethodarguments"
+      options:
+      - name: "ignoreDefinition"
+        type: "Boolean"
+        required: false
+      - name: "methodPattern"
+        type: "String"
+        required: true
+      - name: "newParameterNames"
+        type: "String[]"
+        required: true
+      - name: "oldParameterNames"
+        type: "String[]"
+        required: false
+    org.openrewrite.java.ReplaceConstant:
+      name: "org.openrewrite.java.ReplaceConstant"
+      description: "Replace a named constant with a literal value when you wish to\
+        \ remove the old constant."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/replaceconstant"
+      options:
+      - name: "constantName"
+        type: "String"
+        required: true
+      - name: "literalValue"
+        type: "String"
+        required: true
+      - name: "owningType"
+        type: "String"
+        required: true
+    org.openrewrite.java.SimplifyMethodChain:
+      name: "org.openrewrite.java.SimplifyMethodChain"
+      description: "Simplify `a.b().c()` to `a.d()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/simplifymethodchain"
+      options:
+      - name: "methodPatternChain"
+        type: "List"
+        required: true
+      - name: "newMethodName"
+        type: "String"
+        required: true
+    org.openrewrite.java.UpdateSourcePositions:
+      name: "org.openrewrite.java.UpdateSourcePositions"
+      description: "Calculate start position and length for every AST element."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/updatesourcepositions"
+      options: []
+    org.openrewrite.java.UseStaticImport:
+      name: "org.openrewrite.java.UseStaticImport"
+      description: "Removes unnecessary receiver types from static method invocations.\
+        \ For example, `Collections.emptyList()` becomes `emptyList()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/usestaticimport"
+      options:
+      - name: "methodPattern"
+        type: "String"
+        required: true
+    org.openrewrite.java.cleanup.AddSerialVersionUidToSerializable:
+      name: "org.openrewrite.java.cleanup.AddSerialVersionUidToSerializable"
+      description: "A `serialVersionUID` field is strongly recommended in all `Serializable`\
+        \ classes. If this is not defined on a `Serializable` class, the compiler\
+        \ will generate this value. If a change is later made to the class, the generated\
+        \ value will change and attempts to deserialize the class will fail."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/addserialversionuidtoserializable"
+      options: []
+    org.openrewrite.java.cleanup.AtomicPrimitiveEqualsUsesGet:
+      name: "org.openrewrite.java.cleanup.AtomicPrimitiveEqualsUsesGet"
+      description: "`AtomicBoolean#equals(Object)`, `AtomicInteger#equals(Object)`\
+        \ and `AtomicLong#equals(Object)` are only equal to their instance. This recipe\
+        \ converts `a.equals(b)` to `a.get() == b.get()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/atomicprimitiveequalsusesget"
+      options: []
+    org.openrewrite.java.cleanup.AvoidBoxedBooleanExpressions:
+      name: "org.openrewrite.java.cleanup.AvoidBoxedBooleanExpressions"
+      description: "Under certain conditions the `java.lang.Boolean` type is used\
+        \ as an expression, and it may throw a `NullPointerException` if the value\
+        \ is null."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/avoidboxedbooleanexpressions"
+      options: []
+    org.openrewrite.java.cleanup.BigDecimalRoundingConstantsToEnums:
+      name: "org.openrewrite.java.cleanup.BigDecimalRoundingConstantsToEnums"
+      description: "Convert `BigDecimal` rounding constants to the equivalent `RoundingMode`\
+        \ enum."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/bigdecimalroundingconstantstoenums"
+      options: []
+    org.openrewrite.java.cleanup.BooleanChecksNotInverted:
+      name: "org.openrewrite.java.cleanup.BooleanChecksNotInverted"
+      description: "It is needlessly complex to invert the result of a boolean comparison.\
+        \ The opposite comparison should be made instead."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/booleanchecksnotinverted"
+      options: []
+    org.openrewrite.java.cleanup.CaseInsensitiveComparisonsDoNotChangeCase:
+      name: "org.openrewrite.java.cleanup.CaseInsensitiveComparisonsDoNotChangeCase"
+      description: "Remove `String#toLowerCase()` or `String#toUpperCase()` from `String#equalsIgnoreCase(..)`\
+        \ comparisons."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/caseinsensitivecomparisonsdonotchangecase"
+      options: []
+    org.openrewrite.java.cleanup.CatchClauseOnlyRethrows:
+      name: "org.openrewrite.java.cleanup.CatchClauseOnlyRethrows"
+      description: "A `catch` clause that only rethrows the caught exception is unnecessary.\
+        \ Letting the exception bubble up as normal achieves the same result with\
+        \ less code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/catchclauseonlyrethrows"
+      options: []
+    org.openrewrite.java.cleanup.Cleanup:
+      name: "org.openrewrite.java.cleanup.Cleanup"
+      description: "Automatically cleanup code, e.g. remove unnecessary parentheses,\
+        \ simplify expressions."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/cleanup"
+      options: []
+    org.openrewrite.java.cleanup.CombineSemanticallyEqualCatchBlocks:
+      name: "org.openrewrite.java.cleanup.CombineSemanticallyEqualCatchBlocks"
+      description: "Combine catches in a try that contain semantically equivalent\
+        \ blocks. No change will be made when a caught exception exists if combing\
+        \ catches may change application behavior or type attribution is missing."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/combinesemanticallyequalcatchblocks"
+      options: []
+    org.openrewrite.java.cleanup.CommonStaticAnalysis:
+      name: "org.openrewrite.java.cleanup.CommonStaticAnalysis"
+      description: "Resolve common static analysis issues discovered through 3rd party\
+        \ tools."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/commonstaticanalysis"
+      options: []
+    org.openrewrite.java.cleanup.CompareEnumsWithEqualityOperator:
+      name: "org.openrewrite.java.cleanup.CompareEnumsWithEqualityOperator"
+      description: "Replaces `Enum equals(java.lang.Object)` with `Enum == java.lang.Object`.\
+        \ An `!Enum equals(java.lang.Object)` will change to `!=`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/compareenumswithequalityoperator"
+      options: []
+    org.openrewrite.java.cleanup.ControlFlowIndentation:
+      name: "org.openrewrite.java.cleanup.ControlFlowIndentation"
+      description: "Program flow control statements like `if`, `while`, and `for`\
+        \ can omit curly braces when they apply to only a single statement. This recipe\
+        \ ensures that any statements which follow that statement are correctly indented\
+        \ to show they are not part of the flow control statement."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/controlflowindentation"
+      options: []
+    org.openrewrite.java.cleanup.CovariantEquals:
+      name: "org.openrewrite.java.cleanup.CovariantEquals"
+      description: "Checks that classes and records which define a covariant `equals()`\
+        \ method also override method `equals(Object)`. Covariant `equals()` means\
+        \ a method that is similar to `equals(Object)`, but with a covariant parameter\
+        \ type (any subtype of `Object`)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/covariantequals"
+      options: []
+    org.openrewrite.java.cleanup.DefaultComesLast:
+      name: "org.openrewrite.java.cleanup.DefaultComesLast"
+      description: "Ensure the `default` case comes last after all the cases in a\
+        \ switch statement."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/defaultcomeslast"
+      options: []
+    org.openrewrite.java.cleanup.EmptyBlock:
+      name: "org.openrewrite.java.cleanup.EmptyBlock"
+      description: "Remove empty blocks that effectively do nothing."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/emptyblock"
+      options: []
+    org.openrewrite.java.cleanup.EqualsAvoidsNull:
+      name: "org.openrewrite.java.cleanup.EqualsAvoidsNull"
+      description: "Checks that any combination of String literals is on the left\
+        \ side of an `equals()` comparison. Also checks for String literals assigned\
+        \ to some field (such as `someString.equals(anotherString = \"text\"))`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/equalsavoidsnull"
+      options: []
+    org.openrewrite.java.cleanup.ExplicitCharsetOnStringGetBytes:
+      name: "org.openrewrite.java.cleanup.ExplicitCharsetOnStringGetBytes"
+      description: "This makes the behavior of the code platform neutral. It will\
+        \ not override any existing explicit encodings, even if they don't match the\
+        \ default encoding option."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/explicitcharsetonstringgetbytes"
+      options:
+      - name: "encoding"
+        type: "String"
+        required: false
+    org.openrewrite.java.cleanup.ExplicitInitialization:
+      name: "org.openrewrite.java.cleanup.ExplicitInitialization"
+      description: "Checks if any class or object member is explicitly initialized\
+        \ to default for its type value (`null` for object references, zero for numeric\
+        \ types and `char` and `false` for `boolean`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/explicitinitialization"
+      options: []
+    org.openrewrite.java.cleanup.ExplicitLambdaArgumentTypes:
+      name: "org.openrewrite.java.cleanup.ExplicitLambdaArgumentTypes"
+      description: "Adds explicit types on lambda arguments, which are otherwise optional.\
+        \ This can make the code clearer and easier to read. This does not add explicit\
+        \ types on arguments when the lambda has one or two parameters and does not\
+        \ have a block body, as things are considered more readable in those cases.\
+        \ For example, `stream.map((a, b) -> a.length);` will not have explicit types\
+        \ added."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/explicitlambdaargumenttypes"
+      options: []
+    org.openrewrite.java.cleanup.ExternalizableHasNoArgsConstructor:
+      name: "org.openrewrite.java.cleanup.ExternalizableHasNoArgsConstructor"
+      description: "`Externalizable` classes handle both serialization and deserialization\
+        \ and must have a no-args constructor for the deserialization process."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/externalizablehasnoargsconstructor"
+      options: []
+    org.openrewrite.java.cleanup.FallThrough:
+      name: "org.openrewrite.java.cleanup.FallThrough"
+      description: "Checks for fall-through in switch statements, adding `break` statements\
+        \ in locations where a case contains Java code but does not have a `break`,\
+        \ `return`, `throw`, or `continue` statement."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/fallthrough"
+      options: []
+    org.openrewrite.java.cleanup.FinalClass:
+      name: "org.openrewrite.java.cleanup.FinalClass"
+      description: "Adds the `final` modifier to classes that expose no public or\
+        \ package-private constructors."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/finalclass"
+      options: []
+    org.openrewrite.java.cleanup.FinalizeLocalVariables:
+      name: "org.openrewrite.java.cleanup.FinalizeLocalVariables"
+      description: "Adds the `final` modifier keyword to local variables which are\
+        \ not reassigned."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/finalizelocalvariables"
+      options: []
+    org.openrewrite.java.cleanup.FixSerializableFields:
+      name: "org.openrewrite.java.cleanup.FixSerializableFields"
+      description: "The fields of a class that implements `Serializable` must also\
+        \ implement `Serializable` or be marked as `transient`.\n\nThis recipe will\
+        \ look for any classes that directly or indirectly implement `Serializable`\
+        \ and for any member fields that are not serializable it will do one of two\
+        \ things:\n\n- If a non-serializable field has a type that is represented\
+        \ by a `SourceFile` within the same project, that SourceFile will be changed\
+        \ to implement `Serializable`.\n\n- If a non-serializable field has a type\
+        \ that is not represented as a `SourceFile`, the field will be marked as `transient`\n\
+        \nNOTE: If `markAllAsTransient` is set to `true`, this recipe will mark all\
+        \ non-serializable fields as `transient`.\n\nNOTE: Any fullyQualified names\
+        \ listed in the `fullyQualifiedExclusions` will be marked as transient, even\
+        \ if that SourceFile exists in the same project.\n\nNOTE: This recipe does\
+        \ NOT recursively modify newly `Serilazable` classes to cut down on the graph\
+        \ of SourceFiles that may be impacted during a recipe run."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/fixserializablefields"
+      options:
+      - name: "fullyQualifiedExclusions"
+        type: "List"
+        required: false
+      - name: "markAllAsTransient"
+        type: "Boolean"
+        required: true
+    org.openrewrite.java.cleanup.FixStringFormatExpressions:
+      name: "org.openrewrite.java.cleanup.FixStringFormatExpressions"
+      description: "Fix `String#format` and `String#formatted` expressions by replacing\
+        \ `\\n` newline characters with `%n` and removing any unused arguments. Note\
+        \ this recipe is scoped to only transform format expressions which do not\
+        \ specify the argument index."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/fixstringformatexpressions"
+      options: []
+    org.openrewrite.java.cleanup.ForLoopControlVariablePostfixOperators:
+      name: "org.openrewrite.java.cleanup.ForLoopControlVariablePostfixOperators"
+      description: "Replace `for` loop control variables using pre-increment (`++i`)\
+        \ or pre-decrement (`--i`) operators with their post-increment (`i++`) or\
+        \ post-decrement (`i++`) notation equivalents."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/forloopcontrolvariablepostfixoperators"
+      options: []
+    org.openrewrite.java.cleanup.ForLoopIncrementInUpdate:
+      name: "org.openrewrite.java.cleanup.ForLoopIncrementInUpdate"
+      description: "The increment should be moved to the loop's increment clause if\
+        \ possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/forloopincrementinupdate"
+      options: []
+    org.openrewrite.java.cleanup.HiddenField:
+      name: "org.openrewrite.java.cleanup.HiddenField"
+      description: "Refactor local variables or parameters which shadow a field defined\
+        \ in the same class."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/hiddenfield"
+      options: []
+    org.openrewrite.java.cleanup.HideUtilityClassConstructor:
+      name: "org.openrewrite.java.cleanup.HideUtilityClassConstructor"
+      description: "Ensures utility classes (classes containing only static methods\
+        \ or fields in their API) do not have a public constructor."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/hideutilityclassconstructor"
+      options: []
+    org.openrewrite.java.cleanup.IndexOfChecksShouldUseAStartPosition:
+      name: "org.openrewrite.java.cleanup.IndexOfChecksShouldUseAStartPosition"
+      description: "Replaces `indexOf(String)` in binary operations if the compared\
+        \ value is an int and not less than 1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/indexofchecksshoulduseastartposition"
+      options: []
+    org.openrewrite.java.cleanup.IndexOfReplaceableByContains:
+      name: "org.openrewrite.java.cleanup.IndexOfReplaceableByContains"
+      description: "Checking if a value is included in a `String` or `List` using\
+        \ `indexOf(value)>-1` or `indexOf(value)>=0` can be replaced with `contains(value)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/indexofreplaceablebycontains"
+      options: []
+    org.openrewrite.java.cleanup.IndexOfShouldNotCompareGreaterThanZero:
+      name: "org.openrewrite.java.cleanup.IndexOfShouldNotCompareGreaterThanZero"
+      description: "Replaces `String#indexOf(String) > 0` and `List#indexOf(Object)\
+        \ > 0` with `>=1`. Checking `indexOf` against `>0` ignores the first element,\
+        \ whereas `>-1` is inclusive of the first element. For clarity, `>=1` is used,\
+        \ because `>0` and `>=1` are semantically equal. Using `>0` may appear to\
+        \ be a mistake with the intent of including all elements. If the intent is\
+        \ to check whether a value in included in a `String` or `List`, the `String#contains(String)`\
+        \ or `List#contains(Object)` methods may be better options altogether."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/indexofshouldnotcomparegreaterthanzero"
+      options: []
+    org.openrewrite.java.cleanup.InlineVariable:
+      name: "org.openrewrite.java.cleanup.InlineVariable"
+      description: "Inline variables when they are immediately used to return or throw."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/inlinevariable"
+      options: []
+    org.openrewrite.java.cleanup.IsEmptyCallOnCollections:
+      name: "org.openrewrite.java.cleanup.IsEmptyCallOnCollections"
+      description: "Also check for _not_ `isEmpty()` when testing for not equal to\
+        \ zero size."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/isemptycalloncollections"
+      options: []
+    org.openrewrite.java.cleanup.JavaApiBestPractices:
+      name: "org.openrewrite.java.cleanup.JavaApiBestPractices"
+      description: "Use the Java standard library in a way that is most idiomatic."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/javaapibestpractices"
+      options: []
+    org.openrewrite.java.cleanup.LambdaBlockToExpression:
+      name: "org.openrewrite.java.cleanup.LambdaBlockToExpression"
+      description: "Single-line statement lambdas returning a value can be replaced\
+        \ with expression lambdas."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/lambdablocktoexpression"
+      options: []
+    org.openrewrite.java.cleanup.LowercasePackage:
+      name: "org.openrewrite.java.cleanup.LowercasePackage"
+      description: "By convention all Java package names should contain only lowercase\
+        \ letters, numbers, and dashes. This recipe converts any uppercase letters\
+        \ in package names to be lowercase."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/lowercasepackage"
+      options: []
+    org.openrewrite.java.cleanup.MethodNameCasing:
+      name: "org.openrewrite.java.cleanup.MethodNameCasing"
+      description: "Method names should comply with a naming convention."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/methodnamecasing"
+      options:
+      - name: "includeTestSources"
+        type: "Boolean"
+        required: false
+      - name: "renamePublicMethods"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.cleanup.MethodParamPad:
+      name: "org.openrewrite.java.cleanup.MethodParamPad"
+      description: "Fixes whitespace padding between the identifier of a method definition\
+        \ or method invocation and the left parenthesis of the parameter list. For\
+        \ example, when configured to remove spacing, `someMethodInvocation (x);`\
+        \ becomes `someMethodInvocation(x)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/methodparampad"
+      options: []
+    org.openrewrite.java.cleanup.MinimumSwitchCases:
+      name: "org.openrewrite.java.cleanup.MinimumSwitchCases"
+      description: "`switch` statements are useful when many code paths branch depending\
+        \ on the value of a single expression. For just one or two code paths, the\
+        \ code will be more readable with `if` statements."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/minimumswitchcases"
+      options: []
+    org.openrewrite.java.cleanup.MissingOverrideAnnotation:
+      name: "org.openrewrite.java.cleanup.MissingOverrideAnnotation"
+      description: "Adds `@Override` to methods overriding superclass methods or implementing\
+        \ interface methods. Annotating methods improves readability by showing the\
+        \ author's intent to override. Additionally, when annotated, the compiler\
+        \ will emit an error when a signature of the overridden method does not match\
+        \ the superclass method."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/missingoverrideannotation"
+      options:
+      - name: "ignoreAnonymousClassMethods"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.cleanup.ModifierOrder:
+      name: "org.openrewrite.java.cleanup.ModifierOrder"
+      description: "Modifiers should be declared in the correct order as recommended\
+        \ by the JLS."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/modifierorder"
+      options: []
+    org.openrewrite.java.cleanup.MultipleVariableDeclarations:
+      name: "org.openrewrite.java.cleanup.MultipleVariableDeclarations"
+      description: "Places each variable declaration in its own statement and on its\
+        \ own line. Using one variable declaration per line encourages commenting\
+        \ and can increase readability."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/multiplevariabledeclarations"
+      options: []
+    org.openrewrite.java.cleanup.NeedBraces:
+      name: "org.openrewrite.java.cleanup.NeedBraces"
+      description: "Adds missing braces around code such as single-line `if`, `for`,\
+        \ `while`, and `do-while` block bodies."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/needbraces"
+      options: []
+    org.openrewrite.java.cleanup.NestedEnumsAreNotStatic:
+      name: "org.openrewrite.java.cleanup.NestedEnumsAreNotStatic"
+      description: "Remove static modifier from nested enum types since they are implicitly\
+        \ static."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nestedenumsarenotstatic"
+      options: []
+    org.openrewrite.java.cleanup.NewStringBuilderBufferWithCharArgument:
+      name: "org.openrewrite.java.cleanup.NewStringBuilderBufferWithCharArgument"
+      description: "Instantiating a `StringBuilder` or a `StringBuffer` with a `Character`\
+        \ results in the `int` representation of the character being used for the\
+        \ initial size."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/newstringbuilderbufferwithcharargument"
+      options: []
+    org.openrewrite.java.cleanup.NoDoubleBraceInitialization:
+      name: "org.openrewrite.java.cleanup.NoDoubleBraceInitialization"
+      description: "Replace `List`, `Map`, and `Set` double brace initialization with\
+        \ an initialization block."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nodoublebraceinitialization"
+      options: []
+    org.openrewrite.java.cleanup.NoEmptyCollectionWithRawType:
+      name: "org.openrewrite.java.cleanup.NoEmptyCollectionWithRawType"
+      description: "Replaces `Collections#EMPTY_..` with methods that return generic\
+        \ types."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/noemptycollectionwithrawtype"
+      options: []
+    org.openrewrite.java.cleanup.NoEqualityInForCondition:
+      name: "org.openrewrite.java.cleanup.NoEqualityInForCondition"
+      description: "Testing for loop termination using an equality operator (`==`\
+        \ and `!=`) is dangerous, because it could set up an infinite loop. Using\
+        \ a relational operator instead makes it harder to accidentally write an infinite\
+        \ loop."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/noequalityinforcondition"
+      options: []
+    org.openrewrite.java.cleanup.NoFinalizer:
+      name: "org.openrewrite.java.cleanup.NoFinalizer"
+      description: "Finalizers are deprecated. Use of `finalize()` can lead to performance\
+        \ issues, deadlocks, hangs, and other undesirable behavior."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nofinalizer"
+      options: []
+    org.openrewrite.java.cleanup.NoPrimitiveWrappersForToStringOrCompareTo:
+      name: "org.openrewrite.java.cleanup.NoPrimitiveWrappersForToStringOrCompareTo"
+      description: "Primitive wrappers should not be instantiated only for `#toString()`\
+        \ or `#compareTo(..)` invocations."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/noprimitivewrappersfortostringorcompareto"
+      options: []
+    org.openrewrite.java.cleanup.NoRedundantJumpStatements:
+      name: "org.openrewrite.java.cleanup.NoRedundantJumpStatements"
+      description: "Jump statements such as return and continue let you change the\
+        \ default flow of program execution, but jump statements that direct the control\
+        \ flow to the original direction are just a waste of keystrokes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/noredundantjumpstatements"
+      options: []
+    org.openrewrite.java.cleanup.NoToStringOnStringType:
+      name: "org.openrewrite.java.cleanup.NoToStringOnStringType"
+      description: "Remove unnecessary `String#toString()` invocations on objects\
+        \ which are already a string."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/notostringonstringtype"
+      options: []
+    org.openrewrite.java.cleanup.NoValueOfOnStringType:
+      name: "org.openrewrite.java.cleanup.NoValueOfOnStringType"
+      description: "Replace unnecessary `String#valueOf(..)` method invocations with\
+        \ the argument directly. This occurs when the argument to `String#valueOf(arg)`\
+        \ is a string literal, such as `String.valueOf(\"example\")`. Or, when the\
+        \ `String#valueOf(..)` invocation is used in a concatenation, such as `\"\
+        example\" + String.valueOf(\"example\")`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/novalueofonstringtype"
+      options: []
+    org.openrewrite.java.cleanup.NoWhitespaceAfter:
+      name: "org.openrewrite.java.cleanup.NoWhitespaceAfter"
+      description: "Removes unnecessary whitespace appearing after a token. A linebreak\
+        \ after a token is allowed unless `allowLineBreaks` is set to `false`, in\
+        \ which case it will be removed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nowhitespaceafter"
+      options: []
+    org.openrewrite.java.cleanup.NoWhitespaceBefore:
+      name: "org.openrewrite.java.cleanup.NoWhitespaceBefore"
+      description: "Removes unnecessary whitespace preceding a token. A linebreak\
+        \ before a token will be removed unless `allowLineBreaks` is set to `true`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/nowhitespacebefore"
+      options: []
+    org.openrewrite.java.cleanup.ObjectFinalizeCallsSuper:
+      name: "org.openrewrite.java.cleanup.ObjectFinalizeCallsSuper"
+      description: "Overrides of `Object#finalize()` should call super."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/objectfinalizecallssuper"
+      options: []
+    org.openrewrite.java.cleanup.OperatorWrap:
+      name: "org.openrewrite.java.cleanup.OperatorWrap"
+      description: "Fixes line wrapping policies on operators."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/operatorwrap"
+      options: []
+    org.openrewrite.java.cleanup.PadEmptyForLoopComponents:
+      name: "org.openrewrite.java.cleanup.PadEmptyForLoopComponents"
+      description: "Fixes padding on empty `for` loop iterators and initializers to\
+        \ match Checkstyle policies."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/pademptyforloopcomponents"
+      options: []
+    org.openrewrite.java.cleanup.PrimitiveWrapperClassConstructorToValueOf:
+      name: "org.openrewrite.java.cleanup.PrimitiveWrapperClassConstructorToValueOf"
+      description: "The constructor of all primitive types has been deprecated in\
+        \ favor of using the static factory method `valueOf` available for each of\
+        \ the primitive type wrappers."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/primitivewrapperclassconstructortovalueof"
+      options: []
+    org.openrewrite.java.cleanup.RedundantFileCreation:
+      name: "org.openrewrite.java.cleanup.RedundantFileCreation"
+      description: "Remove unnecessary intermediate creations of files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/redundantfilecreation"
+      options: []
+    org.openrewrite.java.cleanup.ReferentialEqualityToObjectEquals:
+      name: "org.openrewrite.java.cleanup.ReferentialEqualityToObjectEquals"
+      description: "Using `==` or `!=` compares object references, not the equality\
+        \ of two objects. This modifies code where both sides of a binary operation\
+        \ (`==` or `!=`) override `Object.equals(Object obj)` except when the comparison\
+        \ is within an overridden `Object.equals(Object obj)` method declaration itself.WARNING,\
+        \ The resulting transformation must be carefully reviewed since any modifications\
+        \ change the programs semantics."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/referentialequalitytoobjectequals"
+      options: []
+    org.openrewrite.java.cleanup.RemoveCallsToSystemGc:
+      name: "org.openrewrite.java.cleanup.RemoveCallsToSystemGc"
+      description: "Removes calls to `System.gc()` and `Runtime.gc()`. When to invoke\
+        \ garbage collection is best left to the JVM."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removecallstosystemgc"
+      options: []
+    org.openrewrite.java.cleanup.RemoveEmptyJavaDocParameters:
+      name: "org.openrewrite.java.cleanup.RemoveEmptyJavaDocParameters"
+      description: "Removes `@params`, `@return`, and `@throws` with no description\
+        \ from JavaDocs."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeemptyjavadocparameters"
+      options: []
+    org.openrewrite.java.cleanup.RemoveExtraSemicolons:
+      name: "org.openrewrite.java.cleanup.RemoveExtraSemicolons"
+      description: "Optional semicolons at the end of try-with-resources are also\
+        \ removed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeextrasemicolons"
+      options: []
+    org.openrewrite.java.cleanup.RemoveJavaDocAuthorTag:
+      name: "org.openrewrite.java.cleanup.RemoveJavaDocAuthorTag"
+      description: "Removes author tags from JavaDocs to reduce code maintenance."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removejavadocauthortag"
+      options: []
+    org.openrewrite.java.cleanup.RemoveRedundantTypeCast:
+      name: "org.openrewrite.java.cleanup.RemoveRedundantTypeCast"
+      description: "Removes unnecessary type casts. Does not currently check casts\
+        \ in lambdas, class constructors, and method invocations."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeredundanttypecast"
+      options: []
+    org.openrewrite.java.cleanup.RemoveUnneededAssertion:
+      name: "org.openrewrite.java.cleanup.RemoveUnneededAssertion"
+      description: "Remove unneeded assertions like `assert true`, `assertTrue(true)`,\
+        \ or `assertFalse(false)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunneededassertion"
+      options: []
+    org.openrewrite.java.cleanup.RemoveUnneededBlock:
+      name: "org.openrewrite.java.cleanup.RemoveUnneededBlock"
+      description: "Flatten blocks into inline statements when possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunneededblock"
+      options: []
+    org.openrewrite.java.cleanup.RemoveUnusedLocalVariables:
+      name: "org.openrewrite.java.cleanup.RemoveUnusedLocalVariables"
+      description: "If a local variable is declared but not used, it is dead code\
+        \ and should be removed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunusedlocalvariables"
+      options:
+      - name: "ignoreVariablesNamed"
+        type: "String[]"
+        required: false
+    org.openrewrite.java.cleanup.RemoveUnusedPrivateFields:
+      name: "org.openrewrite.java.cleanup.RemoveUnusedPrivateFields"
+      description: "If a private field is declared but not used in the program, it\
+        \ can be considered dead code and should therefore be removed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunusedprivatefields"
+      options: []
+    org.openrewrite.java.cleanup.RemoveUnusedPrivateMethods:
+      name: "org.openrewrite.java.cleanup.RemoveUnusedPrivateMethods"
+      description: "`private` methods that are never executed are dead code and should\
+        \ be removed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/removeunusedprivatemethods"
+      options: []
+    org.openrewrite.java.cleanup.RenameExceptionInEmptyCatch:
+      name: "org.openrewrite.java.cleanup.RenameExceptionInEmptyCatch"
+      description: "Renames caught exceptions in empty catch blocks to `ignored`.\
+        \ `ignored` will be incremented by 1 if a namespace conflict exists."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/renameexceptioninemptycatch"
+      options: []
+    org.openrewrite.java.cleanup.RenameLocalVariablesToCamelCase:
+      name: "org.openrewrite.java.cleanup.RenameLocalVariablesToCamelCase"
+      description: "Reformat local variable and method parameter names to camelCase\
+        \ to comply with Java naming convention. The recipe will not rename variables\
+        \ declared in for loop controls or catches with a single character. The first\
+        \ character is set to lower case and existing capital letters are preserved.\
+        \ Special characters that are allowed in java field names `$` and `_` are\
+        \ removed. If a special character is removed the next valid alpha-numeric\
+        \ will be capitalized. Currently, does not support renaming members of classes.\
+        \ The recipe will not rename a variable if the result already exists in the\
+        \ class, conflicts with a java reserved keyword, or the result is blank."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/renamelocalvariablestocamelcase"
+      options: []
+    org.openrewrite.java.cleanup.RenameMethodsNamedHashcodeEqualOrTostring:
+      name: "org.openrewrite.java.cleanup.RenameMethodsNamedHashcodeEqualOrTostring"
+      description: "Methods should not be named `hashcode`, `equal`, or `tostring`.\
+        \ Any of these are confusing as they appear to be intended as overridden methods\
+        \ from the `Object` base class, despite being case-insensitive."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/renamemethodsnamedhashcodeequalortostring"
+      options: []
+    org.openrewrite.java.cleanup.RenamePrivateFieldsToCamelCase:
+      name: "org.openrewrite.java.cleanup.RenamePrivateFieldsToCamelCase"
+      description: "Reformat private field names to camelCase to comply with Java\
+        \ naming convention. The recipe will not rename fields with default, protected\
+        \ or public access modifiers.The recipe will not rename private constants.The\
+        \ first character is set to lower case and existing capital letters are preserved.\
+        \ Special characters that are allowed in java field names `$` and `_` are\
+        \ removed. If a special character is removed the next valid alphanumeric will\
+        \ be capitalized. The recipe will not rename a field if the result already\
+        \ exists in the class, conflicts with a java reserved keyword, or the result\
+        \ is blank."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/renameprivatefieldstocamelcase"
+      options: []
+    org.openrewrite.java.cleanup.ReplaceDuplicateStringLiterals:
+      name: "org.openrewrite.java.cleanup.ReplaceDuplicateStringLiterals"
+      description: "Replaces `String` literals with a length of 5 or greater repeated\
+        \ a minimum of 3 times. Qualified `String` literals include final Strings,\
+        \ method invocations, and new class invocations. Adds a new `private static\
+        \ final String` or uses an existing equivalent class field. A new variable\
+        \ name will be generated based on the literal value if an existing field does\
+        \ not exist. The generated name will append a numeric value to the variable\
+        \ name if a name already exists in the compilation unit."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/replaceduplicatestringliterals"
+      options:
+      - name: "includeTestSources"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.cleanup.ReplaceLambdaWithMethodReference:
+      name: "org.openrewrite.java.cleanup.ReplaceLambdaWithMethodReference"
+      description: "Replaces the single statement lambdas `o -> o instanceOf X`, `o\
+        \ -> (A) o`, `o -> System.out.println(o)`, `o -> o != null`, `o -> o == null`\
+        \ with the equivalent method reference."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/replacelambdawithmethodreference"
+      options: []
+    org.openrewrite.java.cleanup.ReplaceStackWithDeque:
+      name: "org.openrewrite.java.cleanup.ReplaceStackWithDeque"
+      description: "From the Javadoc of `Stack`:\n> A more complete and consistent\
+        \ set of LIFO stack operations is provided by the Deque interface and its\
+        \ implementations, which should be used in preference to this class."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/replacestackwithdeque"
+      options: []
+    org.openrewrite.java.cleanup.ReplaceThreadRunWithThreadStart:
+      name: "org.openrewrite.java.cleanup.ReplaceThreadRunWithThreadStart"
+      description: "`Thread.run()` should not be called directly."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/replacethreadrunwiththreadstart"
+      options: []
+    org.openrewrite.java.cleanup.SimplifyBooleanExpression:
+      name: "org.openrewrite.java.cleanup.SimplifyBooleanExpression"
+      description: "Checks for over-complicated boolean expressions. Finds code like\
+        \ `if (b == true)`, `b || true`, `!false`, etc."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifybooleanexpression"
+      options: []
+    org.openrewrite.java.cleanup.SimplifyBooleanReturn:
+      name: "org.openrewrite.java.cleanup.SimplifyBooleanReturn"
+      description: "Simplifies Boolean expressions by removing redundancies, e.g.:\
+        \ `a && true` simplifies to `a`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifybooleanreturn"
+      options: []
+    org.openrewrite.java.cleanup.SimplifyCompoundStatement:
+      name: "org.openrewrite.java.cleanup.SimplifyCompoundStatement"
+      description: "Fixes or removes useless compound statements. For example, removing\
+        \ `b &= true`, and replacing `b &= false` with `b = false`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifycompoundstatement"
+      options: []
+    org.openrewrite.java.cleanup.SimplifyConsecutiveAssignments:
+      name: "org.openrewrite.java.cleanup.SimplifyConsecutiveAssignments"
+      description: "Combine consecutive assignments into a single statement where\
+        \ possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifyconsecutiveassignments"
+      options: []
+    org.openrewrite.java.cleanup.SimplifyConstantIfBranchExecution:
+      name: "org.openrewrite.java.cleanup.SimplifyConstantIfBranchExecution"
+      description: "Checks for if expressions that are always `true` or `false` and\
+        \ simplifies them."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/simplifyconstantifbranchexecution"
+      options: []
+    org.openrewrite.java.cleanup.StaticMethodNotFinal:
+      name: "org.openrewrite.java.cleanup.StaticMethodNotFinal"
+      description: "Static methods do not need to be declared final because they cannot\
+        \ be overridden."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/staticmethodnotfinal"
+      options: []
+    org.openrewrite.java.cleanup.StringLiteralEquality:
+      name: "org.openrewrite.java.cleanup.StringLiteralEquality"
+      description: "`String.equals()` should be used when checking value equality\
+        \ on String literals. Using `==` or `!=` compares object references, not the\
+        \ actual value of the Strings. This only modifies code where at least one\
+        \ side of the binary operation (`==` or `!=`) is a String literal, such as\
+        \ `\"someString\" == someVariable;`. This is to prevent inadvertently changing\
+        \ code where referential equality is the user's intent."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/stringliteralequality"
+      options: []
+    org.openrewrite.java.cleanup.TypecastParenPad:
+      name: "org.openrewrite.java.cleanup.TypecastParenPad"
+      description: "Fixes whitespace padding between a typecast type identifier and\
+        \ the enclosing left and right parenthesis. For example, when configured to\
+        \ remove spacing, `( int ) 0L;` becomes `(int) 0L;`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/typecastparenpad"
+      options: []
+    org.openrewrite.java.cleanup.UnnecessaryCatch:
+      name: "org.openrewrite.java.cleanup.UnnecessaryCatch"
+      description: "A refactoring operation may result in a checked exception that\
+        \ is no longer thrown from a `try` block. This recipe will find and remove\
+        \ unnecessary catch blocks."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessarycatch"
+      options: []
+    org.openrewrite.java.cleanup.UnnecessaryCloseInTryWithResources:
+      name: "org.openrewrite.java.cleanup.UnnecessaryCloseInTryWithResources"
+      description: "Remove unnecessary `AutoCloseable#close()` statements in try-with-resources."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessarycloseintrywithresources"
+      options: []
+    org.openrewrite.java.cleanup.UnnecessaryExplicitTypeArguments:
+      name: "org.openrewrite.java.cleanup.UnnecessaryExplicitTypeArguments"
+      description: "When explicit type arguments are inferrable by the compiler, they\
+        \ may be removed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessaryexplicittypearguments"
+      options: []
+    org.openrewrite.java.cleanup.UnnecessaryParentheses:
+      name: "org.openrewrite.java.cleanup.UnnecessaryParentheses"
+      description: "Removes unnecessary parentheses from code where extra parentheses\
+        \ pairs are redundant."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessaryparentheses"
+      options: []
+    org.openrewrite.java.cleanup.UnnecessaryPrimitiveAnnotations:
+      name: "org.openrewrite.java.cleanup.UnnecessaryPrimitiveAnnotations"
+      description: "Remove `@Nullable` and `@CheckForNull` annotations from primitives\
+        \ since they can't be null."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessaryprimitiveannotations"
+      options: []
+    org.openrewrite.java.cleanup.UnnecessaryThrows:
+      name: "org.openrewrite.java.cleanup.UnnecessaryThrows"
+      description: "Remove unnecessary `throws` declarations. This recipe will only\
+        \ remove unused, checked exception if:\n\n- The declaring class or the method\
+        \ declaration is `final`.\n- The method declaration is `static` or `private`.\n\
+        - If the method overriding a method declaration in a super class and the super\
+        \ does not throw the exception.\n- If the method is `public` or `protected`\
+        \ and the exception is not documented via a JavaDoc as a `@throws` tag."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unnecessarythrows"
+      options: []
+    org.openrewrite.java.cleanup.UnwrapRepeatableAnnotations:
+      name: "org.openrewrite.java.cleanup.UnwrapRepeatableAnnotations"
+      description: "Java 8 introduced the concept of `@Repeatable` annotations, making\
+        \ the wrapper annotation unnecessary."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/unwraprepeatableannotations"
+      options: []
+    org.openrewrite.java.cleanup.UpperCaseLiteralSuffixes:
+      name: "org.openrewrite.java.cleanup.UpperCaseLiteralSuffixes"
+      description: "Using upper case literal suffixes for declaring literals is less\
+        \ ambiguous, e.g., `1l` versus `1L`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/uppercaseliteralsuffixes"
+      options: []
+    org.openrewrite.java.cleanup.UseAsBuilder:
+      name: "org.openrewrite.java.cleanup.UseAsBuilder"
+      description: "When an API has been designed as a builder, use it that way rather\
+        \ than as a series of setter calls."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/useasbuilder"
+      options:
+      - name: "builderCreator"
+        type: "String"
+        required: false
+      - name: "builderType"
+        type: "String"
+        required: true
+      - name: "immutable"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.cleanup.UseCollectionInterfaces:
+      name: "org.openrewrite.java.cleanup.UseCollectionInterfaces"
+      description: "Use `Deque`, `List`, `Map`, `ConcurrentMap`, `Queue`, and `Set`\
+        \ instead of implemented collections. Replaces the return type of public method\
+        \ declarations and the variable type public variable declarations."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usecollectioninterfaces"
+      options: []
+    org.openrewrite.java.cleanup.UseDiamondOperator:
+      name: "org.openrewrite.java.cleanup.UseDiamondOperator"
+      description: "The diamond operator (`<>`) should be used. Java 7 introduced\
+        \ the diamond operator (<>) to reduce the verbosity of generics code. For\
+        \ instance, instead of having to declare a List's type in both its declaration\
+        \ and its constructor, you can now simplify the constructor declaration with\
+        \ `<>`, and the compiler will infer the type."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usediamondoperator"
+      options: []
+    org.openrewrite.java.cleanup.UseForEachRemoveInsteadOfSetRemoveAll:
+      name: "org.openrewrite.java.cleanup.UseForEachRemoveInsteadOfSetRemoveAll"
+      description: "Using `java.util.Collection#forEach(Set::remove)` rather than\
+        \ `java.util.Set#removeAll(java.util.Collection)` may improve performance\
+        \ due to a possible O(n^2) complexity."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/useforeachremoveinsteadofsetremoveall"
+      options: []
+    org.openrewrite.java.cleanup.UseJavaStyleArrayDeclarations:
+      name: "org.openrewrite.java.cleanup.UseJavaStyleArrayDeclarations"
+      description: "Change C-Style array declarations `int i[];` to `int[] i;`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usejavastylearraydeclarations"
+      options: []
+    org.openrewrite.java.cleanup.UseLambdaForFunctionalInterface:
+      name: "org.openrewrite.java.cleanup.UseLambdaForFunctionalInterface"
+      description: "Instead of anonymous class declarations, use a lambda where possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/uselambdaforfunctionalinterface"
+      options: []
+    org.openrewrite.java.cleanup.UseListSort:
+      name: "org.openrewrite.java.cleanup.UseListSort"
+      description: "The `java.util.Collections#sort(..)` implementation defers to\
+        \ the `java.util.List#sort(Comparator)`, replaced it with the `java.util.List#sort(Comparator)`\
+        \ implementation for better readability."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/uselistsort"
+      options: []
+    org.openrewrite.java.cleanup.UseMapContainsKey:
+      name: "org.openrewrite.java.cleanup.UseMapContainsKey"
+      description: "`map.keySet().contains(a)` can be simplified to `map.containsKey(a)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usemapcontainskey"
+      options: []
+    org.openrewrite.java.cleanup.UseStandardCharset:
+      name: "org.openrewrite.java.cleanup.UseStandardCharset"
+      description: "Replaces `Charset.forName(java.lang.String)` with the equivalent\
+        \ `StandardCharset` constant."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usestandardcharset"
+      options: []
+    org.openrewrite.java.cleanup.UseStringReplace:
+      name: "org.openrewrite.java.cleanup.UseStringReplace"
+      description: "When `String::replaceAll` is used, the first argument should be\
+        \ a real regular expression. If it’s not the case, `String::replace` does\
+        \ exactly the same thing as `String::replaceAll` without the performance drawback\
+        \ of the regex."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/usestringreplace"
+      options: []
+    org.openrewrite.java.cleanup.WhileInsteadOfFor:
+      name: "org.openrewrite.java.cleanup.WhileInsteadOfFor"
+      description: "When only the condition expression is defined in a for loop, and\
+        \ the initialization and increment expressions are missing, a while loop should\
+        \ be used instead to increase readability."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/whileinsteadoffor"
+      options: []
+    org.openrewrite.java.cleanup.WriteOctalValuesAsDecimal:
+      name: "org.openrewrite.java.cleanup.WriteOctalValuesAsDecimal"
+      description: "Developers may not recognize octal values as such, mistaking them\
+        \ instead for decimal values."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/cleanup/writeoctalvaluesasdecimal"
+      options: []
+    org.openrewrite.java.controlflow.ControlFlowVisualization:
+      name: "org.openrewrite.java.controlflow.ControlFlowVisualization"
+      description: "Visualize the control flow of a Java program."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/controlflow/controlflowvisualization"
+      options:
+      - name: "includeDotfile"
+        type: "boolean"
+        required: true
+    org.openrewrite.java.format.AutoFormat:
+      name: "org.openrewrite.java.format.AutoFormat"
+      description: "Format Java code using a standard comprehensive set of Java formatting\
+        \ recipes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/autoformat"
+      options: []
+    org.openrewrite.java.format.BlankLines:
+      name: "org.openrewrite.java.format.BlankLines"
+      description: "Add and/or remove blank lines."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/blanklines"
+      options: []
+    org.openrewrite.java.format.EmptyNewlineAtEndOfFile:
+      name: "org.openrewrite.java.format.EmptyNewlineAtEndOfFile"
+      description: "Some tools work better when files end with an empty line."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/emptynewlineatendoffile"
+      options: []
+    org.openrewrite.java.format.NormalizeFormat:
+      name: "org.openrewrite.java.format.NormalizeFormat"
+      description: "Move whitespace to the outermost AST element possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/normalizeformat"
+      options: []
+    org.openrewrite.java.format.NormalizeLineBreaks:
+      name: "org.openrewrite.java.format.NormalizeLineBreaks"
+      description: "Consistently use either Windows style (CRLF) or Linux style (LF)\
+        \ line breaks. If no `GeneralFormatStyle` is specified this will use whichever\
+        \ style of line endings are more common."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/normalizelinebreaks"
+      options: []
+    org.openrewrite.java.format.NormalizeTabsOrSpaces:
+      name: "org.openrewrite.java.format.NormalizeTabsOrSpaces"
+      description: "Consistently use either tabs or spaces in indentation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/normalizetabsorspaces"
+      options: []
+    org.openrewrite.java.format.RemoveTrailingWhitespace:
+      name: "org.openrewrite.java.format.RemoveTrailingWhitespace"
+      description: "Remove any extra trailing whitespace from the end of each line."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/removetrailingwhitespace"
+      options: []
+    org.openrewrite.java.format.SingleLineComments:
+      name: "org.openrewrite.java.format.SingleLineComments"
+      description: "Write `// hi` instead of `//hi`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/singlelinecomments"
+      options: []
+    org.openrewrite.java.format.Spaces:
+      name: "org.openrewrite.java.format.Spaces"
+      description: "Format whitespace in Java code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/spaces"
+      options: []
+    org.openrewrite.java.format.TabsAndIndents:
+      name: "org.openrewrite.java.format.TabsAndIndents"
+      description: "Format tabs and indents in Java code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/tabsandindents"
+      options: []
+    org.openrewrite.java.format.WrappingAndBraces:
+      name: "org.openrewrite.java.format.WrappingAndBraces"
+      description: "Format line wraps and braces in Java code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/format/wrappingandbraces"
+      options: []
+    org.openrewrite.java.recipes.ExecutionContextParameterName:
+      name: "org.openrewrite.java.recipes.ExecutionContextParameterName"
+      description: "Visitors that are parameterized with `ExecutionContext` should\
+        \ use the parameter name `ctx`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/recipes/executioncontextparametername"
+      options: []
+    org.openrewrite.java.recipes.PublicGetVisitor:
+      name: "org.openrewrite.java.recipes.PublicGetVisitor"
+      description: "It would be a breaking API change to increase the visibility of\
+        \ the method by default, but any recipe can increase visibility of the `Recipe`\
+        \ class. Making them public makes recipes easier to use in other recipes in\
+        \ unexpected ways."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/recipes/publicgetvisitor"
+      options: []
+    org.openrewrite.java.recipes.SetDefaultEstimatedEffortPerOccurrence:
+      name: "org.openrewrite.java.recipes.SetDefaultEstimatedEffortPerOccurrence"
+      description: "Retrofit recipes with a deafult estimated effort per occurrence."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/recipes/setdefaultestimatedeffortperoccurrence"
+      options: []
+    org.openrewrite.java.search.FindAnnotations:
+      name: "org.openrewrite.java.search.FindAnnotations"
+      description: "Find all annotations matching the annotation pattern."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findannotations"
+      options:
+      - name: "annotationPattern"
+        type: "String"
+        required: true
+      - name: "matchMetaAnnotations"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.search.FindDeprecatedClasses:
+      name: "org.openrewrite.java.search.FindDeprecatedClasses"
+      description: "Find uses of deprecated classes, optionally ignoring those classes\
+        \ that are inside deprecated scopes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/finddeprecatedclasses"
+      options:
+      - name: "ignoreDeprecatedScopes"
+        type: "Boolean"
+        required: false
+      - name: "matchInherited"
+        type: "Boolean"
+        required: false
+      - name: "typePattern"
+        type: "String"
+        required: false
+    org.openrewrite.java.search.FindDeprecatedFields:
+      name: "org.openrewrite.java.search.FindDeprecatedFields"
+      description: "Find uses of deprecated fields in any API."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/finddeprecatedfields"
+      options:
+      - name: "ignoreDeprecatedScopes"
+        type: "Boolean"
+        required: false
+      - name: "typePattern"
+        type: "String"
+        required: false
+    org.openrewrite.java.search.FindDeprecatedMethods:
+      name: "org.openrewrite.java.search.FindDeprecatedMethods"
+      description: "Find uses of deprecated methods in any API."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/finddeprecatedmethods"
+      options:
+      - name: "ignoreDeprecatedScopes"
+        type: "Boolean"
+        required: false
+      - name: "methodPattern"
+        type: "String"
+        required: false
+    org.openrewrite.java.search.FindDeprecatedUses:
+      name: "org.openrewrite.java.search.FindDeprecatedUses"
+      description: "Find deprecated uses of methods, fields, and types. Optionally\
+        \ ignore those classes that are inside deprecated scopes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/finddeprecateduses"
+      options:
+      - name: "ignoreDeprecatedScopes"
+        type: "Boolean"
+        required: false
+      - name: "matchInherited"
+        type: "Boolean"
+        required: false
+      - name: "typePattern"
+        type: "String"
+        required: false
+    org.openrewrite.java.search.FindEmptyClasses:
+      name: "org.openrewrite.java.search.FindEmptyClasses"
+      description: "Find empty classes without annotations that do not implement an\
+        \ interface or extend a class."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findemptyclasses"
+      options: []
+    org.openrewrite.java.search.FindEmptyMethods:
+      name: "org.openrewrite.java.search.FindEmptyMethods"
+      description: "Find methods with empty bodies and single public no arg constructors."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findemptymethods"
+      options:
+      - name: "matchOverrides"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.search.FindFields:
+      name: "org.openrewrite.java.search.FindFields"
+      description: "Find uses of a field."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findfields"
+      options:
+      - name: "fieldName"
+        type: "String"
+        required: true
+      - name: "fullyQualifiedTypeName"
+        type: "String"
+        required: true
+    org.openrewrite.java.search.FindFieldsOfType:
+      name: "org.openrewrite.java.search.FindFieldsOfType"
+      description: "Finds declared fields matching a particular class name."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findfieldsoftype"
+      options:
+      - name: "fullyQualifiedTypeName"
+        type: "String"
+        required: true
+    org.openrewrite.java.search.FindFlowBetweenMethods:
+      name: "org.openrewrite.java.search.FindFlowBetweenMethods"
+      description: "Takes two patterns for the start/end methods to find flow between."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findflowbetweenmethods"
+      options:
+      - name: "endMatchOverrides"
+        type: "Boolean"
+        required: false
+      - name: "endMethodPattern"
+        type: "String"
+        required: true
+      - name: "flow"
+        type: "String"
+        required: true
+      - name: "startMatchOverrides"
+        type: "Boolean"
+        required: false
+      - name: "startMethodPattern"
+        type: "String"
+        required: true
+      - name: "target"
+        type: "String"
+        required: true
+    org.openrewrite.java.search.FindImports:
+      name: "org.openrewrite.java.search.FindImports"
+      description: "Locates source files that have imports matching the given type\
+        \ pattern, regardless of whether that import is used in the code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findimports"
+      options:
+      - name: "typePattern"
+        type: "String"
+        required: false
+    org.openrewrite.java.search.FindLiterals:
+      name: "org.openrewrite.java.search.FindLiterals"
+      description: "Find literals matching a pattern."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findliterals"
+      options:
+      - name: "pattern"
+        type: "String"
+        required: true
+    org.openrewrite.java.search.FindMethods:
+      name: "org.openrewrite.java.search.FindMethods"
+      description: "Find method usages by pattern."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findmethods"
+      options:
+      - name: "flow"
+        type: "String"
+        required: false
+      - name: "matchOverrides"
+        type: "Boolean"
+        required: false
+      - name: "methodPattern"
+        type: "String"
+        required: true
+    org.openrewrite.java.search.FindMissingTypes:
+      name: "org.openrewrite.java.search.FindMissingTypes"
+      description: "This is a diagnostic recipe to highlight where ASTs are missing\
+        \ type attribution information."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findmissingtypes"
+      options: []
+    org.openrewrite.java.search.FindRepeatableAnnotations:
+      name: "org.openrewrite.java.search.FindRepeatableAnnotations"
+      description: "Java 8 introduced the concept of `@Repeatable` annotations."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findrepeatableannotations"
+      options: []
+    org.openrewrite.java.search.FindSecrets:
+      name: "org.openrewrite.java.search.FindSecrets"
+      description: "Find secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findsecrets"
+      options: []
+    org.openrewrite.java.search.FindText:
+      name: "org.openrewrite.java.search.FindText"
+      description: "Find occurrences of regular expression based patterns in comments\
+        \ and literals."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findtext"
+      options:
+      - name: "patterns"
+        type: "List"
+        required: true
+    org.openrewrite.java.search.FindTypes:
+      name: "org.openrewrite.java.search.FindTypes"
+      description: "Find type references by name."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/findtypes"
+      options:
+      - name: "checkAssignability"
+        type: "Boolean"
+        required: false
+      - name: "fullyQualifiedTypeName"
+        type: "String"
+        required: true
+    org.openrewrite.java.search.PotentiallyDeadCode:
+      name: "org.openrewrite.java.search.PotentiallyDeadCode"
+      description: "Method definitions that are defined in this project and aren't\
+        \ used."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/potentiallydeadcode"
+      options: []
+    org.openrewrite.java.search.ResultOfMethodCallIgnored:
+      name: "org.openrewrite.java.search.ResultOfMethodCallIgnored"
+      description: "Find locations where the result of the method call is being ignored."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/resultofmethodcallignored"
+      options:
+      - name: "methodPattern"
+        type: "String"
+        required: true
+    org.openrewrite.java.search.UriCreatedWithHttpScheme:
+      name: "org.openrewrite.java.search.UriCreatedWithHttpScheme"
+      description: "This is a sample recipe demonstrating a simple application of\
+        \ local data flow analysis."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/search/uricreatedwithhttpscheme"
+      options: []
+rewrite-java-security:
+  artifactId: "rewrite-java-security"
+  version: "1.19.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.quarkus.ConfigPropertiesToConfigMapping"
-    description: "Migrate Quarkus configuration classes annotated with `@ConfigProperties`\
-      \ to the equivalent Smallrye `@ConfigMapping`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/configpropertiestoconfigmapping"
-    options: []
-  - name: "org.openrewrite.java.quarkus.ConfigureQuarkusMavenPluginWithReasonableDefaults"
-    description: "Configures the `quarkus-maven-plugin` with reasonable defaults,\
-      \ such as default activated `goals` and `<extensions>` configuration."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/configurequarkusmavenpluginwithreasonabledefaults"
-    options: []
-  - name: "org.openrewrite.java.quarkus.MigrateQuarkusMavenPluginNativeImageGoal"
-    description: "Migrates the `quarkus-maven-plugin` deprecated `native-image` goal.\
-      \ If the `native-image` goal needs to be removed, this adds `<quarkus.package.type>native</quarkus.package.type>`\
-      \ to the `native` profile `properties` section, given the `native` profile exists\
-      \ in the `pom.xml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/migratequarkusmavenpluginnativeimagegoal"
-    options: []
-  - name: "org.openrewrite.java.quarkus.MultiTransformHotStreamToMultiHotStream"
-    description: "Replace Mutiny API usages of `multi.transform().toHotStream()` with\
-      \ `multi.toHotStream()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/multitransformhotstreamtomultihotstream"
-    options: []
-  - name: "org.openrewrite.java.quarkus.Quarkus1to1_13Migration"
-    description: "Migrates Quarkus 1.11 to 1.13."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus1to1_13migration"
-    options: []
-  - name: "org.openrewrite.java.quarkus.quarkus2.GrpcServiceAnnotationToGrpcClient"
-    description: "The `@GrpcService` annotation is replaced with `@GrpcClient` in\
-      \ Quarkus 2.x. Removes the optional `@GrpcClient.value()` unless the service\
-      \ name is different from the name of annotated element."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/grpcserviceannotationtogrpcclient"
-    options: []
-  - name: "org.openrewrite.java.quarkus.quarkus2.Quarkus1to2Migration"
-    description: "Migrates Quarkus 1.x to 2.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/quarkus1to2migration"
-    options: []
-  - name: "org.openrewrite.java.quarkus.quarkus2.RemoveAvroMavenPlugin"
-    description: "Removes the `avro-maven-plugin` if the `quarkus-maven-plugin` is\
-      \ found in the project's `pom.xml`. Avro has been integrated with the Quarkus\
-      \ code generation mechanism. This replaces the need to use the Avro plugin."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/removeavromavenplugin"
-    options: []
-  - name: "org.openrewrite.java.quarkus.quarkus2.UseIdentifierOnDefaultKafkaBroker"
-    description: "Use `@io.smallrye.common.annotation.Identifier` on default kafka\
-      \ broker configuration."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/useidentifierondefaultkafkabroker"
-    options: []
-  - name: "org.openrewrite.java.quarkus.quarkus2.UsePanacheEntityBaseStaticMethods"
-    description: "The `getEntityManager()` and the `flush()` methods of `PanacheEntityBase`\
-      \ are now static methods."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/usepanacheentitybasestaticmethods"
-    options: []
-  - name: "org.openrewrite.java.quarkus.quarkus2.UsePanacheEntityBaseUniT"
-    description: "The `persist()` and `persistAndFlush()` methods now return an `Uni<T\
-      \ extends PanacheEntityBase>` instead of an `Uni<Void>` to allow chaining the\
-      \ methods."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/usepanacheentitybaseunit"
-    options: []
-  - name: "org.openrewrite.java.quarkus.quarkus2.UseReactivePanacheMongoEntityBaseUniT"
-    description: "The `persist()`, `update()`, and `persistOrUpdate()` methods now\
-      \ return a `Uni<T extends ReactivePanacheMongoEntityBase>` instead of a `Uni<Void>`\
-      \ to allow chaining the methods."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/usereactivepanachemongoentitybaseunit"
-    options: []
-- artifactId: "rewrite-spring"
-  version: "4.29.0"
+    org.openrewrite.java.security.FindTextDirectionChanges:
+      name: "org.openrewrite.java.security.FindTextDirectionChanges"
+      description: "Finds unicode control characters which can change the direction\
+        \ text is displayed in. These control characters can alter how source code\
+        \ is presented to a human reader without affecting its interpretation by tools\
+        \ like compilers. So a malicious patch could pass code review while introducing\
+        \ vulnerabilities. Note that text direction-changing unicode control characters\
+        \ aren't inherently malicious. These characters can appear for legitimate\
+        \ reasons in code written in or dealing with right-to-left languages. See:\
+        \ https://trojansource.codes/ for more information."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/findtextdirectionchanges"
+      options: []
+    org.openrewrite.java.security.JavaSecurityBestPractices:
+      name: "org.openrewrite.java.security.JavaSecurityBestPractices"
+      description: "Applies security best practices to Java code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/javasecuritybestpractices"
+      options: []
+    org.openrewrite.java.security.PartialPathTraversalVulnerability:
+      name: "org.openrewrite.java.security.PartialPathTraversalVulnerability"
+      description: "Replaces `dir.getCanonicalPath().startsWith(parent.getCanonicalPath()`,\
+        \ which is vulnerable to partial path traversal attacks, with the more secure\
+        \ `dir.getCanonicalFile().toPath().startsWith(parent.getCanonicalFile().toPath())`.\n\
+        \nTo demonstrate this vulnerability, consider `\"/usr/outnot\".startsWith(\"\
+        /usr/out\")`. The check is bypassed although `/outnot` is not under the `/out`\
+        \ directory. It's important to understand that the terminating slash may be\
+        \ removed when using various `String` representations of the `File` object.\
+        \ For example, on Linux, `println(new File(\"/var\"))` will print `/var`,\
+        \ but `println(new File(\"/var\", \"/\")` will print `/var/`; however, `println(new\
+        \ File(\"/var\", \"/\").getCanonicalPath())` will print `/var`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/partialpathtraversalvulnerability"
+      options: []
+    org.openrewrite.java.security.RegularExpressionDenialOfService:
+      name: "org.openrewrite.java.security.RegularExpressionDenialOfService"
+      description: "ReDoS is a Denial of Service attack that exploits the fact that\
+        \ most Regular Expression implementations may reach extreme situations that\
+        \ cause them to work very slowly (exponentially related to input size). See\
+        \ the OWASP description of this attack [here](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)\
+        \ for more details."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/regularexpressiondenialofservice"
+      options: []
+    org.openrewrite.java.security.SecureRandom:
+      name: "org.openrewrite.java.security.SecureRandom"
+      description: "Use cryptographically secure Pseudo Random Number Generation in\
+        \ the \"main\" source set. Replaces instantiation of `java.util.Random` with\
+        \ `java.security.SecureRandom`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/securerandom"
+      options: []
+    org.openrewrite.java.security.SecureRandomPrefersDefaultSeed:
+      name: "org.openrewrite.java.security.SecureRandomPrefersDefaultSeed"
+      description: "Remove `SecureRandom#setSeed(*)` method invocations having constant\
+        \ or predictable arguments."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/securerandomprefersdefaultseed"
+      options: []
+    org.openrewrite.java.security.SecureTempFileCreation:
+      name: "org.openrewrite.java.security.SecureTempFileCreation"
+      description: "`java.io.File.createTempFile()` has exploitable default file permissions.\
+        \ This recipe migrates to the more secure `java.nio.file.Files.createTempFile()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/securetempfilecreation"
+      options: []
+    org.openrewrite.java.security.UseFilesCreateTempDirectory:
+      name: "org.openrewrite.java.security.UseFilesCreateTempDirectory"
+      description: "Use `Files#createTempDirectory` when the sequence `File#createTempFile(..)`->`File#delete()`->`File#mkdir()`\
+        \ is used for creating a temp directory."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/usefilescreatetempdirectory"
+      options: []
+    org.openrewrite.java.security.XmlParserXXEVulnerability:
+      name: "org.openrewrite.java.security.XmlParserXXEVulnerability"
+      description: "Avoid exposing dangerous features of the XML parser by setting\
+        \ XMLInputFactory `IS_SUPPORTING_EXTERNAL_ENTITIES` and `SUPPORT_DTD` properties\
+        \ to `false`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/xmlparserxxevulnerability"
+      options: []
+    org.openrewrite.java.security.ZipSlip:
+      name: "org.openrewrite.java.security.ZipSlip"
+      description: "Zip slip is an arbitrary file overwrite critical vulnerability,\
+        \ which typically results in remote command execution. A fuller description\
+        \ of this vulnerability is available in the [Snyk documentation](https://snyk.io/research/zip-slip-vulnerability)\
+        \ on it."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/zipslip"
+      options:
+      - name: "debug"
+        type: "boolean"
+        required: true
+    org.openrewrite.java.security.marshalling.SecureJacksonDefaultTyping:
+      name: "org.openrewrite.java.security.marshalling.SecureJacksonDefaultTyping"
+      description: "See the [blog post](https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062)\
+        \ on this subject."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/marshalling/securejacksondefaulttyping"
+      options: []
+    org.openrewrite.java.security.marshalling.SecureSnakeYamlConstructor:
+      name: "org.openrewrite.java.security.marshalling.SecureSnakeYamlConstructor"
+      description: "See the [paper](https://github.com/mbechler/marshalsec) on this\
+        \ subject."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/marshalling/securesnakeyamlconstructor"
+      options: []
+    org.openrewrite.java.security.search.FindJacksonDefaultTypeMapping:
+      name: "org.openrewrite.java.security.search.FindJacksonDefaultTypeMapping"
+      description: "`ObjectMapper#enableTypeMapping(..)` can lead to vulnerable deserialization."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/search/findjacksondefaulttypemapping"
+      options: []
+    org.openrewrite.java.security.search.FindVulnerableJacksonJsonTypeInfo:
+      name: "org.openrewrite.java.security.search.FindVulnerableJacksonJsonTypeInfo"
+      description: "Identify where attackers can deserialize gadgets into a target\
+        \ field."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/search/findvulnerablejacksonjsontypeinfo"
+      options: []
+    org.openrewrite.java.security.secrets.FindArtifactorySecrets:
+      name: "org.openrewrite.java.security.secrets.FindArtifactorySecrets"
+      description: "Locates Artifactory secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findartifactorysecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindAwsSecrets:
+      name: "org.openrewrite.java.security.secrets.FindAwsSecrets"
+      description: "Locates AWS secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findawssecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindAzureSecrets:
+      name: "org.openrewrite.java.security.secrets.FindAzureSecrets"
+      description: "Locates Azure secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findazuresecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindDiscordSecrets:
+      name: "org.openrewrite.java.security.secrets.FindDiscordSecrets"
+      description: "Locates Discord secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/finddiscordsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindGenericSecrets:
+      name: "org.openrewrite.java.security.secrets.FindGenericSecrets"
+      description: "Locates generic secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findgenericsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindGitHubSecrets:
+      name: "org.openrewrite.java.security.secrets.FindGitHubSecrets"
+      description: "Locates GitHub secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findgithubsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindGoogleSecrets:
+      name: "org.openrewrite.java.security.secrets.FindGoogleSecrets"
+      description: "Locates Google secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findgooglesecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindHerokuSecrets:
+      name: "org.openrewrite.java.security.secrets.FindHerokuSecrets"
+      description: "Locates Heroku secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findherokusecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindJwtSecrets:
+      name: "org.openrewrite.java.security.secrets.FindJwtSecrets"
+      description: "Locates JWTs stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findjwtsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindMailChimpSecrets:
+      name: "org.openrewrite.java.security.secrets.FindMailChimpSecrets"
+      description: "Locates MailChimp secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findmailchimpsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindMailgunSecrets:
+      name: "org.openrewrite.java.security.secrets.FindMailgunSecrets"
+      description: "Locates Mailgun secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findmailgunsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindNpmSecrets:
+      name: "org.openrewrite.java.security.secrets.FindNpmSecrets"
+      description: "Locates NPM secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findnpmsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindPasswordInUrlSecrets:
+      name: "org.openrewrite.java.security.secrets.FindPasswordInUrlSecrets"
+      description: "Locates URLs that contain passwords in plain text."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findpasswordinurlsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindPayPalSecrets:
+      name: "org.openrewrite.java.security.secrets.FindPayPalSecrets"
+      description: "Locates PayPal secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findpaypalsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindPgpSecrets:
+      name: "org.openrewrite.java.security.secrets.FindPgpSecrets"
+      description: "Locates PGP secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findpgpsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindPicaticSecrets:
+      name: "org.openrewrite.java.security.secrets.FindPicaticSecrets"
+      description: "Locates Picatic secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findpicaticsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindRsaSecrets:
+      name: "org.openrewrite.java.security.secrets.FindRsaSecrets"
+      description: "Locates RSA private keys stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findrsasecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindSecrets:
+      name: "org.openrewrite.java.security.secrets.FindSecrets"
+      description: "Locates secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindSecretsByPattern:
+      name: "org.openrewrite.java.security.secrets.FindSecretsByPattern"
+      description: "A secret is a literal that matches any one of the provided patterns."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findsecretsbypattern"
+      options:
+      - name: "keyPattern"
+        type: "String"
+        required: false
+      - name: "secretName"
+        type: "String"
+        required: true
+      - name: "valuePattern"
+        type: "String"
+        required: true
+    org.openrewrite.java.security.secrets.FindSendGridSecrets:
+      name: "org.openrewrite.java.security.secrets.FindSendGridSecrets"
+      description: "Locates SendGrid secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findsendgridsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindSlackSecrets:
+      name: "org.openrewrite.java.security.secrets.FindSlackSecrets"
+      description: "Locates Slack secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findslacksecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindSquareSecrets:
+      name: "org.openrewrite.java.security.secrets.FindSquareSecrets"
+      description: "Locates Square secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findsquaresecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindSshSecrets:
+      name: "org.openrewrite.java.security.secrets.FindSshSecrets"
+      description: "Locates SSH secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findsshsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindStripeSecrets:
+      name: "org.openrewrite.java.security.secrets.FindStripeSecrets"
+      description: "Locates Stripe secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findstripesecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindTelegramSecrets:
+      name: "org.openrewrite.java.security.secrets.FindTelegramSecrets"
+      description: "Locates Telegram secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findtelegramsecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindTwilioSecrets:
+      name: "org.openrewrite.java.security.secrets.FindTwilioSecrets"
+      description: "Locates Twilio secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findtwiliosecrets"
+      options: []
+    org.openrewrite.java.security.secrets.FindTwitterSecrets:
+      name: "org.openrewrite.java.security.secrets.FindTwitterSecrets"
+      description: "Locates Twitter secrets stored in plain text in code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/secrets/findtwittersecrets"
+      options: []
+    org.openrewrite.java.security.spring.CsrfProtection:
+      name: "org.openrewrite.java.security.spring.CsrfProtection"
+      description: "Cross-Site Request Forgery (CSRF) is a type of attack that occurs\
+        \ when a malicious web site, email, blog, instant message, or program causes\
+        \ a user's web browser to perform an unwanted action on a trusted site when\
+        \ the user is authenticated. See the full [OWASP cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/spring/csrfprotection"
+      options:
+      - name: "onlyIfSecurityConfig"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.security.spring.PreventClickjacking:
+      name: "org.openrewrite.java.security.spring.PreventClickjacking"
+      description: "The `frame-ancestors` directive can be used in a Content-Security-Policy\
+        \ HTTP response header to indicate whether or not a browser should be allowed\
+        \ to render a page in a `<frame>` or `<iframe>`. Sites can use this to avoid\
+        \ Clickjacking attacks by ensuring that their content is not embedded into\
+        \ other sites."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/security/spring/preventclickjacking"
+      options:
+      - name: "onlyIfSecurityConfig"
+        type: "Boolean"
+        required: false
+rewrite-jhipster:
+  artifactId: "rewrite-jhipster"
+  version: "1.14.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.spring.BeanMethodsNotPublic"
-    description: "Remove public modifier from `@Bean` methods. They no longer have\
-      \ to be public visibility to be usable by Spring."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/beanmethodsnotpublic"
-    options: []
-  - name: "org.openrewrite.java.spring.ExpandProperties"
-    description: "Expand YAML properties to not use the dot syntax shortcut."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/expandproperties"
-    options: []
-  - name: "org.openrewrite.java.spring.ImplicitWebAnnotationNames"
-    description: "Removes implicit web annotation names."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/implicitwebannotationnames"
-    options: []
-  - name: "org.openrewrite.java.spring.NoAutowiredOnConstructor"
-    description: "Spring can infer an autowired constructor when there is a single\
-      \ constructor on the bean. This recipe removes unneeded `@Autowired` annotations\
-      \ on constructors."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/noautowiredonconstructor"
-    options: []
-  - name: "org.openrewrite.java.spring.NoRequestMappingAnnotation"
-    description: "Replace method declaration `@RequestMapping` annotations with `@GetMapping`,\
-      \ `@PostMapping`, etc. when possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/norequestmappingannotation"
-    options: []
-  - name: "org.openrewrite.java.spring.SeparateApplicationYamlByProfile"
-    description: "The Spring team's recommendation is to separate profile properties\
-      \ into their own YAML files now."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/separateapplicationyamlbyprofile"
-    options: []
-  - name: "org.openrewrite.java.spring.UpdateApiManifest"
-    description: "Keep a consolidated manifest of the API endpoints that this application\
-      \ exposes up-to-date."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/updateapimanifest"
-    options: []
-  - name: "org.openrewrite.java.spring.YamlPropertiesToKebabCase"
-    description: "Normalize Spring YAML properties to use lowercase and hyphen-separated\
-      \ syntax. For example, changing `spring.main.showBanner` to `spring.main.show-banner`.\
-      \ With [Spring's relaxed binding](https://docs.spring.io/spring-boot/docs/2.5.6/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding),\
-      \ `kebab-case` may be used in properties files and still be converted to configuration\
-      \ beans. Note, an exception to this is the case of `@Value`, which is match-sensitive.\
-      \ For example, `@Value(\"${anExampleValue}\")` will not match `an-example-value`.\
-      \ [The Spring reference documentation recommends using `kebab-case` for properties\
-      \ where possible.](https://docs.spring.io/spring-boot/docs/2.5.6/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding)"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/yamlpropertiestokebabcase"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.ConditionalOnBeanAnyNestedCondition"
-    description: "Migrate multi-condition `@ConditionalOnBean` annotations to `AnyNestedCondition`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/conditionalonbeananynestedcondition"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.DatabaseComponentAndBeanInitializationOrdering"
-    description: "Beans of certain well-known types, such as JdbcTemplate, will be\
-      \ ordered so that they are initialized after the database has been initialized.\
-      \ If you have a bean that works with the DataSource directly, annotate its class\
-      \ or @Bean method with @DependsOnDatabaseInitialization to ensure that it too\
-      \ is initialized after the database has been initialized."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/databasecomponentandbeaninitializationordering"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.GetErrorAttributes"
-    description: "`ErrorAttributes#getErrorAttributes(WebRequest, boolean)` was deprecated\
-      \ in Spring Boot 2.3."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/geterrorattributes"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MergeBootstrapYamlWithApplicationYaml"
-    description: "In Spring Boot 2.4, support for `bootstrap.yml` was removed. It's\
-      \ properties should be merged with `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/mergebootstrapyamlwithapplicationyaml"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateAbstractHealthIndicatorToPingHealthIndicator"
-    description: "`org.springframework.boot.actuate.health.AbstractHealthIndicator`\
-      \ was deprecated in 2.2."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateabstracthealthindicatortopinghealthindicator"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateActuatorMediaTypeToApiVersion"
-    description: "Spring-Boot-Actuator `ActuatorMediaType` was deprecated in 2.5 in\
-      \ favor of `ApiVersion#getProducedMimeType()`. Replace `MediaType.parseMediaType(ActuatorMediaType.Vx_JSON)`\
-      \ with `MediaType.asMediaType(ApiVersion.Vx.getProducedMimeType())`"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateactuatormediatypetoapiversion"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanName"
-    description: "Replaces field and static access of `ConfigurationPropertiesBindingPostProcessor#VALIDATOR_BEAN_NAME`\
-      \ with `EnableConfigurationProperties#VALIDATOR_BEAN_NAME`. Deprecated in 2.2.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateconfigurationpropertiesbindingpostprocessorvalidatorbeanname"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateDatabaseCredentials"
-    description: "If you currently define a `spring.flyway.url` or `spring.liquibase.url`\
-      \ you may need to provide additional username and password properties. In earlier\
-      \ versions of Spring Boot, these settings were derived from `spring.datasource`\
-      \ properties but this turned out to be problematic for people that provided\
-      \ their own `DataSource` beans."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratedatabasecredentials"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateDiskSpaceHealthIndicatorConstructor"
-    description: "`DiskSpaceHealthIndicator(File, long)` was deprecated in Spring\
-      \ Data 2.1 for removal in 2.2."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratediskspacehealthindicatorconstructor"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateErrorControllerPackageName"
-    description: "`org.springframework.boot.autoconfigure.web.ErrorController` was\
-      \ deprecated in 1.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateerrorcontrollerpackagename"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateErrorPropertiesIncludeStackTraceConstants"
-    description: "`ErrorProperties#IncludeStacktrace.ON_TRACE_PARAM` was deprecated\
-      \ in 2.3.x and removed in 2.5.0."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateerrorpropertiesincludestacktraceconstants"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateHsqlEmbeddedDatabaseConnection"
-    description: "Spring-Boot `EmbeddedDatabaseConnection.HSQL` was deprecated in\
-      \ favor of `EmbeddedDatabaseConnection.HSQLDB` in 2.4."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratehsqlembeddeddatabaseconnection"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateHttpMessageConvertersPackageName"
-    description: "`org.springframework.boot.autoconfigure.web.HttpMessageConverters`\
-      \ was deprecated in 1.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratehttpmessageconverterspackagename"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateLocalServerPortAnnotation"
-    description: "Updates the package and adds the necessary dependency if `LocalServerPort`\
-      \ is in use. The package of `LocalServerPort` was changed in Spring Boot 2.0,\
-      \ necessitating changes."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratelocalserverportannotation"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateLoggingSystemPropertyConstants"
-    description: "Replaces field and static access of deprecated fields in `LoggingSystemProperties`\
-      \ with the recommendations from `LogbackLoggingSystemProperties`. Deprecated\
-      \ in 2.4.x and removed in 2.6.0."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateloggingsystempropertyconstants"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateMultipartConfigFactory"
-    description: "Methods to set DataSize with primitive arguments were deprecated\
-      \ in 2.1 and removed in 2.2."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratemultipartconfigfactory"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateNotBlankPackageName"
-    description: "`org.hibernate.validator.constraints.NotBlank` was deprecated in\
-      \ 1.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratenotblankpackagename"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateNotEmptyPackageName"
-    description: "`org.hibernate.validator.constraints.NotEmpty` was deprecated in\
-      \ 1.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratenotemptypackagename"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateRestClientBuilderCustomizerPackageName"
-    description: "`org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientBuilderCustomizer`\
-      \ was deprecated in 2.3."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migraterestclientbuildercustomizerpackagename"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateRestTemplateBuilderBasicAuthorization"
-    description: "`RestTemplateBuilder#basicAuthorization` was deprecated in 2.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateresttemplatebuilderbasicauthorization"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateRestTemplateBuilderTimeoutByInt"
-    description: "`RestTemplateBuilder#setConnectTimeout(int)` and `RestTemplateBuilder#setReadTimeout(int)`\
-      \ were deprecated in Spring Boot 2.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateresttemplatebuildertimeoutbyint"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateSpringBootServletInitializerPackageName"
-    description: "`org.springframework.boot.web.support.SpringBootServletInitializer`\
-      \ was deprecated in 1.4.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratespringbootservletinitializerpackagename"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateUndertowServletWebServerFactoryIsEagerInitFilters"
-    description: "`org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory#isEagerInitFilters`\
-      \ was deprecated in 2.4 and are removed in 2.6."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateundertowservletwebserverfactoryiseagerinitfilters"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateUndertowServletWebServerFactorySetEagerInitFilters"
-    description: "`org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory#setEagerInitFilters`\
-      \ was deprecated in 2.4 and are removed in 2.6."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateundertowservletwebserverfactoryseteagerinitfilters"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.MigrateWebTestClientBuilderCustomizerPackageName"
-    description: "`org.springframework.boot.test.autoconfigure.web.reactive.WebTestClientBuilderCustomizer`\
-      \ was deprecated in 2.2."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratewebtestclientbuildercustomizerpackagename"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.OutputCaptureExtension"
-    description: "Use the JUnit Jupiter extension instead of JUnit 4 rule."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/outputcaptureextension"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.RemoveObsoleteSpringRunners"
-    description: "Remove obsolete classpath runners."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/removeobsoletespringrunners"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils"
-    description: "Replaces any references to the deprecated `EnvironmentTestUtils`\
-      \ with `TestPropertyValues` and the appropriate functionality."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/replacedeprecatedenvironmenttestutils"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory"
-    description: "Migrate `RestTemplateBuilder#requestFactory` calls to use a `Supplier`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/resttemplatebuilderrequestfactory"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SamlRelyingPartyPropertyApplicationPropertiesMove"
-    description: "Renames spring.security.saml2.relyingparty.registration.(any).identityprovider\
-      \ to spring.security.saml2.relyingparty.registration.(any).assertingparty."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/samlrelyingpartypropertyapplicationpropertiesmove"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBoot1To2Migration"
-    description: "Migrates Spring Boot 1.x to latest version of 2.x, updating tests\
-      \ to JUnit 5, and applying 2.x best practices."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot1to2migration"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBoot2BestPractices"
-    description: "Applies best practices to Spring Boot 2 applications."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot2bestpractices"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration"
-    description: "Migrates Spring Boot 2.x projects having JUnit 4.x tests to JUnit\
-      \ Jupiter."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot2junit4to5migration"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBoot2To3Migration"
-    description: "Migrates Spring Boot 2.x to latest version of 3.x"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot2to3migration"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootMavenPluginMigrateAgentToAgents"
-    description: "Migrate the `spring-boot.run.agent` Maven plugin configuration key\
-      \ to `spring-boot.run.agents`. Deprecated in 2.2.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootmavenpluginmigrateagenttoagents"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_0"
-    description: "Migrate properties found in `application.properties` and `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_0"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_1"
-    description: "Migrate properties found in `application.properties` and `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_1"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_2"
-    description: "Migrate properties found in `application.properties` and `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_2"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_3"
-    description: "Migrate properties found in `application.properties` and `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_3"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_4"
-    description: "Migrate properties found in `application.properties` and `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_4"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_5"
-    description: "Migrate properties found in `application.properties` and `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_5"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_6"
-    description: "Migrate properties found in `application.properties` and `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_6"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_7"
-    description: "Migrate properties found in `application.properties` and `application.yml`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_7"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UnnecessarySpringExtension"
-    description: "`@SpringBootTest` and all test slice annotations already applies\
-      \ `@SpringExtension` as of Spring Boot 2.1.0."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/unnecessaryspringextension"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UnnecessarySpringRunWith"
-    description: "Remove `@RunWith` annotations on Spring tests."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/unnecessaryspringrunwith"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_0"
-    description: "Upgrade to Spring Boot 2.0 from prior 1.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_0"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_1"
-    description: "Upgrade to Spring Boot 2.1 from any prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_1"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_2"
-    description: "Upgrade to Spring Boot 2.2 from any prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_2"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_3"
-    description: "Upgrade to Spring Boot 2.3 from any prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_3"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4"
-    description: "Upgrade to Spring Boot 2.4 from any prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_4"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5"
-    description: "Upgrade to Spring Boot 2.5 from any prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_5"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6"
-    description: "Upgrade to Spring Boot 2.6 from any prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_6"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7"
-    description: "Upgrade to Spring Boot 2.7 from any prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_7"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.WebSecurityConfigurerAdapter"
-    description: ""
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/websecurityconfigureradapter"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.search.CustomizingJooqDefaultConfiguration"
-    description: "To streamline the customization of jOOQ’s `DefaultConfiguration`,\
-      \ a bean that implements `DefaultConfigurationCustomizer` can now be defined.\
-      \ This customizer callback should be used in favour of defining one or more\
-      \ `*Provider` beans, the support for which has now been deprecated. See [Spring\
-      \ Boot 2.5 jOOQ customization](https://docs.spring.io/spring-boot/docs/2.5.x/reference/htmlsingle/#features.sql.jooq.customizing)."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/customizingjooqdefaultconfiguration"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.search.IntegrationSchedulerPoolRecipe"
-    description: "Spring Integration now reuses an available TaskScheduler rather\
-      \ than configuring its own. In a typical application setup relying on the auto-configuration,\
-      \ this means that Spring Integration uses the auto-configured task scheduler\
-      \ that has a pool size of 1. To restore Spring Integration’s default of 10 threads,\
-      \ use the `spring.task.scheduling.pool.size` property."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/integrationschedulerpoolrecipe"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.search.LoggingShutdownHooks"
-    description: "Spring Boot registers a logging shutdown hook by default for JAR-based\
-      \ applications to ensure that logging resources are released when the JVM exits.\
-      \ If your application is deployed as a WAR then the shutdown hook is not registered\
-      \ since the servlet container usually handles logging concerns.\n\nMost applications\
-      \ will want the shutdown hook. However, if your application has complex context\
-      \ hierarchies, then you may need to disable it. You can use the `logging.register-shutdown-hook`\
-      \ property to do that."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/loggingshutdownhooks"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.search.MessagesInTheDefaultErrorView"
-    description: "As of Spring Boot 2.5 the `message` attribute in the default error\
-      \ view was removed rather than blanked when it is not shown.\n`spring-webmvc`\
-      \ or `spring-webflux` projects that parse the error response JSON may need to\
-      \ deal with the missing item\n([release notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#messages-in-the-default-error-view)).\n\
-      You can still use the `server.error.include-message` property if you want messages\
-      \ to be included.\n"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/messagesinthedefaulterrorview"
-    options: []
-  - name: "org.openrewrite.java.spring.boot2.search.UpgradeRequirementsSpringBoot_2_5"
-    description: "Identify changes needed to upgrade to Spring Boot 2.5.\n"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/upgraderequirementsspringboot_2_5"
-    options: []
-  - name: "org.openrewrite.java.spring.boot3.MavenPomUpgrade"
-    description: "Upgrade Maven Pom to Spring Boot 3.0 from prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/mavenpomupgrade"
-    options: []
-  - name: "org.openrewrite.java.spring.boot3.PreciseBeanType"
-    description: "Replace Bean method return types with concrete types being returned.\
-      \ This is required for Spring 6 AOT"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/precisebeantype"
-    options: []
-  - name: "org.openrewrite.java.spring.boot3.RemoveConstructorBindingAnnotation"
-    description: "As of Boot 3.0 @ConstructorBinding is no longer needed at the type\
-      \ level on @ConfigurationProperties classes and should be removed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/removeconstructorbindingannotation"
-    options: []
-  - name: "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0"
-    description: "Upgrade to Spring Boot 3.0 from prior 2.x version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/upgradespringboot_3_0"
-    options: []
-  - name: "org.openrewrite.java.spring.cve.Spring4Shell"
-    description: "See the [blog post](https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement#status)\
-      \ on the issue. This recipe can be further refined as more information becomes\
-      \ available."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/cve/spring4shell"
-    options: []
-  - name: "org.openrewrite.java.spring.data.MigrateJpaSort"
-    description: "Equivalent constructors in `JpaSort` were deprecated in Spring Data\
-      \ 2.3."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/migratejpasort"
-    options: []
-  - name: "org.openrewrite.java.spring.data.MigrateQuerydslJpaRepository"
-    description: "`QuerydslJpaRepository<T, ID extends Serializable>` was deprecated\
-      \ in Spring Data 2.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/migratequerydsljparepository"
-    options: []
-  - name: "org.openrewrite.java.spring.data.UpgradeSpringData_2_3"
-    description: "Upgrade to Spring Data to 2.3 from any prior version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/upgradespringdata_2_3"
-    options: []
-  - name: "org.openrewrite.java.spring.data.UpgradeSpringData_2_5"
-    description: "Upgrade to Spring Data to 2.5 from any prior version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/upgradespringdata_2_5"
-    options: []
-  - name: "org.openrewrite.java.spring.data.UseJpaRepositoryDeleteAllInBatch"
-    description: "`JpaRepository#deleteInBatch(Iterable)` was deprecated in 2.5."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/usejparepositorydeleteallinbatch"
-    options: []
-  - name: "org.openrewrite.java.spring.data.UseJpaRepositoryGetById"
-    description: "`JpaRepository#getOne(ID)` was deprecated in 2.5."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/usejparepositorygetbyid"
-    options: []
-  - name: "org.openrewrite.java.spring.framework.EnvironmentAcceptsProfiles"
-    description: "`Environment#acceptsProfiles(String...)` was deprecated in Spring\
-      \ Framework 5.1."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/environmentacceptsprofiles"
-    options: []
-  - name: "org.openrewrite.java.spring.framework.JdbcTemplateObjectArrayArgToVarArgs"
-    description: "`JdbcTemplate` signatures with `Object[]` arguments are deprecated,\
-      \ in favor of their existing varargs equivalents."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/jdbctemplateobjectarrayargtovarargs"
-    options: []
-  - name: "org.openrewrite.java.spring.framework.MigrateInstantiationAwareBeanPostProcessorAdapter"
-    description: "As of Spring-Framework 5.3 `InstantiationAwareBeanPostProcessorAdapter`\
-      \ is deprecated in favor of the existing default methods in `SmartInstantiationAwareBeanPostProcessor`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/migrateinstantiationawarebeanpostprocessoradapter"
-    options: []
-  - name: "org.openrewrite.java.spring.framework.MigrateUtf8MediaTypes"
-    description: "Spring-Web MediaTypes `APPLICATION_JSON_UTF8` and `APPLICATION_PROBLEM_JSON_UTF8`\
-      \ were deprecated in 5.2."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/migrateutf8mediatypes"
-    options: []
-  - name: "org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies"
-    description: "Upgrade spring-framework 5.x Maven dependencies using a Node Semver\
-      \ advanced range selector."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframeworkdependencies"
-    options:
-    - name: "newVersion"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1"
-    description: "Upgrade to Spring Framework to 5.1 from any prior version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframework_5_1"
-    options: []
-  - name: "org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2"
-    description: "Upgrade to Spring Framework to 5.2 from any prior version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframework_5_2"
-    options: []
-  - name: "org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3"
-    description: "Upgrade to Spring Framework to 5.3 from any prior version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframework_5_3"
-    options: []
-  - name: "org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty"
-    description: "`StringUtils#isEmpty(Object)` was deprecated in 5.3."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/useobjectutilsisempty"
-    options: []
-  - name: "org.openrewrite.maven.spring.UpgradeExplicitSpringBootDependencies"
-    description: "Upgrades un-managed spring-boot project dependencies according to\
-      \ the specified spring-boot version"
-    docLink: "https://docs.openrewrite.org/reference/recipes/maven/spring/upgradeexplicitspringbootdependencies"
-    options:
-    - name: "fromVersion"
-      type: "String"
-      required: true
-    - name: "toVersion"
-      type: "String"
-      required: true
-- artifactId: "rewrite-terraform"
-  version: "1.13.0"
+    org.openrewrite.java.jhipster.FixCwe338:
+      name: "org.openrewrite.java.jhipster.FixCwe338"
+      description: "Use a cryptographically strong pseudo-random number generator\
+        \ (PRNG)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/jhipster/fixcwe338"
+      options: []
+rewrite-json:
+  artifactId: "rewrite-json"
+  version: "7.33.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.terraform.AddConfiguration"
-    description: "If the configuration has a different value, leave it alone. If it\
-      \ is missing, add it."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/addconfiguration"
-    options:
-    - name: "content"
-      type: "String"
-      required: true
-    - name: "resourceName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.terraform.SecureRandom"
-    description: ""
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/securerandom"
-    options:
-    - name: "byteLength"
-      type: "Integer"
-      required: false
-  - name: "org.openrewrite.terraform.aws.AWSBestPractices"
-    description: "Securely operate on Amazon Web Services."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/awsbestpractices"
-    options: []
-  - name: "org.openrewrite.terraform.aws.DisableInstanceMetadataServiceV1"
-    description: "As a request/response method IMDSv1 is prone to local misconfigurations."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/disableinstancemetadataservicev1"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnableApiGatewayCaching"
-    description: "Enable caching for all methods of API Gateway."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/enableapigatewaycaching"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnableDynamoDbPITR"
-    description: "DynamoDB Point-In-Time Recovery (PITR) is an automatic backup service\
-      \ for DynamoDB table data that helps protect your DynamoDB tables from accidental\
-      \ write or delete operations."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/enabledynamodbpitr"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnableECRScanOnPush"
-    description: "ECR Image Scanning assesses and identifies operating system vulnerabilities.\
-      \ Using automated image scans you can ensure container image vulnerabilities\
-      \ are found before getting pushed to production."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/enableecrscanonpush"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptAuroraClusters"
-    description: "Native Aurora encryption helps protect your cloud applications and\
-      \ fulfils compliance requirements for data-at-rest encryption."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptauroraclusters"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptCodeBuild"
-    description: "Build artifacts, such as a cache, logs, exported raw test report\
-      \ data files, and build results, are encrypted by default using CMKs for Amazon\
-      \ S3 that are managed by the AWS Key Management Service."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptcodebuild"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptDAXStorage"
-    description: "DAX encryption at rest automatically integrates with AWS KMS for\
-      \ managing the single service default key used to encrypt clusters."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptdaxstorage"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptDocumentDB"
-    description: "The encryption feature available for Amazon DocumentDB clusters\
-      \ provides an additional layer of data protection by helping secure your data\
-      \ against unauthorized access to the underlying storage."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptdocumentdb"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptEBSSnapshots"
-    description: "EBS snapshots should be encrypted, as they often include sensitive\
-      \ information, customer PII or CPNI."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptebssnapshots"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptEBSVolumeLaunchConfiguration"
-    description: "EBS volumes allow you to create encrypted launch configurations\
-      \ when creating EC2 instances and auto scaling. When the entire EBS volume is\
-      \ encrypted, data stored at rest on the volume, disk I/O, snapshots created\
-      \ from the volume, and data in-transit between EBS and EC2 are all encrypted."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptebsvolumelaunchconfiguration"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptEBSVolumes"
-    description: "Encrypting EBS volumes ensures that replicated copies of your images\
-      \ are secure even if they are accidentally exposed. AWS EBS encryption uses\
-      \ AWS KMS customer master keys (CMK) when creating encrypted volumes and snapshots.\
-      \ Storing EBS volumes in their encrypted state reduces the risk of data exposure\
-      \ or data loss."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptebsvolumes"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptEFSVolumesInECSTaskDefinitionsInTransit"
-    description: "Enable attached EFS definitions in ECS tasks to use encryption in\
-      \ transit."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptefsvolumesinecstaskdefinitionsintransit"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptElastiCacheRedisAtRest"
-    description: "ElastiCache for Redis offers default encryption at rest as a service."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptelasticacheredisatrest"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptElastiCacheRedisInTransit"
-    description: "ElastiCache for Redis offers optional encryption in transit. In-transit\
-      \ encryption provides an additional layer of data protection when transferring\
-      \ data over standard HTTPS protocol."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptelasticacheredisintransit"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptNeptuneStorage"
-    description: "Encryption of Neptune storage protects data and metadata against\
-      \ unauthorized access."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptneptunestorage"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptRDSClusters"
-    description: "Native RDS encryption helps protect your cloud applications and\
-      \ fulfils compliance requirements for data-at-rest encryption."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptrdsclusters"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EncryptRedshift"
-    description: "Redshift clusters should be securely encrypted at rest."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptredshift"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSCMKRotationIsEnabled"
-    description: "Ensure AWS CMK rotation is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawscmkrotationisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSEFSWithEncryptionForDataAtRestIsEnabled"
-    description: "Ensure AWS EFS with encryption for data at rest is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawsefswithencryptionfordataatrestisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSEKSClusterEndpointAccessIsPubliclyDisabled"
-    description: "Ensure AWS EKS cluster endpoint access is publicly disabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawseksclusterendpointaccessispubliclydisabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSElasticsearchDomainEncryptionForDataAtRestIsEnabled"
-    description: "Ensure AWS Elasticsearch domain encryption for data at rest is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawselasticsearchdomainencryptionfordataatrestisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSElasticsearchDomainsHaveEnforceHTTPSEnabled"
-    description: "Ensure AWS Elasticsearch domains have `EnforceHTTPS` enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawselasticsearchdomainshaveenforcehttpsenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSElasticsearchHasNodeToNodeEncryptionEnabled"
-    description: "Ensure AWS Elasticsearch has node-to-node encryption enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawselasticsearchhasnodetonodeencryptionenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSIAMPasswordPolicyHasAMinimumOf14Characters"
-    description: "Ensure AWS IAM password policy has a minimum of 14 characters."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawsiampasswordpolicyhasaminimumof14characters"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSLambdaFunctionIsConfiguredForFunctionLevelConcurrentExecutionLimit"
-    description: "Ensure AWS Lambda function is configured for function-level concurrent\
-      \ execution limit."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawslambdafunctionisconfiguredforfunctionlevelconcurrentexecutionlimit"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSLambdaFunctionsHaveTracingEnabled"
-    description: "Ensure AWS Lambda functions have tracing enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawslambdafunctionshavetracingenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSRDSDatabaseInstanceIsNotPubliclyAccessible"
-    description: "Ensure AWS RDS database instance is not publicly accessible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawsrdsdatabaseinstanceisnotpubliclyaccessible"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAWSS3ObjectVersioningIsEnabled"
-    description: "Ensure AWS S3 object versioning is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawss3objectversioningisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureAmazonEKSControlPlaneLoggingEnabledForAllLogTypes"
-    description: "Ensure Amazon EKS control plane logging enabled for all log types."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureamazonekscontrolplaneloggingenabledforalllogtypes"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureCloudTrailLogFileValidationIsEnabled"
-    description: "Ensure CloudTrail log file validation is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurecloudtraillogfilevalidationisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureDataStoredInAnS3BucketIsSecurelyEncryptedAtRest"
-    description: "Ensure data stored in an S3 bucket is securely encrypted at rest."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensuredatastoredinans3bucketissecurelyencryptedatrest"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureDetailedMonitoringForEC2InstancesIsEnabled"
-    description: "Ensure detailed monitoring for EC2 instances is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensuredetailedmonitoringforec2instancesisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureEC2IsEBSOptimized"
-    description: "Ensure EC2 is EBS optimized."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureec2isebsoptimized"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureECRRepositoriesAreEncrypted"
-    description: "Ensure ECR repositories are encrypted."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureecrrepositoriesareencrypted"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureEnhancedMonitoringForAmazonRDSInstancesIsEnabled"
-    description: "Ensure enhanced monitoring for Amazon RDS instances is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureenhancedmonitoringforamazonrdsinstancesisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyExpiresPasswordsWithin90DaysOrLess"
-    description: "Ensure IAM password policy expires passwords within 90 days or less."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyexpirespasswordswithin90daysorless"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyPreventsPasswordReuse"
-    description: "Ensure IAM password policy prevents password reuse."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicypreventspasswordreuse"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneLowercaseLetter"
-    description: "Ensure IAM password policy requires at least one lowercase letter."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyrequiresatleastonelowercaseletter"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneNumber"
-    description: "Ensure IAM password policy requires at least one number."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyrequiresatleastonenumber"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneSymbol"
-    description: "Ensure IAM password policy requires at least one symbol."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyrequiresatleastonesymbol"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneUppercaseLetter"
-    description: "Ensure IAM password policy requires at least one uppercase letter."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyrequiresatleastoneuppercaseletter"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureKinesisStreamIsSecurelyEncrypted"
-    description: "Ensure Kinesis Stream is securely encrypted."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurekinesisstreamissecurelyencrypted"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureRDSDatabaseHasIAMAuthenticationEnabled"
-    description: "Ensure RDS database has IAM authentication enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurerdsdatabasehasiamauthenticationenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureRDSInstancesHaveMultiAZEnabled"
-    description: "Ensure RDS instances have Multi-AZ enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurerdsinstanceshavemultiazenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureRespectiveLogsOfAmazonRDSAreEnabled"
-    description: "Ensure respective logs of Amazon RDS are enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurerespectivelogsofamazonrdsareenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureTheS3BucketHasAccessLoggingEnabled"
-    description: "Ensure the S3 bucket has access logging enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurethes3buckethasaccessloggingenabled"
-    options: []
-  - name: "org.openrewrite.terraform.aws.EnsureVPCSubnetsDoNotAssignPublicIPByDefault"
-    description: "Ensure VPC subnets do not assign public IP by default."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurevpcsubnetsdonotassignpublicipbydefault"
-    options: []
-  - name: "org.openrewrite.terraform.aws.ImmutableECRTags"
-    description: "Amazon ECR supports immutable tags, preventing image tags from being\
-      \ overwritten. In the past, ECR tags could have been overwritten, this could\
-      \ be overcome by requiring users to uniquely identify an image using a naming\
-      \ convention."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/immutableecrtags"
-    options: []
-  - name: "org.openrewrite.terraform.aws.UseHttpsForCloudfrontDistribution"
-    description: "Secure communication by default."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/usehttpsforcloudfrontdistribution"
-    options: []
-  - name: "org.openrewrite.terraform.azure.AzureBestPractices"
-    description: "Securely operate on Microsoft Azure."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/azurebestpractices"
-    options: []
-  - name: "org.openrewrite.terraform.azure.DisableKubernetesDashboard"
-    description: "Disabling the dashboard eliminates it as an attack vector. The dashboard\
-      \ add-on is disabled by default for all new clusters created on Kubernetes 1.18\
-      \ or greater."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/disablekubernetesdashboard"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnableAzureStorageAccountTrustedMicrosoftServicesAccess"
-    description: "Certain Microsoft services that interact with storage accounts operate\
-      \ from networks that cannot be granted access through network rules. Using this\
-      \ configuration, you can allow the set of trusted Microsoft services to bypass\
-      \ those network rules."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/enableazurestorageaccounttrustedmicrosoftservicesaccess"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnableAzureStorageSecureTransferRequired"
-    description: "Microsoft recommends requiring secure transfer for all storage accounts."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/enableazurestoragesecuretransferrequired"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnableGeoRedundantBackupsOnPostgreSQLServer"
-    description: "Ensure PostgreSQL server enables geo-redundant backups."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/enablegeoredundantbackupsonpostgresqlserver"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EncryptAzureVMDataDiskWithADECMK"
-    description: "Ensure Azure VM data disk is encrypted with ADE/CMK."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/encryptazurevmdatadiskwithadecmk"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAKSPoliciesAddOn"
-    description: "Azure Policy Add-on for Kubernetes service (AKS) extends Gatekeeper\
-      \ v3, an admission controller webhook for Open Policy Agent (OPA), to apply\
-      \ at-scale enforcements and safeguards on your clusters in a centralized, consistent\
-      \ manner."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureakspoliciesaddon"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAKVSecretsHaveAnExpirationDateSet"
-    description: "Ensure AKV secrets have an expiration date set."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureakvsecretshaveanexpirationdateset"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureASecurityContactPhoneNumberIsPresent"
-    description: "Ensure a security contact phone number is present."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureasecuritycontactphonenumberispresent"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureActivityLogRetentionIsSetTo365DaysOrGreater"
-    description: "Ensure activity log retention is set to 365 days or greater."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureactivitylogretentionissetto365daysorgreater"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAllKeysHaveAnExpirationDate"
-    description: "Ensure all keys have an expiration date."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureallkeyshaveanexpirationdate"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAppServiceEnablesDetailedErrorMessages"
-    description: "Ensure app service enables detailed error messages."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureappserviceenablesdetailederrormessages"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAppServiceEnablesFailedRequestTracing"
-    description: "Ensure app service enables failed request tracing."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureappserviceenablesfailedrequesttracing"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAppServiceEnablesHTTPLogging"
-    description: "Ensure app service enables HTTP logging."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureappserviceenableshttplogging"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAppServicesUseAzureFiles"
-    description: "Ensure app services use Azure files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureappservicesuseazurefiles"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAzureAppServiceWebAppRedirectsHTTPToHTTPS"
-    description: "Ensure Azure App Service Web app redirects HTTP to HTTPS."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazureappservicewebappredirectshttptohttps"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAzureApplicationGatewayHasWAFEnabled"
-    description: "Ensure Azure application gateway has WAF enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazureapplicationgatewayhaswafenabled"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAzureKeyVaultIsRecoverable"
-    description: "Ensure Azure key vault is recoverable."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazurekeyvaultisrecoverable"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAzureNetworkWatcherNSGFlowLogsRetentionIsGreaterThan90Days"
-    description: "Ensure Azure Network Watcher NSG flow logs retention is greater\
-      \ than 90 days."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazurenetworkwatchernsgflowlogsretentionisgreaterthan90days"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAzurePostgreSQLDatabaseServerWithSSLConnectionIsEnabled"
-    description: "Ensure Azure PostgreSQL database server with SSL connection is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazurepostgresqldatabaseserverwithsslconnectionisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAzureSQLServerAuditLogRetentionIsGreaterThan90Days"
-    description: "Ensure Azure SQL server audit log retention is greater than 90 days."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazuresqlserverauditlogretentionisgreaterthan90days"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAzureSQLServerSendAlertsToFieldValueIsSet"
-    description: "Ensure Azure SQL server send alerts to field value is set."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazuresqlserversendalertstofieldvalueisset"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureAzureSQLServerThreatDetectionAlertsAreEnabledForAllThreatTypes"
-    description: "Ensure Azure SQL Server threat detection alerts are enabled for\
-      \ all threat types."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazuresqlserverthreatdetectionalertsareenabledforallthreattypes"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureFTPDeploymentsAreDisabled"
-    description: "Ensure FTP Deployments are disabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureftpdeploymentsaredisabled"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureKeyVaultAllowsFirewallRulesSettings"
-    description: "Ensure key vault allows firewall rules settings."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurekeyvaultallowsfirewallrulessettings"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureKeyVaultEnablesPurgeProtection"
-    description: "Ensure key vault enables purge protection."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurekeyvaultenablespurgeprotection"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureKeyVaultKeyIsBackedByHSM"
-    description: "Ensure key vault key is backed by HSM."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurekeyvaultkeyisbackedbyhsm"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureKeyVaultSecretsHaveContentTypeSet"
-    description: "Ensure key vault secrets have `content_type` set."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurekeyvaultsecretshavecontenttypeset"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureLogProfileIsConfiguredToCaptureAllActivities"
-    description: "Ensure log profile is configured to capture all activities."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurelogprofileisconfiguredtocaptureallactivities"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureMSSQLServersHaveEmailServiceAndCoAdministratorsEnabled"
-    description: "Ensure MSSQL servers have email service and co-administrators enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremssqlservershaveemailserviceandcoadministratorsenabled"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureManagedIdentityProviderIsEnabledForAppServices"
-    description: "Ensure managed identity provider is enabled for app services."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremanagedidentityproviderisenabledforappservices"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureMySQLIsUsingTheLatestVersionOfTLSEncryption"
-    description: "Ensure MySQL is using the latest version of TLS encryption."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlisusingthelatestversionoftlsencryption"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureMySQLServerDatabasesHaveEnforceSSLConnectionEnabled"
-    description: "Ensure MySQL server databases have Enforce SSL connection enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlserverdatabaseshaveenforcesslconnectionenabled"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureMySQLServerDisablesPublicNetworkAccess"
-    description: "Ensure MySQL server disables public network access."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlserverdisablespublicnetworkaccess"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureMySQLServerEnablesGeoRedundantBackups"
-    description: "Ensure MySQL server enables geo-redundant backups."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlserverenablesgeoredundantbackups"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureMySQLServerEnablesThreatDetectionPolicy"
-    description: "Ensure MySQL server enables Threat Detection policy."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlserverenablesthreatdetectionpolicy"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsurePostgreSQLServerDisablesPublicNetworkAccess"
-    description: "Ensure PostgreSQL server disables public network access."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurepostgresqlserverdisablespublicnetworkaccess"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsurePostgreSQLServerEnablesInfrastructureEncryption"
-    description: "Ensure PostgreSQL server enables infrastructure encryption."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurepostgresqlserverenablesinfrastructureencryption"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsurePostgreSQLServerEnablesThreatDetectionPolicy"
-    description: "Ensure PostgreSQL server enables Threat Detection policy."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurepostgresqlserverenablesthreatdetectionpolicy"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsurePublicNetworkAccessEnabledIsSetToFalseForMySQLServers"
-    description: "Ensure public network access enabled is set to False for mySQL servers."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurepublicnetworkaccessenabledissettofalseformysqlservers"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureSendEmailNotificationForHighSeverityAlertsIsEnabled"
-    description: "Ensure Send email notification for high severity alerts is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuresendemailnotificationforhighseverityalertsisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureSendEmailNotificationForHighSeverityAlertsToAdminsIsEnabled"
-    description: "Ensure Send email notification for high severity alerts to admins\
-      \ is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuresendemailnotificationforhighseverityalertstoadminsisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureStandardPricingTierIsSelected"
-    description: "Ensure standard pricing tier is selected."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurestandardpricingtierisselected"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureStorageAccountUsesLatestTLSVersion"
-    description: "Communication between an Azure Storage account and a client application\
-      \ is encrypted using Transport Layer Security (TLS). Microsoft recommends using\
-      \ the latest version of TLS for all your Microsoft Azure App Service web applications."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurestorageaccountuseslatesttlsversion"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureTheStorageContainerStoringActivityLogsIsNotPubliclyAccessible"
-    description: "Ensure the storage container storing activity logs is not publicly\
-      \ accessible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurethestoragecontainerstoringactivitylogsisnotpubliclyaccessible"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureWebAppHasIncomingClientCertificatesEnabled"
-    description: "Ensure Web App has incoming client certificates enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurewebapphasincomingclientcertificatesenabled"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureWebAppUsesTheLatestVersionOfHTTP"
-    description: "Ensure Web App uses the latest version of HTTP."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurewebappusesthelatestversionofhttp"
-    options: []
-  - name: "org.openrewrite.terraform.azure.EnsureWebAppUsesTheLatestVersionOfTLSEncryption"
-    description: "Ensure Web App uses the latest version of TLS encryption."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurewebappusesthelatestversionoftlsencryption"
-    options: []
-  - name: "org.openrewrite.terraform.azure.SetAzureStorageAccountDefaultNetworkAccessToDeny"
-    description: "Ensure Azure Storage Account default network access is set to Deny."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/setazurestorageaccountdefaultnetworkaccesstodeny"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnablePodSecurityPolicyControllerOnGKEClusters"
-    description: "Ensure `PodSecurityPolicy` controller is enabled on Google Kubernetes\
-      \ Engine (GKE) clusters."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/enablepodsecuritypolicycontrollerongkeclusters"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnableVPCFlowLogsAndIntranodeVisibility"
-    description: "Enable VPC flow logs and intranode visibility."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/enablevpcflowlogsandintranodevisibility"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnableVPCFlowLogsForSubnetworks"
-    description: "Ensure GCP VPC flow logs for subnets are enabled. Flow Logs capture\
-      \ information on IP traffic moving through network interfaces. This information\
-      \ can be used to monitor anomalous traffic and provide security insights."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/enablevpcflowlogsforsubnetworks"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureBinaryAuthorizationIsUsed"
-    description: "Ensure binary authorization is used."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensurebinaryauthorizationisused"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureComputeInstancesLaunchWithShieldedVMEnabled"
-    description: "Ensure compute instances launch with shielded VM enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensurecomputeinstanceslaunchwithshieldedvmenabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureGCPCloudStorageBucketWithUniformBucketLevelAccessAreEnabled"
-    description: "Ensure GCP cloud storage bucket with uniform bucket-level access\
-      \ are enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuregcpcloudstoragebucketwithuniformbucketlevelaccessareenabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureGCPKubernetesClusterNodeAutoRepairConfigurationIsEnabled"
-    description: "Ensure GCP Kubernetes cluster node auto-repair configuration is\
-      \ enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuregcpkubernetesclusternodeautorepairconfigurationisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureGCPKubernetesEngineClustersHaveLegacyComputeEngineMetadataEndpointsDisabled"
-    description: "Ensure GCP Kubernetes engine clusters have legacy compute engine\
-      \ metadata endpoints disabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuregcpkubernetesengineclustershavelegacycomputeenginemetadataendpointsdisabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureGCPVMInstancesHaveBlockProjectWideSSHKeysFeatureEnabled"
-    description: "Ensure GCP VM instances have block project-wide SSH keys feature\
-      \ enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuregcpvminstanceshaveblockprojectwidesshkeysfeatureenabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureIPForwardingOnInstancesIsDisabled"
-    description: "Ensure IP forwarding on instances is disabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensureipforwardingoninstancesisdisabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsurePrivateClusterIsEnabledWhenCreatingKubernetesClusters"
-    description: "Ensure private cluster is enabled when creating Kubernetes clusters."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensureprivateclusterisenabledwhencreatingkubernetesclusters"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureSecureBootForShieldedGKENodesIsEnabled"
-    description: "Ensure secure boot for shielded GKE nodes is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuresecurebootforshieldedgkenodesisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureShieldedGKENodesAreEnabled"
-    description: "Ensure shielded GKE nodes are enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensureshieldedgkenodesareenabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.EnsureTheGKEMetadataServerIsEnabled"
-    description: "Ensure the GKE metadata server is enabled."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensurethegkemetadataserverisenabled"
-    options: []
-  - name: "org.openrewrite.terraform.gcp.GCPBestPractices"
-    description: "Securely operate on Google Cloud Platform."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/gcpbestpractices"
-    options: []
-  - name: "org.openrewrite.terraform.search.FindResource"
-    description: "Find a Terraform resource by resource type."
-    docLink: "https://docs.openrewrite.org/reference/recipes/terraform/search/findresource"
-    options:
-    - name: "resourceName"
-      type: "String"
-      required: true
-- artifactId: "rewrite-testing-frameworks"
-  version: "1.30.0"
+    org.openrewrite.json.ChangeKey:
+      name: "org.openrewrite.json.ChangeKey"
+      description: "Change a JSON mapping entry key leaving the value intact."
+      docLink: "https://docs.openrewrite.org/reference/recipes/json/changekey"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newKey"
+        type: "String"
+        required: true
+      - name: "oldKeyPath"
+        type: "String"
+        required: true
+    org.openrewrite.json.ChangeValue:
+      name: "org.openrewrite.json.ChangeValue"
+      description: "Change a JSON mapping entry value leaving the key intact."
+      docLink: "https://docs.openrewrite.org/reference/recipes/json/changevalue"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "oldKeyPath"
+        type: "String"
+        required: true
+      - name: "value"
+        type: "String"
+        required: true
+    org.openrewrite.json.DeleteKey:
+      name: "org.openrewrite.json.DeleteKey"
+      description: "Delete a JSON mapping entry key."
+      docLink: "https://docs.openrewrite.org/reference/recipes/json/deletekey"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "keyPath"
+        type: "String"
+        required: true
+    org.openrewrite.json.search.FindKey:
+      name: "org.openrewrite.json.search.FindKey"
+      description: "Find JSON object members by JsonPath expression."
+      docLink: "https://docs.openrewrite.org/reference/recipes/json/search/findkey"
+      options:
+      - name: "key"
+        type: "String"
+        required: true
+rewrite-kubernetes:
+  artifactId: "rewrite-kubernetes"
+  version: "1.25.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.java.testing.assertj.Assertj"
-    description: "Migrates JUnit asserts to AssertJ and applies best practices to\
-      \ assertions."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/assertj"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertArrayEqualsToAssertThat"
-    description: "Convert JUnit-style `assertArrayEquals()` to assertJ's `assertThat().contains()`\
-      \ equivalents."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertarrayequalstoassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertEqualsToAssertThat"
-    description: "Convert JUnit-style `assertEquals()` to AssertJ's `assertThat().isEqualTo()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertequalstoassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertFalseToAssertThat"
-    description: "Convert JUnit-style `assertFalse()` to AssertJ's `assertThat().isFalse()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertfalsetoassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertNotEqualsToAssertThat"
-    description: "Convert JUnit-style `assertNotEquals()` to AssertJ's `assertThat().isNotEqualTo()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertnotequalstoassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertNotNullToAssertThat"
-    description: "Convert JUnit-style `assertNotNull()` to AssertJ's `assertThat().isNotNull()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertnotnulltoassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertNullToAssertThat"
-    description: "Convert JUnit-style `assertNull()` to AssertJ's `assertThat().isNull()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertnulltoassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertSameToAssertThat"
-    description: "Convert JUnit-style `assertSame()` to AssertJ's `assertThat().isSameAs()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertsametoassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertThrowsToAssertExceptionType"
-    description: "Convert `JUnit#AssertThrows` to `AssertJ#assertThatExceptionOfType`\
-      \ to allow for chained assertions on the thrown exception."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertthrowstoassertexceptiontype"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitAssertTrueToAssertThat"
-    description: "Convert JUnit-style `assertTrue()` to AssertJ's `assertThat().isTrue()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitasserttruetoassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitFailToAssertJFail"
-    description: "Convert JUnit-style `fail()` to AssertJ's `fail()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitfailtoassertjfail"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.JUnitToAssertj"
-    description: "AssertJ provides a rich set of assertions, truly helpful error messages,\
-      \ improves test code readability."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junittoassertj"
-    options: []
-  - name: "org.openrewrite.java.testing.assertj.StaticImports"
-    description: "Consistently use a static import rather than inlining the `Assertions`\
-      \ class name in tests."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/staticimports"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.AssertEqualsNullToAssertNull"
-    description: "Using `assertNull(a)` is simpler and more clear."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertequalsnulltoassertnull"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.AssertFalseEqualsToAssertNotEquals"
-    description: "Using `assertNotEquals(a,b)` is simpler and more clear."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertfalseequalstoassertnotequals"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.AssertFalseNegationToAssertTrue"
-    description: "Using `assertTrue` is simpler and more clear."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertfalsenegationtoasserttrue"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.AssertFalseNullToAssertNotNull"
-    description: "Using `assertNotNull(a)` is simpler and more clear."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertfalsenulltoassertnotnull"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.AssertTrueComparisonToAssertEquals"
-    description: "Using `assertEquals(a,b)` is simpler and more clear."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/asserttruecomparisontoassertequals"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.AssertTrueEqualsToAssertEquals"
-    description: "Using `assertEquals(a,b)` is simpler and more clear."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/asserttrueequalstoassertequals"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.AssertTrueNegationToAssertFalse"
-    description: "Using `assertFalse` is simpler and more clear."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/asserttruenegationtoassertfalse"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.AssertTrueNullToAssertNull"
-    description: "Using `assertNull(a)` is simpler and more clear."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/asserttruenulltoassertnull"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.BestPractices"
-    description: "Applies best practices to tests."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/bestpractices"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.RemoveEmptyTests"
-    description: "Removes empty methods with a `@Test` annotation if the body does\
-      \ not have comments."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/removeemptytests"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.RemoveTestPrefix"
-    description: "Remove `test` from methods with `@Test`, `@ParameterizedTest`, `@RepeatedTest`\
-      \ or `@TestFactory`. They no longer have to prefix test to be usable by JUnit\
-      \ 5."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/removetestprefix"
-    options: []
-  - name: "org.openrewrite.java.testing.cleanup.TestsShouldIncludeAssertions"
-    description: "For tests not having any assertions, wrap the statements with JUnit\
-      \ Jupiter's `Assertions#assertThrowDoesNotThrow(..)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/testsshouldincludeassertions"
-    options:
-    - name: "additionalAsserts"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic"
-    description: "Remove `public` and optionally `protected` modifiers from methods\
-      \ with `@Test`, `@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`, `@BeforeEach`\
-      \ or `@AfterEach`. They no longer have to be public visibility to be usable\
-      \ by JUnit 5."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/testsshouldnotbepublic"
-    options:
-    - name: "removeProtectedModifiers"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.java.testing.cucumber.CucumberAnnotationToSuite"
-    description: "Replace @Cucumber with @Suite and @SelectClasspathResource(\"cucumber/annotated/class/package\"\
-      )."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumberannotationtosuite"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.CucumberJava8HookDefinitionToCucumberJava"
-    description: "Replace LamdbaGlue hook definitions with new annotated methods with\
-      \ the same body"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumberjava8hookdefinitiontocucumberjava"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.CucumberJava8StepDefinitionToCucumberJava"
-    description: "Replace StepDefinitionBody methods with StepDefinitionAnnotations\
-      \ on new methods with the same body"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumberjava8stepdefinitiontocucumberjava"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.CucumberJava8ToJava"
-    description: "Migrates Cucumber-Java8 step definitions and LambdaGlue hooks to\
-      \ Cucumber-Java annotated methods."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumberjava8tojava"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.CucumberToJunitPlatformSuite"
-    description: "Migrates Cucumber tests to Junit Test Suites."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumbertojunitplatformsuite"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.DropSummaryPrinter"
-    description: "Replace SummaryPrinter with Plugin, if not already present."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/dropsummaryprinter"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.RegexToCucumberExpression"
-    description: "Strip regex prefix and suffix from step annotation expressions arguments\
-      \ where possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/regextocucumberexpression"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.UpgradeCucumber2x"
-    description: "Upgrade to Cucumber-JVM 2.x from any previous version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/upgradecucumber2x"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.UpgradeCucumber5x"
-    description: "Upgrade to Cucumber-JVM 5.x from any previous version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/upgradecucumber5x"
-    options: []
-  - name: "org.openrewrite.java.testing.cucumber.UpgradeCucumber7x"
-    description: "Upgrade to Cucumber-JVM 7.x from any previous version."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/upgradecucumber7x"
-    options: []
-  - name: "org.openrewrite.java.testing.hamcrest.AddHamcrestIfUsed"
-    description: "JUnit Jupiter does not include hamcrest as a transitive dependency.\
-      \ If needed, add a direct dependency."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/hamcrest/addhamcrestifused"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.AddMissingNested"
-    description: "Adds `@Nested` to inner classes that contain JUnit 5 tests."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/addmissingnested"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.AssertToAssertions"
-    description: "Change JUnit 4's `org.junit.Assert` into JUnit Jupiter's `org.junit.jupiter.api.Assertions`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/asserttoassertions"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.CategoryToTag"
-    description: "Transforms the JUnit 4 `@Category`, which can list multiple categories,\
-      \ into one `@Tag` annotation per category listed."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/categorytotag"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.CleanupAssertions"
-    description: "Simplifies JUnit Jupiter assertions to their most-direct equivalents"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/cleanupassertions"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.CleanupJUnitImports"
-    description: "Removes unused `org.junit` import symbols."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/cleanupjunitimports"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.EnclosedToNested"
-    description: "Removes the `Enclosed` specification from a class, and adds `Nested`\
-      \ to its inner classes"
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/enclosedtonested"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.ExpectedExceptionToAssertThrows"
-    description: "Replace usages of JUnit 4's `@Rule ExpectedException` with JUnit\
-      \ 5's `Assertions.assertThrows()`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/expectedexceptiontoassertthrows"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.IgnoreToDisabled"
-    description: "Migrates JUnit 4.x `@Ignore` to JUnit Jupiter `@Disabled`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/ignoretodisabled"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.JUnit4to5Migration"
-    description: "Migrates JUnit 4.x tests to JUnit Jupiter."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/junit4to5migration"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.JUnit5BestPractices"
-    description: "Applies best practices to tests."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/junit5bestpractices"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.JUnitParamsRunnerToParameterized"
-    description: "Convert Pragmatists Parameterized test to the JUnit Jupiter ParameterizedTest\
-      \ equivalent."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/junitparamsrunnertoparameterized"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.LifecycleNonPrivate"
-    description: "Make JUnit 5's `@AfterAll`, `@AfterEach`, `@BeforeAll` and `@BeforeEach`\
-      \ non private."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/lifecyclenonprivate"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.MigrateJUnitTestCase"
-    description: "Convert JUnit 4 `TestCase` to JUnit Jupiter."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/migratejunittestcase"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension"
-    description: "Replaces `MockitoJUnit` rules with `MockitoExtension`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/mockitojunittomockitoextension"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.ParameterizedRunnerToParameterized"
-    description: "Convert JUnit4 parameterized runner the JUnit Jupiter parameterized\
-      \ test equivalent."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/parameterizedrunnertoparameterized"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.RemoveObsoleteRunners"
-    description: "Some JUnit4 `@RunWith` annotations do not require replacement with\
-      \ an equivalent JUnit Jupiter `@ExtendsWith` annotation. This can be used to\
-      \ remove those runners that either do not have a JUnit Jupiter equivalent or\
-      \ do not require a replacement as part of JUnit 4 to 5 migration."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/removeobsoleterunners"
-    options:
-    - name: "obsoleteRunners"
-      type: "List"
-      required: true
-  - name: "org.openrewrite.java.testing.junit5.RunnerToExtension"
-    description: "Replace runners with the JUnit Jupiter extension equivalent."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/runnertoextension"
-    options:
-    - name: "extension"
-      type: "String"
-      required: true
-    - name: "runners"
-      type: "List"
-      required: true
-  - name: "org.openrewrite.java.testing.junit5.StaticImports"
-    description: "Always use a static import for assertion methods."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/staticimports"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.TempDirNonFinal"
-    description: "Make JUnit 5's `org.junit.jupiter.api.io.TempDir` fields non final."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/tempdirnonfinal"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.TemporaryFolderToTempDir"
-    description: "Translates JUnit4's `org.junit.rules.TemporaryFolder` into JUnit\
-      \ 5's `org.junit.jupiter.api.io.TempDir`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/temporaryfoldertotempdir"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.TestRuleToTestInfo"
-    description: "Replace usages of JUnit 4's `@Rule TestName` with JUnit 5's TestInfo."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/testruletotestinfo"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.UpdateBeforeAfterAnnotations"
-    description: "Replace JUnit 4's `@Before`, `@BeforeClass`, `@After`, and `@AfterClass`\
-      \ annotations with their JUnit Jupiter equivalents."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/updatebeforeafterannotations"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.UpdateMockWebServer"
-    description: "Replace usages of okhttp3 3.x @Rule MockWebServer with 4.x MockWebServer."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/updatemockwebserver"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.UpdateTestAnnotation"
-    description: "Update usages of JUnit 4's `@org.junit.Test` annotation to JUnit5's\
-      \ `org.junit.jupiter.api.Test` annotation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/updatetestannotation"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.UseHamcrestAssertThat"
-    description: "JUnit 4's `Assert#assertThat(..)` This method was deprecated in\
-      \ JUnit 4 and removed in JUnit Jupiter."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/usehamcrestassertthat"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.UseMockitoExtension"
-    description: "Migrate uses of `@RunWith(MockitoJUnitRunner.class)` (and similar\
-      \ annotations) to `@ExtendWith(MockitoExtension.class)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/usemockitoextension"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.UseTestMethodOrder"
-    description: "JUnit optionally allows test method execution order to be specified.\
-      \ This Recipe replaces JUnit4 test execution ordering annotations with JUnit5\
-      \ replacements."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/usetestmethodorder"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.UseWiremockExtension"
-    description: "As of 2.31.0, wiremock [supports JUnit 5](http://wiremock.org/docs/junit-jupiter/)\
-      \ via an extension."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/usewiremockextension"
-    options: []
-  - name: "org.openrewrite.java.testing.junit5.VertxUnitToVertxJunit5"
-    description: "Migrates Vertx `@RunWith` `VertxUnitRunner` to the JUnit Jupiter\
-      \ `@ExtendWith` `VertxExtension`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/vertxunittovertxjunit5"
-    options: []
-  - name: "org.openrewrite.java.testing.mockito.CleanupMockitoImports"
-    description: "Removes unused `org.mockito` import symbols, unless its possible\
-      \ they are associated with method invocations having null or unknown type information."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/cleanupmockitoimports"
-    options: []
-  - name: "org.openrewrite.java.testing.mockito.MockUtilsToStatic"
-    description: "Best-effort attempt to remove Mockito `MockUtil` instances."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/mockutilstostatic"
-    options: []
-  - name: "org.openrewrite.java.testing.mockito.Mockito1to3Migration"
-    description: "Upgrade Mockito from 1.x to 3.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/mockito1to3migration"
-    options: []
-  - name: "org.openrewrite.java.testing.mockito.Mockito1to4Migration"
-    description: "Upgrade Mockito from 1.x to 4.x."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/mockito1to4migration"
-    options: []
-  - name: "org.openrewrite.java.testing.mockito.MockitoJUnitRunnerSilentToExtension"
-    description: "Replace `@RunWith(MockitoJUnitRunner.Silent.class)` with `@ExtendWith(MockitoExtension.class)`\
-      \ and `@MockitoSettings(strictness = Strictness.LENIENT)`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/mockitojunitrunnersilenttoextension"
-    options: []
-- artifactId: "rewrite-xml"
-  version: "7.32.1"
+    org.openrewrite.kubernetes.AddConfiguration:
+      name: "org.openrewrite.kubernetes.AddConfiguration"
+      description: "Add default required configuration when it is missing."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/addconfiguration"
+      options:
+      - name: "apiVersion"
+        type: "String"
+        required: false
+      - name: "configurationPath"
+        type: "String"
+        required: true
+      - name: "resourceKind"
+        type: "String"
+        required: true
+      - name: "value"
+        type: "String"
+        required: true
+    org.openrewrite.kubernetes.ImagePullPolicyAlways:
+      name: "org.openrewrite.kubernetes.ImagePullPolicyAlways"
+      description: "Ensures the latest version of a tag is deployed each time."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/imagepullpolicyalways"
+      options: []
+    org.openrewrite.kubernetes.KubernetesBestPractices:
+      name: "org.openrewrite.kubernetes.KubernetesBestPractices"
+      description: "Applies best practices to Kubernetes manifests."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/kubernetesbestpractices"
+      options: []
+    org.openrewrite.kubernetes.LifecycleRuleOnStorageBucket:
+      name: "org.openrewrite.kubernetes.LifecycleRuleOnStorageBucket"
+      description: "When defining a rule, you can specify any set of conditions for\
+        \ any action. The following configuration defines a rule to delete all objects\
+        \ older than 7 days in a bucket."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/lifecycleruleonstoragebucket"
+      options: []
+    org.openrewrite.kubernetes.LimitContainerCapabilities:
+      name: "org.openrewrite.kubernetes.LimitContainerCapabilities"
+      description: "Limiting the admission of containers with capabilities ensures\
+        \ that only a small number of containers have extended capabilities outside\
+        \ the default range."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/limitcontainercapabilities"
+      options: []
+    org.openrewrite.kubernetes.MissingCpuLimits:
+      name: "org.openrewrite.kubernetes.MissingCpuLimits"
+      description: "A system without managed quotas could eventually collapse due\
+        \ to inadequate resources for the tasks it bares."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingcpulimits"
+      options: []
+    org.openrewrite.kubernetes.MissingCpuRequest:
+      name: "org.openrewrite.kubernetes.MissingCpuRequest"
+      description: "If a container is created in a namespace that has a default CPU\
+        \ limit, and the container does not specify its own CPU limit, then the container\
+        \ is assigned the default CPU limit."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingcpurequest"
+      options: []
+    org.openrewrite.kubernetes.MissingMemoryLimits:
+      name: "org.openrewrite.kubernetes.MissingMemoryLimits"
+      description: "With no limit set, kubectl allocates more and more memory to the\
+        \ container until it runs out."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingmemorylimits"
+      options: []
+    org.openrewrite.kubernetes.MissingMemoryRequest:
+      name: "org.openrewrite.kubernetes.MissingMemoryRequest"
+      description: "A container is guaranteed to have as much memory as it requests,\
+        \ but is not allowed to use more memory than the limit set. This configuration\
+        \ may save resources and prevent an attack on an exploited container."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingmemoryrequest"
+      options: []
+    org.openrewrite.kubernetes.MissingPodLivenessProbe:
+      name: "org.openrewrite.kubernetes.MissingPodLivenessProbe"
+      description: "The kubelet uses liveness probes to know when to schedule restarts\
+        \ for containers. Restarting a container in a deadlock state can help to make\
+        \ the application more available, despite bugs."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingpodlivenessprobe"
+      options: []
+    org.openrewrite.kubernetes.MissingPodReadinessProbe:
+      name: "org.openrewrite.kubernetes.MissingPodReadinessProbe"
+      description: "Using the Readiness Probe ensures teams define what actions need\
+        \ to be taken to prevent failure and ensure recovery in case of unexpected\
+        \ errors."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/missingpodreadinessprobe"
+      options: []
+    org.openrewrite.kubernetes.NoHostIPCSharing:
+      name: "org.openrewrite.kubernetes.NoHostIPCSharing"
+      description: "Preventing sharing of host PID/IPC namespace, networking, and\
+        \ ports ensures proper isolation between Docker containers and the underlying\
+        \ host."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/nohostipcsharing"
+      options: []
+    org.openrewrite.kubernetes.NoHostNetworkSharing:
+      name: "org.openrewrite.kubernetes.NoHostNetworkSharing"
+      description: "When using the host network mode for a container, that container’\
+        s network stack is not isolated from the Docker host, so the container shares\
+        \ the host’s networking namespace and does not get its own IP-address allocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/nohostnetworksharing"
+      options: []
+    org.openrewrite.kubernetes.NoHostProcessIdSharing:
+      name: "org.openrewrite.kubernetes.NoHostProcessIdSharing"
+      description: "Sharing the host process ID namespace breaks the isolation between\
+        \ container images and can make processes visible to other containers in the\
+        \ pod. This includes all information in the /proc directory, which can sometimes\
+        \ include passwords or keys, passed as environment variables."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/nohostprocessidsharing"
+      options: []
+    org.openrewrite.kubernetes.NoPrivilegeEscalation:
+      name: "org.openrewrite.kubernetes.NoPrivilegeEscalation"
+      description: "Does not allow a process to gain more privileges than its parent\
+        \ process."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/noprivilegeescalation"
+      options: []
+    org.openrewrite.kubernetes.NoPrivilegedContainers:
+      name: "org.openrewrite.kubernetes.NoPrivilegedContainers"
+      description: "Privileged containers are containers that have all of the root\
+        \ capabilities of a host machine, allowing access to resources that are not\
+        \ accessible in ordinary containers."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/noprivilegedcontainers"
+      options: []
+    org.openrewrite.kubernetes.NoRootContainers:
+      name: "org.openrewrite.kubernetes.NoRootContainers"
+      description: "Containers that run as root frequently have more permissions than\
+        \ their workload requires which, in case of compromise, could help an attacker\
+        \ further their exploits."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/norootcontainers"
+      options: []
+    org.openrewrite.kubernetes.ReadOnlyRootFilesystem:
+      name: "org.openrewrite.kubernetes.ReadOnlyRootFilesystem"
+      description: "Using an immutable root filesystem and a verified boot mechanism\
+        \ prevents against attackers from \"owning\" the machine through permanent\
+        \ local changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/readonlyrootfilesystem"
+      options: []
+    org.openrewrite.kubernetes.UpdateContainerImageName:
+      name: "org.openrewrite.kubernetes.UpdateContainerImageName"
+      description: "Search for image names that match patterns and replace the components\
+        \ of the name with new values."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/updatecontainerimagename"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "imageToFind"
+        type: "String"
+        required: true
+      - name: "imageToUpdate"
+        type: "String"
+        required: false
+      - name: "includeInitContainers"
+        type: "boolean"
+        required: false
+      - name: "repoToFind"
+        type: "String"
+        required: false
+      - name: "repoToUpdate"
+        type: "String"
+        required: false
+      - name: "tagToFind"
+        type: "String"
+        required: false
+      - name: "tagToUpdate"
+        type: "String"
+        required: false
+    org.openrewrite.kubernetes.rbac.AddRuleToRole:
+      name: "org.openrewrite.kubernetes.rbac.AddRuleToRole"
+      description: "Add RBAC rules to ClusterRoles or namespaced Roles."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/rbac/addruletorole"
+      options:
+      - name: "apiGroups"
+        type: "Set"
+        required: true
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "rbacResourceName"
+        type: "String"
+        required: true
+      - name: "rbacResourceType"
+        type: "String"
+        required: true
+      - name: "resourceNames"
+        type: "Set"
+        required: false
+      - name: "resources"
+        type: "Set"
+        required: true
+      - name: "verbs"
+        type: "Set"
+        required: true
+    org.openrewrite.kubernetes.resource.CapResourceValueToMaximum:
+      name: "org.openrewrite.kubernetes.resource.CapResourceValueToMaximum"
+      description: "Cap resource values that exceed a specific maximum."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/resource/capresourcevaluetomaximum"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "resourceLimit"
+        type: "String"
+        required: true
+      - name: "resourceType"
+        type: "String"
+        required: true
+      - name: "resourceValueType"
+        type: "String"
+        required: true
+    org.openrewrite.kubernetes.resource.FindExceedsResourceRatio:
+      name: "org.openrewrite.kubernetes.resource.FindExceedsResourceRatio"
+      description: "Find resource manifests that have requests to limits ratios beyond\
+        \ a specific maximum."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/resource/findexceedsresourceratio"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "ratioLimit"
+        type: "String"
+        required: true
+      - name: "resourceType"
+        type: "String"
+        required: true
+    org.openrewrite.kubernetes.resource.FindExceedsResourceValue:
+      name: "org.openrewrite.kubernetes.resource.FindExceedsResourceValue"
+      description: "Find resource manifests that have limits set beyond a specific\
+        \ maximum."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/resource/findexceedsresourcevalue"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "resourceLimit"
+        type: "String"
+        required: true
+      - name: "resourceType"
+        type: "String"
+        required: true
+      - name: "resourceValueType"
+        type: "String"
+        required: true
+    org.openrewrite.kubernetes.search.FindAnnotation:
+      name: "org.openrewrite.kubernetes.search.FindAnnotation"
+      description: "Find annotations that optionally match a given regex."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findannotation"
+      options:
+      - name: "annotationName"
+        type: "String"
+        required: true
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "value"
+        type: "String"
+        required: false
+    org.openrewrite.kubernetes.search.FindDisallowedImageTags:
+      name: "org.openrewrite.kubernetes.search.FindDisallowedImageTags"
+      description: "The set of image tags to find which are considered disallowed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/finddisallowedimagetags"
+      options:
+      - name: "disallowedTags"
+        type: "Set"
+        required: true
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "includeInitContainers"
+        type: "boolean"
+        required: false
+    org.openrewrite.kubernetes.search.FindImage:
+      name: "org.openrewrite.kubernetes.search.FindImage"
+      description: "The image name to search for in containers and initContainers."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findimage"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "imageName"
+        type: "String"
+        required: true
+      - name: "imageTag"
+        type: "String"
+        required: false
+      - name: "includeInitContainers"
+        type: "boolean"
+        required: false
+      - name: "repository"
+        type: "String"
+        required: false
+    org.openrewrite.kubernetes.search.FindMissingDigest:
+      name: "org.openrewrite.kubernetes.search.FindMissingDigest"
+      description: "Find instances of a container name that fails to specify a digest."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findmissingdigest"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "includeInitContainers"
+        type: "boolean"
+        required: false
+    org.openrewrite.kubernetes.search.FindMissingOrInvalidAnnotation:
+      name: "org.openrewrite.kubernetes.search.FindMissingOrInvalidAnnotation"
+      description: "Find annotations that optionally match a given value."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findmissingorinvalidannotation"
+      options:
+      - name: "annotationName"
+        type: "String"
+        required: true
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "value"
+        type: "String"
+        required: false
+    org.openrewrite.kubernetes.search.FindMissingOrInvalidLabel:
+      name: "org.openrewrite.kubernetes.search.FindMissingOrInvalidLabel"
+      description: "Find labels that optionally match a given regex."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findmissingorinvalidlabel"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "labelName"
+        type: "String"
+        required: true
+      - name: "value"
+        type: "String"
+        required: false
+    org.openrewrite.kubernetes.search.FindNonTlsIngress:
+      name: "org.openrewrite.kubernetes.search.FindNonTlsIngress"
+      description: "Find Ingress resources that don't disallow HTTP or don't have\
+        \ TLS configured."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findnontlsingress"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+    org.openrewrite.kubernetes.search.FindResourceMissingConfiguration:
+      name: "org.openrewrite.kubernetes.search.FindResourceMissingConfiguration"
+      description: "Find Kubernetes resources with missing configuration."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/search/findresourcemissingconfiguration"
+      options:
+      - name: "configurationPath"
+        type: "String"
+        required: true
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "resourceKind"
+        type: "String"
+        required: false
+    org.openrewrite.kubernetes.services.FindServiceExternalIPs:
+      name: "org.openrewrite.kubernetes.services.FindServiceExternalIPs"
+      description: "Find any `Service` whose `externalIP` list contains, or does not\
+        \ contain, one of a list of IPs."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/services/findserviceexternalips"
+      options:
+      - name: "externalIPs"
+        type: "Set"
+        required: true
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "findMissing"
+        type: "boolean"
+        required: false
+    org.openrewrite.kubernetes.services.FindServicesByType:
+      name: "org.openrewrite.kubernetes.services.FindServicesByType"
+      description: "Type of Kubernetes `Service` to find."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/services/findservicesbytype"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "serviceType"
+        type: "String"
+        required: true
+    org.openrewrite.kubernetes.services.UpdateServiceExternalIP:
+      name: "org.openrewrite.kubernetes.services.UpdateServiceExternalIP"
+      description: "Swap out an IP address with another one in `Service` `externalIP`\
+        \ settings."
+      docLink: "https://docs.openrewrite.org/reference/recipes/kubernetes/services/updateserviceexternalip"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "ipToFind"
+        type: "String"
+        required: true
+      - name: "ipToUpdate"
+        type: "String"
+        required: true
+rewrite-logging-frameworks:
+  artifactId: "rewrite-logging-frameworks"
+  version: "1.15.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.xml.AddCommentToXmlTag"
-    description: "Adds a comment as the first element in a `XML` tag."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/addcommenttoxmltag"
-    options:
-    - name: "commentText"
-      type: "String"
-      required: true
-    - name: "xPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.xml.ChangeTagAttribute"
-    description: "Alters XML Attribute value within specified element."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/changetagattribute"
-    options:
-    - name: "attributeName"
-      type: "String"
-      required: true
-    - name: "elementName"
-      type: "String"
-      required: true
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newValue"
-      type: "String"
-      required: true
-    - name: "oldValue"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.xml.ChangeTagName"
-    description: "Alters the name of XML tags matching the provided expression."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/changetagname"
-    options:
-    - name: "elementName"
-      type: "String"
-      required: true
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newName"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.xml.RemoveTrailingWhitespace"
-    description: "Remove any extra trailing whitespace from the end of each line."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/removetrailingwhitespace"
-    options: []
-  - name: "org.openrewrite.xml.format.AutoFormat"
-    description: "Indents XML using the most common indentation size and tabs or space\
-      \ choice in use in the file."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/autoformat"
-    options: []
-  - name: "org.openrewrite.xml.format.LineBreaks"
-    description: "Add line breaks at appropriate places between XML syntax elements."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/linebreaks"
-    options: []
-  - name: "org.openrewrite.xml.format.NormalizeFormat"
-    description: "Move whitespace to the outermost AST element possible."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/normalizeformat"
-    options: []
-  - name: "org.openrewrite.xml.format.NormalizeLineBreaks"
-    description: "Consistently use either Windows style (CRLF) or Linux style (LF)\
-      \ line breaks. If no `GeneralFormatStyle` is specified this will use whichever\
-      \ style of line endings are more common."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/normalizelinebreaks"
-    options: []
-  - name: "org.openrewrite.xml.format.NormalizeTabsOrSpaces"
-    description: "Consistently use either tabs or spaces in indentation."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/normalizetabsorspaces"
-    options: []
-  - name: "org.openrewrite.xml.format.TabsAndIndents"
-    description: "Format tabs and indents in XML code."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/tabsandindents"
-    options: []
-  - name: "org.openrewrite.xml.search.FindTags"
-    description: "Find XML tags by XPath expression."
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/search/findtags"
-    options:
-    - name: "xPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.xml.security.DateBoundSuppressions"
-    description: "Adds an expiration date to all OWASP suppressions in order to ensure\
-      \ that they are periodically reviewed. For use with the OWASP `dependency-check`\
-      \ tool. More details: https://jeremylong.github.io/DependencyCheck/general/suppression.html"
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/security/dateboundsuppressions"
-    options:
-    - name: "untilDate"
-      type: "String"
-      required: false
-  - name: "org.openrewrite.xml.security.RemoveSuppressions"
-    description: "Remove all OWASP suppressions with a suppression end date in the\
-      \ past, as these are no longer valid. For use with the OWASP `dependency-check`\
-      \ tool. More details on OWASP suppression files: https://jeremylong.github.io/DependencyCheck/general/suppression.html"
-    docLink: "https://docs.openrewrite.org/reference/recipes/xml/security/removesuppressions"
-    options: []
-- artifactId: "rewrite-yaml"
-  version: "7.32.1"
+    org.openrewrite.java.logging.ParameterizedLogging:
+      name: "org.openrewrite.java.logging.ParameterizedLogging"
+      description: "Transform logging statements using concatenation for messages\
+        \ and variables into a parameterized format. For example, `logger.info(\"\
+        hi \" + userName)` becomes `logger.info(\"hi {}\", userName)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/parameterizedlogging"
+      options:
+      - name: "methodPattern"
+        type: "String"
+        required: true
+      - name: "removeToString"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.logging.PrintStackTraceToLogError:
+      name: "org.openrewrite.java.logging.PrintStackTraceToLogError"
+      description: "When a logger is present, log exceptions rather than calling `printStackTrace()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/printstacktracetologerror"
+      options:
+      - name: "addLogger"
+        type: "Boolean"
+        required: false
+      - name: "loggerName"
+        type: "String"
+        required: false
+      - name: "loggingFramework"
+        type: "String"
+        required: false
+    org.openrewrite.java.logging.SystemErrToLogging:
+      name: "org.openrewrite.java.logging.SystemErrToLogging"
+      description: "Replace `System.err` print statements with a logger."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/systemerrtologging"
+      options:
+      - name: "addLogger"
+        type: "Boolean"
+        required: false
+      - name: "loggerName"
+        type: "String"
+        required: false
+      - name: "loggingFramework"
+        type: "String"
+        required: false
+    org.openrewrite.java.logging.SystemOutToLogging:
+      name: "org.openrewrite.java.logging.SystemOutToLogging"
+      description: "Replace `System.out` print statements with a logger."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/systemouttologging"
+      options:
+      - name: "addLogger"
+        type: "Boolean"
+        required: false
+      - name: "level"
+        type: "String"
+        required: false
+      - name: "loggerName"
+        type: "String"
+        required: false
+      - name: "loggingFramework"
+        type: "String"
+        required: false
+    org.openrewrite.java.logging.SystemPrintToLogging:
+      name: "org.openrewrite.java.logging.SystemPrintToLogging"
+      description: "Replace `System.out` and `System.err` print statements with a\
+        \ logger."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/systemprinttologging"
+      options:
+      - name: "addLogger"
+        type: "Boolean"
+        required: false
+      - name: "level"
+        type: "String"
+        required: false
+      - name: "loggerName"
+        type: "String"
+        required: false
+      - name: "loggingFramework"
+        type: "String"
+        required: false
+    org.openrewrite.java.logging.log4j.Log4j1ToLog4j2:
+      name: "org.openrewrite.java.logging.log4j.Log4j1ToLog4j2"
+      description: "Migrates Log4j 1.x to Log4j 2.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/log4j/log4j1tolog4j2"
+      options: []
+    org.openrewrite.java.logging.log4j.ParameterizedLogging:
+      name: "org.openrewrite.java.logging.log4j.ParameterizedLogging"
+      description: "Log4j 2.x supports parameterized logging, which can significantly\
+        \ boost logging performance for disabled logging statements."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/log4j/parameterizedlogging"
+      options: []
+    org.openrewrite.java.logging.log4j.PrependRandomName:
+      name: "org.openrewrite.java.logging.log4j.PrependRandomName"
+      description: "To make finding the callsite of a logging statement easier in\
+        \ code search."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/log4j/prependrandomname"
+      options: []
+    org.openrewrite.java.logging.logback.Log4jAppenderToLogback:
+      name: "org.openrewrite.java.logging.logback.Log4jAppenderToLogback"
+      description: "Migrates custom Log4j 2.x Appender components to `logback-classic`.\
+        \ This recipe operates on the following assumptions: 1.) The contents of the\
+        \ `append()` method remains unchanged. 2.) The `requiresLayout()` method is\
+        \ not used in logback and can be removed. 3.) In logback, the `stop()` method\
+        \ is the equivalent of log4j's close() method. For more details, see this\
+        \ page from logback: [`Migration from log4j`](http://logback.qos.ch/manual/migrationFromLog4j.html)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/logback/log4jappendertologback"
+      options: []
+    org.openrewrite.java.logging.logback.Log4jLayoutToLogback:
+      name: "org.openrewrite.java.logging.logback.Log4jLayoutToLogback"
+      description: "Migrates custom Log4j 2.x Layout components to `logback-classic`.\
+        \ This recipe operates on the following assumptions: 1. A logback-classic\
+        \ layout must extend the `LayoutBase<ILoggingEvent>` class. 2. log4j's `format()`\
+        \ is renamed to `doLayout()` in a logback-classic layout. 3. LoggingEvent\
+        \ `getRenderedMessage()` is converted to LoggingEvent `getMessage()`. 4. The\
+        \ log4j ignoresThrowable() method is not needed and has no equivalent in logback-classic.\
+        \ 5. The activateOptions() method merits further discussion. In log4j, a layout\
+        \ will have its activateOptions() method invoked by log4j configurators, that\
+        \ is PropertyConfigurator or DOMConfigurator just after all the options of\
+        \ the layout have been set. Thus, the layout will have an opportunity to check\
+        \ that its options are coherent and if so, proceed to fully initialize itself.\
+        \ 6. In logback-classic, layouts must implement the LifeCycle interface which\
+        \ includes a method called start(). The start() method is the equivalent of\
+        \ log4j's activateOptions() method. For more details, see this page from logback:\
+        \ [`Migration from log4j`](http://logback.qos.ch/manual/migrationFromLog4j.html)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/logback/log4jlayouttologback"
+      options: []
+    org.openrewrite.java.logging.logback.Log4jToLogback:
+      name: "org.openrewrite.java.logging.logback.Log4jToLogback"
+      description: "Migrates usage of Apache Log4j 2.x to using `logback` as an SLF4J\
+        \ implementation directly. Note, this currently does not modify `log4j.properties`\
+        \ files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/logback/log4jtologback"
+      options: []
+    org.openrewrite.java.logging.slf4j.ConvertLogMessageMessageOnlyToLogMessageAndThrowable:
+      name: "org.openrewrite.java.logging.slf4j.ConvertLogMessageMessageOnlyToLogMessageAndThrowable"
+      description: "Convert `Logger#error|warn(throwable#message)` to `Logger#error|warn(<log-message>,\
+        \ e)` invocations having only the error's message as the parameter, to a log\
+        \ statement with message and throwable."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/convertlogmessagemessageonlytologmessageandthrowable"
+      options:
+      - name: "logMessage"
+        type: "String"
+        required: false
+    org.openrewrite.java.logging.slf4j.Log4j1ToSlf4j1:
+      name: "org.openrewrite.java.logging.slf4j.Log4j1ToSlf4j1"
+      description: "Transforms usages of Log4j 1.x to leveraging SLF4J 1.x directly.\
+        \ Note, this currently does not modify `log4j.properties` files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/log4j1toslf4j1"
+      options: []
+    org.openrewrite.java.logging.slf4j.Log4j2ToSlf4j1:
+      name: "org.openrewrite.java.logging.slf4j.Log4j2ToSlf4j1"
+      description: "Transforms usages of Log4j 2.x to leveraging SLF4J 1.x directly.\
+        \ Note, this currently does not modify `log4j.properties` files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/log4j2toslf4j1"
+      options: []
+    org.openrewrite.java.logging.slf4j.Log4jToSlf4j:
+      name: "org.openrewrite.java.logging.slf4j.Log4jToSlf4j"
+      description: "Migrates usage of Apache Log4j to using SLF4J directly. Use of\
+        \ the traditional Log4j to SLF4J bridge can result in loss of performance,\
+        \ as the Log4j messages must be formatted before they can be passed to SLF4J.\
+        \ Note, this currently does not modify `log4j.properties` files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/log4jtoslf4j"
+      options: []
+    org.openrewrite.java.logging.slf4j.LoggersNamedForEnclosingClass:
+      name: "org.openrewrite.java.logging.slf4j.LoggersNamedForEnclosingClass"
+      description: "Ensure `LoggerFactory#getLogger(Class)` is called with the enclosing\
+        \ class as argument."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/loggersnamedforenclosingclass"
+      options: []
+    org.openrewrite.java.logging.slf4j.ParameterizedLogging:
+      name: "org.openrewrite.java.logging.slf4j.ParameterizedLogging"
+      description: "SLF4J supports parameterized logging, which can significantly\
+        \ boost logging performance for disabled logging statements."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/parameterizedlogging"
+      options: []
+    org.openrewrite.java.logging.slf4j.Slf4jBestPractices:
+      name: "org.openrewrite.java.logging.slf4j.Slf4jBestPractices"
+      description: "Applies best practices to logging with SLF4J."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/slf4jbestpractices"
+      options: []
+    org.openrewrite.java.logging.slf4j.Slf4jLogShouldBeConstant:
+      name: "org.openrewrite.java.logging.slf4j.Slf4jLogShouldBeConstant"
+      description: "Logging statements shouldn't begin with `String#format`, calls\
+        \ to `toString()`, etc."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/logging/slf4j/slf4jlogshouldbeconstant"
+      options: []
+rewrite-maven:
+  artifactId: "rewrite-maven"
+  version: "7.33.0"
   markdownRecipeDescriptors:
-  - name: "org.openrewrite.yaml.ChangeKey"
-    description: "Change a YAML mapping entry key leaving the value intact."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/changekey"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newKey"
-      type: "String"
-      required: true
-    - name: "oldKeyPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.yaml.ChangePropertyKey"
-    description: "Change a YAML property key leaving the value intact. Nested YAML\
-      \ mappings are interpreted as dot separated property names, i.e. as Spring Boot\
-      \ interprets application.yml files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/changepropertykey"
-    options:
-    - name: "except"
-      type: "List"
-      required: false
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newPropertyKey"
-      type: "String"
-      required: true
-    - name: "oldPropertyKey"
-      type: "String"
-      required: true
-    - name: "relaxedBinding"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.yaml.ChangeValue"
-    description: "Change a YAML mapping entry value leaving the key intact."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/changevalue"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "oldKeyPath"
-      type: "String"
-      required: true
-    - name: "value"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.yaml.CoalesceProperties"
-    description: "Simplify nested map hierarchies into their simplest dot separated\
-      \ property form, i.e. as Spring Boot interprets application.yml files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/coalesceproperties"
-    options: []
-  - name: "org.openrewrite.yaml.CopyValue"
-    description: "Copies a YAML value from one key to another. The existing key/value\
-      \ pair remains unaffected by this change. If either the source or destination\
-      \ key path does not exist, no value will be copied. Furthermore, copies are\
-      \ limited to scalar values, not whole YAML blocks."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/copyvalue"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "newKey"
-      type: "String"
-      required: true
-    - name: "oldKeyPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.yaml.DeleteKey"
-    description: "Delete a YAML mapping entry key."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/deletekey"
-    options:
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "keyPath"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.yaml.DeleteProperty"
-    description: "Delete a YAML property. Nested YAML mappings are interpreted as\
-      \ dot separated property names, i.e.  as Spring Boot interprets application.yml\
-      \ files like `a.b.c.d` or `a.b.c:d`."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/deleteproperty"
-    options:
-    - name: "coalesce"
-      type: "Boolean"
-      required: false
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "propertyKey"
-      type: "String"
-      required: true
-    - name: "relaxedBinding"
-      type: "Boolean"
-      required: false
-  - name: "org.openrewrite.yaml.MergeYaml"
-    description: "Merge a YAML snippet with an existing YAML document."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/mergeyaml"
-    options:
-    - name: "acceptTheirs"
-      type: "Boolean"
-      required: false
-    - name: "fileMatcher"
-      type: "String"
-      required: false
-    - name: "key"
-      type: "String"
-      required: true
-    - name: "objectIdentifyingProperty"
-      type: "String"
-      required: false
-    - name: "yaml"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.yaml.cleanup.RemoveUnused"
-    description: "Remove YAML mapping and sequence keys that have no value."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/cleanup/removeunused"
-    options: []
-  - name: "org.openrewrite.yaml.format.Indents"
-    description: "Format tabs and indents in YAML."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/format/indents"
-    options: []
-  - name: "org.openrewrite.yaml.search.FindKey"
-    description: "Find YAML entries by JsonPath expression."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/search/findkey"
-    options:
-    - name: "key"
-      type: "String"
-      required: true
-  - name: "org.openrewrite.yaml.search.FindProperty"
-    description: "Find a YAML property. Nested YAML mappings are interpreted as dot\
-      \ separated property names, i.e.  as Spring Boot interprets `application.yml`\
-      \ files."
-    docLink: "https://docs.openrewrite.org/reference/recipes/yaml/search/findproperty"
-    options:
-    - name: "propertyKey"
-      type: "String"
-      required: true
-    - name: "relaxedBinding"
-      type: "Boolean"
-      required: false
+    org.openrewrite.maven.AddCommentToMavenDependency:
+      name: "org.openrewrite.maven.AddCommentToMavenDependency"
+      description: "Adds a comment as the first element in a `Maven` dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/addcommenttomavendependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "commentText"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "xPath"
+        type: "String"
+        required: true
+    org.openrewrite.maven.AddDependency:
+      name: "org.openrewrite.maven.AddDependency"
+      description: "Add a maven dependency to a `pom.xml` file in the correct scope\
+        \ based on where it is used."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/adddependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "classifier"
+        type: "String"
+        required: false
+      - name: "familyPattern"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "onlyIfUsing"
+        type: "String"
+        required: true
+      - name: "optional"
+        type: "Boolean"
+        required: false
+      - name: "releasesOnly"
+        type: "Boolean"
+        required: false
+      - name: "scope"
+        type: "String"
+        required: false
+      - name: "type"
+        type: "String"
+        required: false
+      - name: "version"
+        type: "String"
+        required: true
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.maven.AddManagedDependency:
+      name: "org.openrewrite.maven.AddManagedDependency"
+      description: "Add a managed maven dependency to a pom.xml file."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/addmanageddependency"
+      options:
+      - name: "addToRootPom"
+        type: "Boolean"
+        required: false
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "classifier"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "onlyIfUsing"
+        type: "String"
+        required: false
+      - name: "releasesOnly"
+        type: "Boolean"
+        required: false
+      - name: "scope"
+        type: "String"
+        required: false
+      - name: "type"
+        type: "String"
+        required: false
+      - name: "version"
+        type: "String"
+        required: true
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.maven.AddPlugin:
+      name: "org.openrewrite.maven.AddPlugin"
+      description: "Add the specified Maven plugin to the pom.xml."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/addplugin"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "dependencies"
+        type: "String"
+        required: false
+      - name: "executions"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "version"
+        type: "String"
+        required: true
+    org.openrewrite.maven.AddPluginDependency:
+      name: "org.openrewrite.maven.AddPluginDependency"
+      description: "Adds the specified dependencies to a Maven plugin. Will not add\
+        \ the plugin if it does not already exist in the pom."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/addplugindependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "pluginArtifactId"
+        type: "String"
+        required: true
+      - name: "pluginGroupId"
+        type: "String"
+        required: true
+      - name: "version"
+        type: "String"
+        required: true
+    org.openrewrite.maven.AddProperty:
+      name: "org.openrewrite.maven.AddProperty"
+      description: "Add a new property to the Maven project property."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/addproperty"
+      options:
+      - name: "key"
+        type: "String"
+        required: true
+      - name: "preserveExistingValue"
+        type: "Boolean"
+        required: false
+      - name: "trustParent"
+        type: "Boolean"
+        required: false
+      - name: "value"
+        type: "String"
+        required: true
+    org.openrewrite.maven.AddRepository:
+      name: "org.openrewrite.maven.AddRepository"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/addrepository"
+      options:
+      - name: "id"
+        type: "String"
+        required: true
+      - name: "layout"
+        type: "String"
+        required: false
+      - name: "releasesChecksumPolicy"
+        type: "String"
+        required: false
+      - name: "releasesEnabled"
+        type: "Boolean"
+        required: false
+      - name: "releasesUpdatePolicy"
+        type: "String"
+        required: false
+      - name: "repoName"
+        type: "String"
+        required: false
+      - name: "snapshotsChecksumPolicy"
+        type: "String"
+        required: false
+      - name: "snapshotsEnabled"
+        type: "Boolean"
+        required: false
+      - name: "snapshotsUpdatePolicy"
+        type: "String"
+        required: false
+      - name: "url"
+        type: "String"
+        required: true
+    org.openrewrite.maven.ChangeDependencyClassifier:
+      name: "org.openrewrite.maven.ChangeDependencyClassifier"
+      description: "Add or alter the classifier of the specified dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changedependencyclassifier"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newClassifier"
+        type: "String"
+        required: false
+    org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      name: "org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId"
+      description: "Change the groupId, artifactId and/or the version of a specified\
+        \ Maven dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changedependencygroupidandartifactid"
+      options:
+      - name: "newArtifactId"
+        type: "String"
+        required: false
+      - name: "newGroupId"
+        type: "String"
+        required: false
+      - name: "newVersion"
+        type: "String"
+        required: false
+      - name: "oldArtifactId"
+        type: "String"
+        required: true
+      - name: "oldGroupId"
+        type: "String"
+        required: true
+      - name: "overrideManagedVersion"
+        type: "Boolean"
+        required: false
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.maven.ChangeDependencyScope:
+      name: "org.openrewrite.maven.ChangeDependencyScope"
+      description: "Add or alter the scope of the specified dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changedependencyscope"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newScope"
+        type: "String"
+        required: false
+    org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId:
+      name: "org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId"
+      description: "Change the groupId, artifactId and optionally the version of a\
+        \ specified Maven managed dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changemanageddependencygroupidandartifactid"
+      options:
+      - name: "newArtifactId"
+        type: "String"
+        required: true
+      - name: "newGroupId"
+        type: "String"
+        required: true
+      - name: "newVersion"
+        type: "String"
+        required: false
+      - name: "oldArtifactId"
+        type: "String"
+        required: true
+      - name: "oldGroupId"
+        type: "String"
+        required: true
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.maven.ChangePackaging:
+      name: "org.openrewrite.maven.ChangePackaging"
+      description: "Sets the packaging type of Maven projects. Either adds the packaging\
+        \ tag if it is missing or changes its context if present."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changepackaging"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "packaging"
+        type: "String"
+        required: true
+    org.openrewrite.maven.ChangeParentPom:
+      name: "org.openrewrite.maven.ChangeParentPom"
+      description: "Change the parent pom of a Maven pom.xml. Identifies the parent\
+        \ pom to be changed by its groupId and artifactId."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changeparentpom"
+      options:
+      - name: "allowVersionDowngrades"
+        type: "boolean"
+        required: false
+      - name: "newArtifactId"
+        type: "String"
+        required: false
+      - name: "newGroupId"
+        type: "String"
+        required: false
+      - name: "newVersion"
+        type: "String"
+        required: true
+      - name: "oldArtifactId"
+        type: "String"
+        required: true
+      - name: "oldGroupId"
+        type: "String"
+        required: true
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.maven.ChangePluginConfiguration:
+      name: "org.openrewrite.maven.ChangePluginConfiguration"
+      description: "Apply the specified configuration to a Maven plugin. Will not\
+        \ add the plugin if it does not already exist in the pom."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changepluginconfiguration"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "configuration"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.maven.ChangePluginDependencies:
+      name: "org.openrewrite.maven.ChangePluginDependencies"
+      description: "Applies the specified dependencies to a Maven plugin. Will not\
+        \ add the plugin if it does not already exist in the pom."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changeplugindependencies"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "dependencies"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.maven.ChangePluginExecutions:
+      name: "org.openrewrite.maven.ChangePluginExecutions"
+      description: "Apply the specified executions to a Maven plugin. Will not add\
+        \ the plugin if it does not already exist in the pom."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changepluginexecutions"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "executions"
+        type: "String"
+        required: false
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.maven.ChangePropertyValue:
+      name: "org.openrewrite.maven.ChangePropertyValue"
+      description: "Changes the specified Maven project property value leaving the\
+        \ key intact."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/changepropertyvalue"
+      options:
+      - name: "addIfMissing"
+        type: "Boolean"
+        required: false
+      - name: "key"
+        type: "String"
+        required: true
+      - name: "newValue"
+        type: "String"
+        required: true
+      - name: "trustParent"
+        type: "Boolean"
+        required: false
+    org.openrewrite.maven.ExcludeDependency:
+      name: "org.openrewrite.maven.ExcludeDependency"
+      description: "Exclude specified dependency from any dependency that transitively\
+        \ includes it."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/excludedependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "scope"
+        type: "String"
+        required: false
+    org.openrewrite.maven.ManageDependencies:
+      name: "org.openrewrite.maven.ManageDependencies"
+      description: "Make existing dependencies managed by moving their version to\
+        \ be specified in the dependencyManagement section of the POM."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/managedependencies"
+      options:
+      - name: "addToRootPom"
+        type: "Boolean"
+        required: false
+      - name: "artifactPattern"
+        type: "String"
+        required: false
+      - name: "groupPattern"
+        type: "String"
+        required: true
+      - name: "skipModelUpdate"
+        type: "Boolean"
+        required: false
+    org.openrewrite.maven.OrderPomElements:
+      name: "org.openrewrite.maven.OrderPomElements"
+      description: "Order POM elements according to the [recommended](http://maven.apache.org/developers/conventions/code.html#pom-code-convention)\
+        \ order."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/orderpomelements"
+      options: []
+    org.openrewrite.maven.RemoveDependency:
+      name: "org.openrewrite.maven.RemoveDependency"
+      description: "Removes a single dependency from the <dependencies> section of\
+        \ the pom.xml."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/removedependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "scope"
+        type: "String"
+        required: false
+    org.openrewrite.maven.RemoveExclusion:
+      name: "org.openrewrite.maven.RemoveExclusion"
+      description: "Remove a single exclusion from on a particular dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/removeexclusion"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "exclusionArtifactId"
+        type: "String"
+        required: true
+      - name: "exclusionGroupId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.maven.RemoveManagedDependency:
+      name: "org.openrewrite.maven.RemoveManagedDependency"
+      description: "Removes a single managed dependency from the <dependencyManagement><dependencies>\
+        \ section of the pom.xml."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/removemanageddependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "scope"
+        type: "String"
+        required: false
+    org.openrewrite.maven.RemovePlugin:
+      name: "org.openrewrite.maven.RemovePlugin"
+      description: "Remove the specified Maven plugin from the pom.xml."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/removeplugin"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.maven.RemoveProperty:
+      name: "org.openrewrite.maven.RemoveProperty"
+      description: "Removes the specified Maven project property from the pom.xml."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/removeproperty"
+      options:
+      - name: "propertyName"
+        type: "String"
+        required: true
+    org.openrewrite.maven.RemoveRedundantDependencyVersions:
+      name: "org.openrewrite.maven.RemoveRedundantDependencyVersions"
+      description: "Remove explicitly-specified dependency versions when a parent\
+        \ POM's dependencyManagement specifies the version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/removeredundantdependencyversions"
+      options:
+      - name: "artifactPattern"
+        type: "String"
+        required: false
+      - name: "groupPattern"
+        type: "String"
+        required: false
+      - name: "onlyIfVersionsMatch"
+        type: "Boolean"
+        required: false
+    org.openrewrite.maven.UpgradeDependencyVersion:
+      name: "org.openrewrite.maven.UpgradeDependencyVersion"
+      description: "Upgrade the version of a dependency by specifying a group and\
+        \ (optionally) an artifact using Node Semver advanced range selectors, allowing\
+        \ more precise control over version updates to patch or minor releases."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/upgradedependencyversion"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newVersion"
+        type: "String"
+        required: true
+      - name: "overrideManagedVersion"
+        type: "Boolean"
+        required: false
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.maven.UpgradeParentVersion:
+      name: "org.openrewrite.maven.UpgradeParentVersion"
+      description: "Set the parent pom version number according to a node-style semver\
+        \ selector or to a specific version number."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/upgradeparentversion"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newVersion"
+        type: "String"
+        required: true
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.maven.UpgradePluginVersion:
+      name: "org.openrewrite.maven.UpgradePluginVersion"
+      description: "Upgrade the version of a plugin using Node Semver advanced range\
+        \ selectors, allowing more precise control over version updates to patch or\
+        \ minor releases."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/upgradepluginversion"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+      - name: "newVersion"
+        type: "String"
+        required: true
+      - name: "trustParent"
+        type: "Boolean"
+        required: false
+      - name: "versionPattern"
+        type: "String"
+        required: false
+    org.openrewrite.maven.cleanup.DependencyManagementDependencyRequiresVersion:
+      name: "org.openrewrite.maven.cleanup.DependencyManagementDependencyRequiresVersion"
+      description: "If they don't have a version, they can't possibly affect dependency\
+        \ resolution anywhere, and can be safely removed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/cleanup/dependencymanagementdependencyrequiresversion"
+      options: []
+    org.openrewrite.maven.search.DependencyInsight:
+      name: "org.openrewrite.maven.search.DependencyInsight"
+      description: "Find direct and transitive dependencies matching a group, artifact,\
+        \ and scope. Results include dependencies that either directly match or transitively\
+        \ include a matching dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/dependencyinsight"
+      options:
+      - name: "artifactIdPattern"
+        type: "String"
+        required: true
+      - name: "groupIdPattern"
+        type: "String"
+        required: true
+      - name: "scope"
+        type: "String"
+        required: true
+    org.openrewrite.maven.search.EffectiveMavenRepositories:
+      name: "org.openrewrite.maven.search.EffectiveMavenRepositories"
+      description: "Lists the Maven repositories that would be used for dependency\
+        \ resolution, in order of precedence. This includes Maven repositories defined\
+        \ in the Maven settings file (and those contributed by active profiles) as\
+        \ determined when the AST was produced."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/effectivemavenrepositories"
+      options: []
+    org.openrewrite.maven.search.FindDependency:
+      name: "org.openrewrite.maven.search.FindDependency"
+      description: "Finds first-order dependency uses, i.e. dependencies that are\
+        \ defined directly in a project."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/finddependency"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.maven.search.FindPlugin:
+      name: "org.openrewrite.maven.search.FindPlugin"
+      description: "Finds a Maven plugin within a pom.xml."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/findplugin"
+      options:
+      - name: "artifactId"
+        type: "String"
+        required: true
+      - name: "groupId"
+        type: "String"
+        required: true
+    org.openrewrite.maven.search.FindProperties:
+      name: "org.openrewrite.maven.search.FindProperties"
+      description: "Finds the specified Maven project properties within a pom.xml."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/search/findproperties"
+      options:
+      - name: "propertyPattern"
+        type: "String"
+        required: true
+    org.openrewrite.maven.security.UseHttpsForRepositories:
+      name: "org.openrewrite.maven.security.UseHttpsForRepositories"
+      description: "Use HTTPS for repository urls."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/security/usehttpsforrepositories"
+      options: []
+    org.openrewrite.maven.utilities.ListDependencies:
+      name: "org.openrewrite.maven.utilities.ListDependencies"
+      description: "List all the dependencies in a scope and add to a text file."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/utilities/listdependencies"
+      options:
+      - name: "scope"
+        type: "String"
+        required: false
+    org.openrewrite.maven.utilities.PrintMavenAsDot:
+      name: "org.openrewrite.maven.utilities.PrintMavenAsDot"
+      description: "The DOT language format is specified [here](https://graphviz.org/doc/info/lang.html)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/utilities/printmavenasdot"
+      options: []
+rewrite-micronaut:
+  artifactId: "rewrite-micronaut"
+  version: "1.19.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.java.micronaut.BeanPropertyCapitalizationStrategy:
+      name: "org.openrewrite.java.micronaut.BeanPropertyCapitalizationStrategy"
+      description: "As of Micronaut 3.x property names for getters like `getXForwarded()`\
+        \ are de-capitalized from `XForwarded` to `xForwarded`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/beanpropertycapitalizationstrategy"
+      options: []
+    org.openrewrite.java.micronaut.CopyNonInheritedAnnotations:
+      name: "org.openrewrite.java.micronaut.CopyNonInheritedAnnotations"
+      description: "As of Micronaut 3.x only [annotations](https://github.com/micronaut-projects/micronaut-core/blob/3.0.x/src/main/docs/guide/appendix/breaks.adoc#annotation-inheritance)\
+        \ that are explicitly meta-annotated with `@Inherited` are inherited from\
+        \ parent classes and interfaces."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/copynoninheritedannotations"
+      options: []
+    org.openrewrite.java.micronaut.FixDeprecatedExceptionHandlerConstructors:
+      name: "org.openrewrite.java.micronaut.FixDeprecatedExceptionHandlerConstructors"
+      description: "Adds `ErrorResponseProcessor` argument to deprecated no-arg `ExceptionHandler`\
+        \ constructors."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/fixdeprecatedexceptionhandlerconstructors"
+      options: []
+    org.openrewrite.java.micronaut.Micronaut2to3Migration:
+      name: "org.openrewrite.java.micronaut.Micronaut2to3Migration"
+      description: "This recipe will apply changes required for migrating from Micronaut\
+        \ 2 to Micronaut 3."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/micronaut2to3migration"
+      options: []
+    org.openrewrite.java.micronaut.OncePerRequestHttpServerFilterToHttpServerFilter:
+      name: "org.openrewrite.java.micronaut.OncePerRequestHttpServerFilterToHttpServerFilter"
+      description: "Starting in Micronaut 3.0 all filters are executed once per request.\
+        \ Directly implement `HttpServerFilter` instead of extending `OncePerRequestHttpServerFilter`\
+        \ and replace any usages of `micronaut.once` attributes with a custom attribute\
+        \ name."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/onceperrequesthttpserverfiltertohttpserverfilter"
+      options: []
+    org.openrewrite.java.micronaut.ProviderImplementationsToMicronautFactories:
+      name: "org.openrewrite.java.micronaut.ProviderImplementationsToMicronautFactories"
+      description: "As of Micronaut 3.x the `@Factory` annotation is required for\
+        \ creating beans from `javax.inject.Provider get()` implementations."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/providerimplementationstomicronautfactories"
+      options: []
+    org.openrewrite.java.micronaut.SubclassesReturnedFromFactoriesNotInjectable:
+      name: "org.openrewrite.java.micronaut.SubclassesReturnedFromFactoriesNotInjectable"
+      description: "As of Micronaut 3.x It is no longer possible to inject the internal\
+        \ implementation type from beans produced via factories. Factory method return\
+        \ types are changed to reflect the resolved return type if the method returns\
+        \ a single non-null type that does not match the method declaration return\
+        \ type."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/subclassesreturnedfromfactoriesnotinjectable"
+      options: []
+    org.openrewrite.java.micronaut.TypeRequiresIntrospection:
+      name: "org.openrewrite.java.micronaut.TypeRequiresIntrospection"
+      description: "In Micronaut 2.x a reflection-based strategy was used to retrieve\
+        \ that information if the class was not annotated with `@Introspected`. As\
+        \ of Micronaut 3.x it is required to annotate classes with `@Introspected`\
+        \ that are used in this way."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/typerequiresintrospection"
+      options: []
+    org.openrewrite.java.micronaut.UpgradeMicronautGradlePropertiesVersion:
+      name: "org.openrewrite.java.micronaut.UpgradeMicronautGradlePropertiesVersion"
+      description: "Set the gradle.properties version number according to a node-style\
+        \ semver selector or to a specific version number."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/upgrademicronautgradlepropertiesversion"
+      options:
+      - name: "newVersion"
+        type: "String"
+        required: true
+    org.openrewrite.java.micronaut.UpgradeMicronautMavenPropertyVersion:
+      name: "org.openrewrite.java.micronaut.UpgradeMicronautMavenPropertyVersion"
+      description: "Set the maven micronaut.version property according to a node-style\
+        \ semver selector or to a specific version number."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/micronaut/upgrademicronautmavenpropertyversion"
+      options:
+      - name: "newVersion"
+        type: "String"
+        required: true
+rewrite-migrate-java:
+  artifactId: "rewrite-migrate-java"
+  version: "1.14.1"
+  markdownRecipeDescriptors:
+    org.openrewrite.java.migrate.AddJDeprScanPlugin:
+      name: "org.openrewrite.java.migrate.AddJDeprScanPlugin"
+      description: "JDeprScan scans class files for uses of deprecated APIs."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/addjdeprscanplugin"
+      options:
+      - name: "release"
+        type: "String"
+        required: false
+    org.openrewrite.java.migrate.AddSuppressionForIllegalReflectionWarningsPlugin:
+      name: "org.openrewrite.java.migrate.AddSuppressionForIllegalReflectionWarningsPlugin"
+      description: "Adds a maven jar plugin that's configured to suppress Illegal\
+        \ Reflection Warnings."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/addsuppressionforillegalreflectionwarningsplugin"
+      options:
+      - name: "version"
+        type: "String"
+        required: false
+    org.openrewrite.java.migrate.Java8toJava11:
+      name: "org.openrewrite.java.migrate.Java8toJava11"
+      description: "This recipe will apply changes commonly needed when upgrading\
+        \ to Java 11. Specifically, for those applications that are built on Java\
+        \ 8, this recipe will update and add dependencies on J2EE libraries that are\
+        \ no longer directly bundled with the JDK. This recipe will also replace deprecated\
+        \ API with equivalents when there is a clear migration strategy. Build files\
+        \ will also be updated to use Java 11 as the target/source and plugins will\
+        \ be also be upgraded to versions that are compatible with Java 11.\n"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/java8tojava11"
+      options: []
+    org.openrewrite.java.migrate.JavaVersion11:
+      name: "org.openrewrite.java.migrate.JavaVersion11"
+      description: "Change maven.compiler.source and maven.compiler.target values\
+        \ to 11."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaversion11"
+      options: []
+    org.openrewrite.java.migrate.JavaVersion17:
+      name: "org.openrewrite.java.migrate.JavaVersion17"
+      description: "Change maven.compiler.source and maven.compiler.target values\
+        \ to 17."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javaversion17"
+      options: []
+    org.openrewrite.java.migrate.UpgradeToJava17:
+      name: "org.openrewrite.java.migrate.UpgradeToJava17"
+      description: "This recipe will apply changes commonly needed when migrating\
+        \ to Java 17. Specifically, for those applications that are built on Java\
+        \ 8, this recipe will update and add dependencies on J2EE libraries that are\
+        \ no longer directly bundled with the JDK. This recipe will also replace deprecated\
+        \ API with equivalents when there is a clear migration strategy. Build files\
+        \ will also be updated to use Java 17 as the target/source and plugins will\
+        \ be also be upgraded to versions that are compatible with Java 17.\n"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/upgradetojava17"
+      options: []
+    org.openrewrite.java.migrate.UseJavaUtilBase64:
+      name: "org.openrewrite.java.migrate.UseJavaUtilBase64"
+      description: "The `sun.misc` package became is not intended for use beyond Java\
+        \ 9. `java.util.Base64` was introduced in Java 8 for general use."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/usejavautilbase64"
+      options: []
+    org.openrewrite.java.migrate.apache.commons.codec.ApacheBase64ToJavaBase64:
+      name: "org.openrewrite.java.migrate.apache.commons.codec.ApacheBase64ToJavaBase64"
+      description: "Migrate `apache.commons.codec.binary.Base64#encodeBase64` to `java.util.Base64.Encoder#encodeBase64`,\
+        \ `apache.commons.codec.binary.Base64#encodeBase64String` to `java.util.Base64.Encoder#encodeToString`,\
+        \ and `apache.commons.codec.binary.Base64#decodeBase64` to `java.util.Base64.Decoder#decode`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/codec/apachebase64tojavabase64"
+      options: []
+    org.openrewrite.java.migrate.apache.commons.io.ApacheFileUtilsToJavaFiles:
+      name: "org.openrewrite.java.migrate.apache.commons.io.ApacheFileUtilsToJavaFiles"
+      description: "Migrate `apache.commons.io.FileUtils` to `java.nio.file.Files`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/apachefileutilstojavafiles"
+      options: []
+    org.openrewrite.java.migrate.apache.commons.io.ApacheIOUtilsUseExplicitCharset:
+      name: "org.openrewrite.java.migrate.apache.commons.io.ApacheIOUtilsUseExplicitCharset"
+      description: "This convert deprecated `IOUtils` method invocations with their\
+        \ charset specific equivalent, e.g. converts `IOUtils.readLines(inputStream)`\
+        \ to `IOUtils.readLines(inputStream, StandardCharsets.UTF_8)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/apacheioutilsuseexplicitcharset"
+      options:
+      - name: "encoding"
+        type: "String"
+        required: false
+    org.openrewrite.java.migrate.apache.commons.io.RelocateApacheCommonsIo:
+      name: "org.openrewrite.java.migrate.apache.commons.io.RelocateApacheCommonsIo"
+      description: "The deployment of `org.apache.commons:commons-io` [was a publishing\
+        \ mistake around 2012](https://issues.sonatype.org/browse/MVNCENTRAL-244)\
+        \ which was corrected by changing the deployment GAV to be located under `commons-io:commons-io`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/relocateapachecommonsio"
+      options: []
+    org.openrewrite.java.migrate.apache.commons.io.UseStandardCharsets:
+      name: "org.openrewrite.java.migrate.apache.commons.io.UseStandardCharsets"
+      description: "Migrate `org.apache.commons.io.Charsets` to `java.nio.charset.StandardCharsets`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/usestandardcharsets"
+      options: []
+    org.openrewrite.java.migrate.apache.commons.io.UseSystemLineSeparator:
+      name: "org.openrewrite.java.migrate.apache.commons.io.UseSystemLineSeparator"
+      description: "Migrate `IOUtils.LINE_SEPARATOR` to `System.lineSeparator()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/apache/commons/io/usesystemlineseparator"
+      options: []
+    org.openrewrite.java.migrate.cobertura.RemoveCoberturaMavenPlugin:
+      name: "org.openrewrite.java.migrate.cobertura.RemoveCoberturaMavenPlugin"
+      description: "This recipe will remove Cobertura, as it is not compatible with\
+        \ Java 11."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/cobertura/removecoberturamavenplugin"
+      options: []
+    org.openrewrite.java.migrate.concurrent.JavaConcurrentAPIs:
+      name: "org.openrewrite.java.migrate.concurrent.JavaConcurrentAPIs"
+      description: "Certain Java concurrent APIs have become deprecated and their\
+        \ usages changed, necessitating usage changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/javaconcurrentapis"
+      options: []
+    org.openrewrite.java.migrate.concurrent.MigrateAtomicBooleanWeakCompareAndSetToWeakCompareAndSetPlain:
+      name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicBooleanWeakCompareAndSetToWeakCompareAndSetPlain"
+      description: "`AtomicBoolean#weakCompareAndSet(boolean, boolean)` was deprecated\
+        \ in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicbooleanweakcompareandsettoweakcompareandsetplain"
+      options: []
+    org.openrewrite.java.migrate.concurrent.MigrateAtomicIntegerArrayWeakCompareAndSetToWeakCompareAndSetPlain:
+      name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicIntegerArrayWeakCompareAndSetToWeakCompareAndSetPlain"
+      description: "`AtomicIntegerArray#weakCompareAndSet(int, int, int)` was deprecated\
+        \ in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicintegerarrayweakcompareandsettoweakcompareandsetplain"
+      options: []
+    org.openrewrite.java.migrate.concurrent.MigrateAtomicIntegerWeakCompareAndSetToWeakCompareAndSetPlain:
+      name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicIntegerWeakCompareAndSetToWeakCompareAndSetPlain"
+      description: "`AtomicInteger#weakCompareAndSet(int, int)` was deprecated in\
+        \ Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicintegerweakcompareandsettoweakcompareandsetplain"
+      options: []
+    org.openrewrite.java.migrate.concurrent.MigrateAtomicLongArrayWeakCompareAndSetToWeakCompareAndSetPlain:
+      name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicLongArrayWeakCompareAndSetToWeakCompareAndSetPlain"
+      description: "`AtomicLongArray#weakCompareAndSet(int, long, long)` was deprecated\
+        \ in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomiclongarrayweakcompareandsettoweakcompareandsetplain"
+      options: []
+    org.openrewrite.java.migrate.concurrent.MigrateAtomicLongWeakCompareAndSetToWeakCompareAndSetPlain:
+      name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicLongWeakCompareAndSetToWeakCompareAndSetPlain"
+      description: "`AtomicLong#weakCompareAndSet(long, long)` was deprecated in Java\
+        \ 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomiclongweakcompareandsettoweakcompareandsetplain"
+      options: []
+    org.openrewrite.java.migrate.concurrent.MigrateAtomicReferenceArrayWeakCompareAndSetToWeakCompareAndSetPlain:
+      name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicReferenceArrayWeakCompareAndSetToWeakCompareAndSetPlain"
+      description: "`AtomicReferenceArray#weakCompareAndSet(int, T, T)` was deprecated\
+        \ in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicreferencearrayweakcompareandsettoweakcompareandsetplain"
+      options: []
+    org.openrewrite.java.migrate.concurrent.MigrateAtomicReferenceWeakCompareAndSetToWeakCompareAndSetPlain:
+      name: "org.openrewrite.java.migrate.concurrent.MigrateAtomicReferenceWeakCompareAndSetToWeakCompareAndSetPlain"
+      description: "`AtomicReference#weakCompareAndSet(T, T)` was deprecated in Java\
+        \ 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/concurrent/migrateatomicreferenceweakcompareandsettoweakcompareandsetplain"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuava:
+      name: "org.openrewrite.java.migrate.guava.NoGuava"
+      description: "Guava filled in important gaps in the Java standard library and\
+        \ still does. But at least some of Guava's API surface area is covered by\
+        \ the Java standard library now, and some projects may be able to remove Guava\
+        \ altogether if they migrate to standard library for these functions."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguava"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaAtomicsNewReference:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaAtomicsNewReference"
+      description: "Prefer the Java standard library over third-party usage of Guava\
+        \ in simple cases like this."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavaatomicsnewreference"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaCreateTempDir:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaCreateTempDir"
+      description: "Replaces Guava `Files#createTempDir()` with Java `Files#createTempDirectory(..)`.\
+        \ Transformations are limited to scopes throwing or catching `java.io.IOException`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavacreatetempdir"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaDirectExecutor:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaDirectExecutor"
+      description: "`Executor` is a SAM-compatible interface, so `Runnable::run` is\
+        \ just as succinct as `MoreExecutors.directExecutor()` but without the third-party\
+        \ library requirement."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavadirectexecutor"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaImmutableListOf:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaImmutableListOf"
+      description: "Replaces `ImmutableList.of(..)` if the returned type is immediately\
+        \ down-cast."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavaimmutablelistof"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaImmutableMapOf:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaImmutableMapOf"
+      description: "Replaces `ImmutableMap.of(..)` if the returned type is immediately\
+        \ down-cast."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavaimmutablemapof"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaImmutableSetOf:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaImmutableSetOf"
+      description: "Replaces `ImmutableSet.of(..)` if the returned type is immediately\
+        \ down-cast.\n  Java 9 introduced `List#of(..)`, `Map#of(..)`, `Set#of(..)`\
+        \ which is similar to `ImmutableList#of(..)`, `ImmutableMap#of(..)`, `ImmutableSet#of(..)`,\
+        \ but has a subtle difference.\n  As per the Java 9 documentation, [`Set.of`\
+        \ provides an unspecified iteration order on the set of elements and is subject\
+        \ to change](https://docs.oracle.com/javase/9/docs/api/java/util/Set.html),\
+        \ whereas [Guava `ImmutableSet` preserves the order from construction time](https://github.com/google/guava/wiki/ImmutableCollectionsExplained#how).\n\
+        \  This is worth pointing out in case your usage calls for iteration order\
+        \ being important."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavaimmutablesetof"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaListsNewArrayList:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaListsNewArrayList"
+      description: "Prefer the Java standard library over third-party usage of Guava\
+        \ in simple cases like this."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavalistsnewarraylist"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaListsNewCopyOnWriteArrayList:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaListsNewCopyOnWriteArrayList"
+      description: "Prefer the Java standard library over third-party usage of Guava\
+        \ in simple cases like this."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavalistsnewcopyonwritearraylist"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaListsNewLinkedList:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaListsNewLinkedList"
+      description: "Prefer the Java standard library over third-party usage of Guava\
+        \ in simple cases like this."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavalistsnewlinkedlist"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaMapsNewLinkedHashMap:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaMapsNewLinkedHashMap"
+      description: "Prefer the Java standard library over third-party usage of Guava\
+        \ in simple cases like this."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavamapsnewlinkedhashmap"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaSetsNewConcurrentHashSet:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaSetsNewConcurrentHashSet"
+      description: "Prefer the Java standard library over third-party usage of Guava\
+        \ in simple cases like this."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavasetsnewconcurrenthashset"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaSetsNewHashSet:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaSetsNewHashSet"
+      description: "Prefer the Java standard library over third-party usage of Guava\
+        \ in simple cases like this."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavasetsnewhashset"
+      options: []
+    org.openrewrite.java.migrate.guava.NoGuavaSetsNewLinkedHashSet:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaSetsNewLinkedHashSet"
+      description: "Prefer the Java standard library over third-party usage of Guava\
+        \ in simple cases like this."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/noguavasetsnewlinkedhashset"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferCharCompare:
+      name: "org.openrewrite.java.migrate.guava.PreferCharCompare"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefercharcompare"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferIntegerCompare:
+      name: "org.openrewrite.java.migrate.guava.PreferIntegerCompare"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegercompare"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferIntegerCompareUnsigned:
+      name: "org.openrewrite.java.migrate.guava.PreferIntegerCompareUnsigned"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegercompareunsigned"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferIntegerDivideUnsigned:
+      name: "org.openrewrite.java.migrate.guava.PreferIntegerDivideUnsigned"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegerdivideunsigned"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferIntegerParseUnsignedInt:
+      name: "org.openrewrite.java.migrate.guava.PreferIntegerParseUnsignedInt"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegerparseunsignedint"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferIntegerRemainderUnsigned:
+      name: "org.openrewrite.java.migrate.guava.PreferIntegerRemainderUnsigned"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferintegerremainderunsigned"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsSynchronizedNavigableMap:
+      name: "org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsSynchronizedNavigableMap"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilcollectionssynchronizednavigablemap"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsUnmodifiableNavigableMap:
+      name: "org.openrewrite.java.migrate.guava.PreferJavaUtilCollectionsUnmodifiableNavigableMap"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilcollectionsunmodifiablenavigablemap"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferJavaUtilFunction:
+      name: "org.openrewrite.java.migrate.guava.PreferJavaUtilFunction"
+      description: "Guava's `Function` extends `java.util.function.Function`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilfunction"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsEquals:
+      name: "org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsEquals"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilobjectsequals"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsHashCode:
+      name: "org.openrewrite.java.migrate.guava.PreferJavaUtilObjectsHashCode"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilobjectshashcode"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferJavaUtilPredicate:
+      name: "org.openrewrite.java.migrate.guava.PreferJavaUtilPredicate"
+      description: "Guava's `Predicate` extends `java.util.function.Predicate`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilpredicate"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferJavaUtilSupplier:
+      name: "org.openrewrite.java.migrate.guava.PreferJavaUtilSupplier"
+      description: "Guava's `Supplier` extends `java.util.function.Supplier`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferjavautilsupplier"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferLongCompare:
+      name: "org.openrewrite.java.migrate.guava.PreferLongCompare"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongcompare"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferLongCompareUnsigned:
+      name: "org.openrewrite.java.migrate.guava.PreferLongCompareUnsigned"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongcompareunsigned"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferLongDivideUnsigned:
+      name: "org.openrewrite.java.migrate.guava.PreferLongDivideUnsigned"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongdivideunsigned"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferLongParseUnsignedLong:
+      name: "org.openrewrite.java.migrate.guava.PreferLongParseUnsignedLong"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongparseunsignedlong"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferLongRemainderUnsigned:
+      name: "org.openrewrite.java.migrate.guava.PreferLongRemainderUnsigned"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/preferlongremainderunsigned"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferMathAddExact:
+      name: "org.openrewrite.java.migrate.guava.PreferMathAddExact"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefermathaddexact"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferMathMultiplyExact:
+      name: "org.openrewrite.java.migrate.guava.PreferMathMultiplyExact"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefermathmultiplyexact"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferMathSubtractExact:
+      name: "org.openrewrite.java.migrate.guava.PreferMathSubtractExact"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefermathsubtractexact"
+      options: []
+    org.openrewrite.java.migrate.guava.PreferShortCompare:
+      name: "org.openrewrite.java.migrate.guava.PreferShortCompare"
+      description: "This method exists in the Java standard library now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/guava/prefershortcompare"
+      options: []
+    org.openrewrite.java.migrate.jacoco.UpgradeJaCoCoMavenPluginVersion:
+      name: "org.openrewrite.java.migrate.jacoco.UpgradeJaCoCoMavenPluginVersion"
+      description: "This recipe will upgrade the JaCoCo Maven plugin to a more recent\
+        \ version compatible with Java 11."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jacoco/upgradejacocomavenpluginversion"
+      options: []
+    org.openrewrite.java.migrate.jakarta.ChangeJavaxAnnotationToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.ChangeJavaxAnnotationToJakarta"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation. Excludes `javax.annotation.processing`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/changejavaxannotationtojakarta"
+      options: []
+    org.openrewrite.java.migrate.jakarta.EhcacheJavaxToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.EhcacheJavaxToJakarta"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/ehcachejavaxtojakarta"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JacksonJavaxToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.JacksonJavaxToJakarta"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/jacksonjavaxtojakarta"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxActivationMigrationToJakartaActivation:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxActivationMigrationToJakartaActivation"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxactivationmigrationtojakartaactivation"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxAnnotationMigrationToJakartaAnnotation:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxAnnotationMigrationToJakartaAnnotation"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxannotationmigrationtojakartaannotation"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxAnnotationPackageToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxAnnotationPackageToJakarta"
+      description: "Change type of classes in the `javax.annotation` package to jakarta."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxannotationpackagetojakarta"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxAnnotationSecurityPackageToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxAnnotationSecurityPackageToJakarta"
+      description: "Change type of classes in the `javax.annotation.security` package\
+        \ to jakarta."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxannotationsecuritypackagetojakarta"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxAnnotationSqlPackageToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxAnnotationSqlPackageToJakarta"
+      description: "Change type of classes in the `javax.annotation.sql` package to\
+        \ jakarta."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxannotationsqlpackagetojakarta"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxBatchMigrationToJakartaBatch:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxBatchMigrationToJakartaBatch"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxbatchmigrationtojakartabatch"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxDecoratorToJakartaDecorator:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxDecoratorToJakartaDecorator"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxdecoratortojakartadecorator"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxEjbToJakartaEjb:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxEjbToJakartaEjb"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxejbtojakartaejb"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxElToJakartaEl:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxElToJakartaEl"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxeltojakartael"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxEnterpriseToJakartaEnterprise:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxEnterpriseToJakartaEnterprise"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxenterprisetojakartaenterprise"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxFacesToJakartaFaces:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxFacesToJakartaFaces"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxfacestojakartafaces"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxInjectMigrationToJakartaInject:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxInjectMigrationToJakartaInject"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxinjectmigrationtojakartainject"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxInterceptorToJakartaInterceptor:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxInterceptorToJakartaInterceptor"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxinterceptortojakartainterceptor"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxJmsToJakartaJms:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxJmsToJakartaJms"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxjmstojakartajms"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxJsonToJakartaJson:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxJsonToJakartaJson"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxjsontojakartajson"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxJwsToJakartaJws:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxJwsToJakartaJws"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxjwstojakartajws"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxMailToJakartaMail:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxMailToJakartaMail"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxmailtojakartamail"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta"
+      description: "Jakarta EE 9 is the first version of Jakarta EE that uses the\
+        \ new `jakarta` namespace."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxmigrationtojakarta"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxPeristenceXmlToJakartaPersistenceXml:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxPeristenceXmlToJakartaPersistenceXml"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxperistencexmltojakartapersistencexml"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxPersistenceToJakartaPersistence:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxPersistenceToJakartaPersistence"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxpersistencetojakartapersistence"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxResourceToJakartaResource:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxResourceToJakartaResource"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxresourcetojakartaresource"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxSecurityToJakartaSecurity:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxSecurityToJakartaSecurity"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxsecuritytojakartasecurity"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxServletToJakartaServlet:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxServletToJakartaServlet"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxservlettojakartaservlet"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxTransactionMigrationToJakartaTransaction:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxTransactionMigrationToJakartaTransaction"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxtransactionmigrationtojakartatransaction"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxValidationMigrationToJakartaValidation:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxValidationMigrationToJakartaValidation"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxvalidationmigrationtojakartavalidation"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxWebsocketToJakartaWebsocket:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxWebsocketToJakartaWebsocket"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxwebsockettojakartawebsocket"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxWsToJakartaWs:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxWsToJakartaWs"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxwstojakartaws"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxXmlBindMigrationToJakartaXmlBind:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxXmlBindMigrationToJakartaXmlBind"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxxmlbindmigrationtojakartaxmlbind"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxXmlSoapToJakartaXmlSoap:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxXmlSoapToJakartaXmlSoap"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxxmlsoaptojakartaxmlsoap"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JavaxXmlWsMigrationToJakartaXmlWs:
+      name: "org.openrewrite.java.migrate.jakarta.JavaxXmlWsMigrationToJakartaXmlWs"
+      description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
+        \ relocation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/javaxxmlwsmigrationtojakartaxmlws"
+      options: []
+    org.openrewrite.java.migrate.jakarta.JohnzonJavaxToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.JohnzonJavaxToJakarta"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/johnzonjavaxtojakarta"
+      options: []
+    org.openrewrite.java.migrate.jakarta.RestAssuredJavaxToJakarta:
+      name: "org.openrewrite.java.migrate.jakarta.RestAssuredJavaxToJakarta"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/jakarta/restassuredjavaxtojakarta"
+      options: []
+    org.openrewrite.java.migrate.javax.AddInjectDependencies:
+      name: "org.openrewrite.java.migrate.javax.AddInjectDependencies"
+      description: "This recipe will add the necessary Inject dependencies for those\
+        \ projects migrating to Java 11."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addinjectdependencies"
+      options: []
+    org.openrewrite.java.migrate.javax.AddJaxbDependencies:
+      name: "org.openrewrite.java.migrate.javax.AddJaxbDependencies"
+      description: "This recipe will add explicit dependencies for Jakarta EE 8 when\
+        \ a Java 8 application is using JAXB. Any existing dependencies will be upgraded\
+        \ to the latest version of Jakarta EE 8. **The artifacts are moved to Jakarta\
+        \ EE 8 but the application can continue to use the `javax.xml.bind` namespace.\n"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addjaxbdependencies"
+      options: []
+    org.openrewrite.java.migrate.javax.AddJaxbRuntime:
+      name: "org.openrewrite.java.migrate.javax.AddJaxbRuntime"
+      description: "Update maven build files to use the latest JAXB runtime from Jakarta\
+        \ EE 8 to maintain compatibility with Java version 11 or greater.  The recipe\
+        \ will add a JAXB run-time, in `provided` scope, to any project that has a\
+        \ transitive dependency on the JAXB API. **The resulting dependencies still\
+        \ use the `javax` namespace, despite the move to the Jakarta artifact**."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addjaxbruntime"
+      options:
+      - name: "runtime"
+        type: "String"
+        required: true
+    org.openrewrite.java.migrate.javax.AddJaxwsDependencies:
+      name: "org.openrewrite.java.migrate.javax.AddJaxwsDependencies"
+      description: "This recipe will add explicit dependencies for Jakarta EE 8 when\
+        \ a Java 8 application is using JAX-WS. Any existing dependencies will be\
+        \ upgraded to the latest version of Jakarta EE 8. **The artifacts are moved\
+        \ to Jakarta EE 8 but the application can continue to use the `javax.xml.bind`\
+        \ namespace.\n"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addjaxwsdependencies"
+      options: []
+    org.openrewrite.java.migrate.javax.AddJaxwsRuntime:
+      name: "org.openrewrite.java.migrate.javax.AddJaxwsRuntime"
+      description: "Update maven build files to use the latest JAX-WS runtime from\
+        \ Jakarta EE 8 to maintain compatibility with Java version 11 or greater.\
+        \  The recipe will add a JAX-WS run-time, in `provided` scope, to any project\
+        \ that has a transitive dependency on the JAX-WS API. **The resulting dependencies\
+        \ still use the `javax` namespace, despite the move to the Jakarta artifact**."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/addjaxwsruntime"
+      options: []
+    org.openrewrite.java.migrate.javax.JavaxLangModelUtil:
+      name: "org.openrewrite.java.migrate.javax.JavaxLangModelUtil"
+      description: "Certain `javax.lang.model.util` APIs have become deprecated and\
+        \ their usages changed, necessitating usage changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/javaxlangmodelutil"
+      options: []
+    org.openrewrite.java.migrate.javax.JavaxManagementMonitorAPIs:
+      name: "org.openrewrite.java.migrate.javax.JavaxManagementMonitorAPIs"
+      description: "Certain `javax.management.monitor` APIs have become deprecated\
+        \ and their usages changed, necessitating usage changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/javaxmanagementmonitorapis"
+      options: []
+    org.openrewrite.java.migrate.javax.JavaxXmlStreamAPIs:
+      name: "org.openrewrite.java.migrate.javax.JavaxXmlStreamAPIs"
+      description: "Certain `javax.xml.stream` APIs have become deprecated and their\
+        \ usages changed, necessitating usage changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/javaxxmlstreamapis"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateAbstractAnnotationValueVisitor6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateAbstractAnnotationValueVisitor6To9"
+      description: "`AbstractAnnotationValueVisitor6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateabstractannotationvaluevisitor6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateAbstractElementVisitor6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateAbstractElementVisitor6To9"
+      description: "`AbstractElementVisitor6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateabstractelementvisitor6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateAbstractTypeVisitor6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateAbstractTypeVisitor6To9"
+      description: "`AbstractTypeVisitor6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateabstracttypevisitor6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateCounterMonitorSetThreshholdToSetInitThreshold:
+      name: "org.openrewrite.java.migrate.javax.MigrateCounterMonitorSetThreshholdToSetInitThreshold"
+      description: "`CounterMonitor#setThreshhold` has been deprecated in JMX 1.2."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratecountermonitorsetthreshholdtosetinitthreshold"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateElementKindVisitor6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateElementKindVisitor6To9"
+      description: "`ElementKindVisitor6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateelementkindvisitor6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateElementScanner6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateElementScanner6To9"
+      description: "`ElementScanner6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migrateelementscanner6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateSimpleAnnotationValueVisitor6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateSimpleAnnotationValueVisitor6To9"
+      description: "`SimpleAnnotationValueVisitor6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratesimpleannotationvaluevisitor6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateSimpleElementVisitor6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateSimpleElementVisitor6To9"
+      description: "`SimpleElementVisitor6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratesimpleelementvisitor6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateSimpleTypeVisitor6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateSimpleTypeVisitor6To9"
+      description: "`SimpleTypeVisitor6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratesimpletypevisitor6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateTypeKindVisitor6To9:
+      name: "org.openrewrite.java.migrate.javax.MigrateTypeKindVisitor6To9"
+      description: "`TypeKindVisitor6` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratetypekindvisitor6to9"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateXMLEventFactoryNewInstanceToNewFactory:
+      name: "org.openrewrite.java.migrate.javax.MigrateXMLEventFactoryNewInstanceToNewFactory"
+      description: "`javax.xml.stream.XMLEventFactory#newInstance` has been deprecated\
+        \ in Java 7."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratexmleventfactorynewinstancetonewfactory"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateXMLInputFactoryNewInstanceToNewFactory:
+      name: "org.openrewrite.java.migrate.javax.MigrateXMLInputFactoryNewInstanceToNewFactory"
+      description: "`javax.xml.stream.XMLInputFactory#newInstance` has been deprecated\
+        \ Java 7."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratexmlinputfactorynewinstancetonewfactory"
+      options: []
+    org.openrewrite.java.migrate.javax.MigrateXMLOutputFactoryNewInstanceToNewFactory:
+      name: "org.openrewrite.java.migrate.javax.MigrateXMLOutputFactoryNewInstanceToNewFactory"
+      description: "`javax.xml.stream.XMLOutputFactory#newInstance` has been deprecated\
+        \ Java 7."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/javax/migratexmloutputfactorynewinstancetonewfactory"
+      options: []
+    org.openrewrite.java.migrate.lang.JavaLangAPIs:
+      name: "org.openrewrite.java.migrate.lang.JavaLangAPIs"
+      description: "Certain Java lang APIs have become deprecated and their usages\
+        \ changed, necessitating usage changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/javalangapis"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterOrDigitToIsJavaIdentifierPart:
+      name: "org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterOrDigitToIsJavaIdentifierPart"
+      description: "`Character#isJavaLetterOrDigit(char)` was deprecated in Java 1.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migratecharacterisjavaletterordigittoisjavaidentifierpart"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterToIsJavaIdentifierStart:
+      name: "org.openrewrite.java.migrate.lang.MigrateCharacterIsJavaLetterToIsJavaIdentifierStart"
+      description: "`Character#isJavaLetter(char)` was deprecated in Java 1.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migratecharacterisjavalettertoisjavaidentifierstart"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateCharacterIsSpaceToIsWhitespace:
+      name: "org.openrewrite.java.migrate.lang.MigrateCharacterIsSpaceToIsWhitespace"
+      description: "`Character#isSpace(char)` was deprecated in Java 1.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migratecharacterisspacetoiswhitespace"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateClassLoaderDefineClass:
+      name: "org.openrewrite.java.migrate.lang.MigrateClassLoaderDefineClass"
+      description: "`ClassLoader#defineClass(byte[], int, int)` was deprecated in\
+        \ Java 1.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateclassloaderdefineclass"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateClassNewInstanceToGetDeclaredConstructorNewInstance:
+      name: "org.openrewrite.java.migrate.lang.MigrateClassNewInstanceToGetDeclaredConstructorNewInstance"
+      description: "`Class#newInstance()` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateclassnewinstancetogetdeclaredconstructornewinstance"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateRuntimeVersionMajorToFeature:
+      name: "org.openrewrite.java.migrate.lang.MigrateRuntimeVersionMajorToFeature"
+      description: "`Runtime.Version#major()` was deprecated in Java 10."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateruntimeversionmajortofeature"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateRuntimeVersionMinorToInterim:
+      name: "org.openrewrite.java.migrate.lang.MigrateRuntimeVersionMinorToInterim"
+      description: "`Runtime.Version#minor()` was deprecated in Java 10."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateruntimeversionminortointerim"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateRuntimeVersionSecurityToUpdate:
+      name: "org.openrewrite.java.migrate.lang.MigrateRuntimeVersionSecurityToUpdate"
+      description: "`Runtime.Version#security()` was deprecated in Java 10."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migrateruntimeversionsecuritytoupdate"
+      options: []
+    org.openrewrite.java.migrate.lang.MigrateSecurityManagerMulticast:
+      name: "org.openrewrite.java.migrate.lang.MigrateSecurityManagerMulticast"
+      description: "`SecurityManager#checkMulticast(InetAddress, byte)` was deprecated\
+        \ in Java 1.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/migratesecuritymanagermulticast"
+      options: []
+    org.openrewrite.java.migrate.lang.StringFormatted:
+      name: "org.openrewrite.java.migrate.lang.StringFormatted"
+      description: "Call `String#formatted(Object...)` on first argument to `String#format(String,\
+        \ Object...)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lang/stringformatted"
+      options: []
+    org.openrewrite.java.migrate.logging.JavaLoggingAPIs:
+      name: "org.openrewrite.java.migrate.logging.JavaLoggingAPIs"
+      description: "Certain Java logging APIs have become deprecated and their usages\
+        \ changed, necessitating usage changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/javaloggingapis"
+      options: []
+    org.openrewrite.java.migrate.logging.MigrateGetLoggingMXBeanToGetPlatformMXBean:
+      name: "org.openrewrite.java.migrate.logging.MigrateGetLoggingMXBeanToGetPlatformMXBean"
+      description: "`LogManager#getLoggingMXBean()` was deprecated in Java 9."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migrategetloggingmxbeantogetplatformmxbean"
+      options: []
+    org.openrewrite.java.migrate.logging.MigrateInterfaceLoggingMXBeanToPlatformLoggingMXBean:
+      name: "org.openrewrite.java.migrate.logging.MigrateInterfaceLoggingMXBeanToPlatformLoggingMXBean"
+      description: "`java.util.logging.LoggingMXBean` has been deprecated."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migrateinterfaceloggingmxbeantoplatformloggingmxbean"
+      options: []
+    org.openrewrite.java.migrate.logging.MigrateLogRecordSetMillisToSetInstant:
+      name: "org.openrewrite.java.migrate.logging.MigrateLogRecordSetMillisToSetInstant"
+      description: "`LogRecord#setMillis(long)` has been deprecated."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migratelogrecordsetmillistosetinstant"
+      options: []
+    org.openrewrite.java.migrate.logging.MigrateLoggerGlobalToGetGlobal:
+      name: "org.openrewrite.java.migrate.logging.MigrateLoggerGlobalToGetGlobal"
+      description: "The preferred way to get the global logger object is via the call\
+        \ `Logger#getGlobal()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migrateloggerglobaltogetglobal"
+      options: []
+    org.openrewrite.java.migrate.logging.MigrateLoggerLogrbToUseResourceBundle:
+      name: "org.openrewrite.java.migrate.logging.MigrateLoggerLogrbToUseResourceBundle"
+      description: "`java.util.logging.Logger#logrb(.., String bundleName, ..)` has\
+        \ been deprecated."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/logging/migrateloggerlogrbtouseresourcebundle"
+      options: []
+    org.openrewrite.java.migrate.lombok.LombokValToFinalVar:
+      name: "org.openrewrite.java.migrate.lombok.LombokValToFinalVar"
+      description: "Replace `lombok.val` with `final var` on projects using Java 11\
+        \ or higher."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lombok/lombokvaltofinalvar"
+      options: []
+    org.openrewrite.java.migrate.lombok.UpdateLombokToJava17:
+      name: "org.openrewrite.java.migrate.lombok.UpdateLombokToJava17"
+      description: "Update Lombok dependency to a version that is compatible with\
+        \ Java 17."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/lombok/updatelomboktojava17"
+      options: []
+    org.openrewrite.java.migrate.metrics.SimplifyMicrometerMeterTags:
+      name: "org.openrewrite.java.migrate.metrics.SimplifyMicrometerMeterTags"
+      description: "Use the simplest method to add new tags."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/metrics/simplifymicrometermetertags"
+      options: []
+    org.openrewrite.java.migrate.net.JavaNetAPIs:
+      name: "org.openrewrite.java.migrate.net.JavaNetAPIs"
+      description: "Certain Java networking APIs have become deprecated and their\
+        \ usages changed, necessitating usage changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/javanetapis"
+      options: []
+    org.openrewrite.java.migrate.net.MigrateHttpURLConnectionHttpServerErrorToHttpInternalError:
+      name: "org.openrewrite.java.migrate.net.MigrateHttpURLConnectionHttpServerErrorToHttpInternalError"
+      description: "`java.net.HttpURLConnection.HTTP_SERVER_ERROR` has been deprecated."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migratehttpurlconnectionhttpservererrortohttpinternalerror"
+      options: []
+    org.openrewrite.java.migrate.net.MigrateMulticastSocketGetTTLToGetTimeToLive:
+      name: "org.openrewrite.java.migrate.net.MigrateMulticastSocketGetTTLToGetTimeToLive"
+      description: "`java.net.MulticastSocket#getTTL()` has been deprecated."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migratemulticastsocketgetttltogettimetolive"
+      options: []
+    org.openrewrite.java.migrate.net.MigrateMulticastSocketSetTTLToSetTimeToLive:
+      name: "org.openrewrite.java.migrate.net.MigrateMulticastSocketSetTTLToSetTimeToLive"
+      description: "`java.net.MulticastSocket#setTTL(byte)` has been deprecated."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migratemulticastsocketsetttltosettimetolive"
+      options: []
+    org.openrewrite.java.migrate.net.MigrateURLDecoderDecode:
+      name: "org.openrewrite.java.migrate.net.MigrateURLDecoderDecode"
+      description: "`java.net.URLDecoder#decode(String)` is platform-dependent. It's\
+        \ advised to specify an encoding."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migrateurldecoderdecode"
+      options: []
+    org.openrewrite.java.migrate.net.MigrateURLEncoderEncode:
+      name: "org.openrewrite.java.migrate.net.MigrateURLEncoderEncode"
+      description: "`java.net.URLEncoder#encode(String)` is platform-dependent. It's\
+        \ advised to specify an encoding."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/net/migrateurlencoderencode"
+      options: []
+    org.openrewrite.java.migrate.search.AboutJavaVersion:
+      name: "org.openrewrite.java.migrate.search.AboutJavaVersion"
+      description: "A diagnostic for studying the applicability of Java version constraints."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/search/aboutjavaversion"
+      options:
+      - name: "whenUsesType"
+        type: "String"
+        required: false
+    org.openrewrite.java.migrate.sql.JavaSqlAPIs:
+      name: "org.openrewrite.java.migrate.sql.JavaSqlAPIs"
+      description: "Certain Java sql APIs have become deprecated and their usages\
+        \ changed, necessitating usage changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/sql/javasqlapis"
+      options: []
+    org.openrewrite.java.migrate.sql.MigrateDriverManagerSetLogStream:
+      name: "org.openrewrite.java.migrate.sql.MigrateDriverManagerSetLogStream"
+      description: "`DriverManager#setLogStream(java.io.PrintStream)` was deprecated\
+        \ in Java 1.2."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/sql/migratedrivermanagersetlogstream"
+      options: []
+    org.openrewrite.java.migrate.util.JavaUtilAPIs:
+      name: "org.openrewrite.java.migrate.util.JavaUtilAPIs"
+      description: "Certain java util APIs have been introduced and are favored over\
+        \ previous APIs."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/javautilapis"
+      options: []
+    org.openrewrite.java.migrate.util.MigrateCollectionsSingletonList:
+      name: "org.openrewrite.java.migrate.util.MigrateCollectionsSingletonList"
+      description: "Replaces `Collections.singletonList(<args>)))` with `List.Of(<args>)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionssingletonlist"
+      options: []
+    org.openrewrite.java.migrate.util.MigrateCollectionsSingletonMap:
+      name: "org.openrewrite.java.migrate.util.MigrateCollectionsSingletonMap"
+      description: "Replaces `Collections.singletonMap(<args>)))` with `Map.Of(<args>)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionssingletonmap"
+      options: []
+    org.openrewrite.java.migrate.util.MigrateCollectionsSingletonSet:
+      name: "org.openrewrite.java.migrate.util.MigrateCollectionsSingletonSet"
+      description: "Replaces `Collections.singleton(<args>)))` with `Set.Of(<args>)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionssingletonset"
+      options: []
+    org.openrewrite.java.migrate.util.MigrateCollectionsUnmodifiableList:
+      name: "org.openrewrite.java.migrate.util.MigrateCollectionsUnmodifiableList"
+      description: "Replaces `unmodifiableList(java.util.Arrays asList(<args>))` with\
+        \ `List.Of(<args>)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionsunmodifiablelist"
+      options: []
+    org.openrewrite.java.migrate.util.MigrateCollectionsUnmodifiableSet:
+      name: "org.openrewrite.java.migrate.util.MigrateCollectionsUnmodifiableSet"
+      description: "Replaces `unmodifiableSet(java.util.Set(java.util.Arrays asList(<args>)))`\
+        \ with `Set.Of(<args>)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/migratecollectionsunmodifiableset"
+      options: []
+    org.openrewrite.java.migrate.util.OptionalNotEmptyToIsPresent:
+      name: "org.openrewrite.java.migrate.util.OptionalNotEmptyToIsPresent"
+      description: "Replace negated Optional.isEmpty() calls with Optional.isPresent()\
+        \ in Java 11 and above."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/optionalnotemptytoispresent"
+      options: []
+    org.openrewrite.java.migrate.util.OptionalNotPresentToIsEmpty:
+      name: "org.openrewrite.java.migrate.util.OptionalNotPresentToIsEmpty"
+      description: "Replace negated Optional.isPresent() calls with Optional.isEmpty()\
+        \ in Java 11 and above."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/optionalnotpresenttoisempty"
+      options: []
+    org.openrewrite.java.migrate.util.UseEnumSetOf:
+      name: "org.openrewrite.java.migrate.util.UseEnumSetOf"
+      description: "Replaces `Set of(..)` with `EnumSet of(..)` if the arguments are\
+        \ enums."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/useenumsetof"
+      options: []
+    org.openrewrite.java.migrate.util.UseMapOf:
+      name: "org.openrewrite.java.migrate.util.UseMapOf"
+      description: "This succinct syntax was introduced in Java 10."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/util/usemapof"
+      options: []
+    org.openrewrite.java.migrate.wro4j.UpgradeWro4jMavenPluginVersion:
+      name: "org.openrewrite.java.migrate.wro4j.UpgradeWro4jMavenPluginVersion"
+      description: "This recipe will upgrade Wro4j to a more recent version compatible\
+        \ with Java 11."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/migrate/wro4j/upgradewro4jmavenpluginversion"
+      options: []
+rewrite-properties:
+  artifactId: "rewrite-properties"
+  version: "7.33.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.properties.AddProperty:
+      name: "org.openrewrite.properties.AddProperty"
+      description: "Adds a new property to a property file at the bottom of the file\
+        \ if it's missing. Whitespace before and after the `=` must be included in\
+        \ the property and value."
+      docLink: "https://docs.openrewrite.org/reference/recipes/properties/addproperty"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "property"
+        type: "String"
+        required: true
+      - name: "value"
+        type: "String"
+        required: true
+    org.openrewrite.properties.ChangePropertyKey:
+      name: "org.openrewrite.properties.ChangePropertyKey"
+      description: "Change a property key leaving the value intact."
+      docLink: "https://docs.openrewrite.org/reference/recipes/properties/changepropertykey"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newPropertyKey"
+        type: "String"
+        required: true
+      - name: "oldPropertyKey"
+        type: "String"
+        required: true
+      - name: "relaxedBinding"
+        type: "Boolean"
+        required: false
+    org.openrewrite.properties.ChangePropertyValue:
+      name: "org.openrewrite.properties.ChangePropertyValue"
+      description: "Change a property value leaving the key intact."
+      docLink: "https://docs.openrewrite.org/reference/recipes/properties/changepropertyvalue"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newValue"
+        type: "String"
+        required: true
+      - name: "oldValue"
+        type: "String"
+        required: false
+      - name: "propertyKey"
+        type: "String"
+        required: true
+      - name: "relaxedBinding"
+        type: "Boolean"
+        required: false
+    org.openrewrite.properties.DeleteProperty:
+      name: "org.openrewrite.properties.DeleteProperty"
+      description: "Deletes key/value pairs from properties files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/properties/deleteproperty"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "propertyKey"
+        type: "String"
+        required: true
+      - name: "relaxedBinding"
+        type: "Boolean"
+        required: false
+    org.openrewrite.properties.search.FindProperties:
+      name: "org.openrewrite.properties.search.FindProperties"
+      description: "Finds occurrences of a property key."
+      docLink: "https://docs.openrewrite.org/reference/recipes/properties/search/findproperties"
+      options:
+      - name: "propertyKey"
+        type: "String"
+        required: true
+      - name: "relaxedBinding"
+        type: "Boolean"
+        required: false
+rewrite-quarkus:
+  artifactId: "rewrite-quarkus"
+  version: "1.14.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.java.quarkus.ConfigPropertiesToConfigMapping:
+      name: "org.openrewrite.java.quarkus.ConfigPropertiesToConfigMapping"
+      description: "Migrate Quarkus configuration classes annotated with `@ConfigProperties`\
+        \ to the equivalent Smallrye `@ConfigMapping`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/configpropertiestoconfigmapping"
+      options: []
+    org.openrewrite.java.quarkus.ConfigureQuarkusMavenPluginWithReasonableDefaults:
+      name: "org.openrewrite.java.quarkus.ConfigureQuarkusMavenPluginWithReasonableDefaults"
+      description: "Configures the `quarkus-maven-plugin` with reasonable defaults,\
+        \ such as default activated `goals` and `<extensions>` configuration."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/configurequarkusmavenpluginwithreasonabledefaults"
+      options: []
+    org.openrewrite.java.quarkus.MigrateQuarkusMavenPluginNativeImageGoal:
+      name: "org.openrewrite.java.quarkus.MigrateQuarkusMavenPluginNativeImageGoal"
+      description: "Migrates the `quarkus-maven-plugin` deprecated `native-image`\
+        \ goal. If the `native-image` goal needs to be removed, this adds `<quarkus.package.type>native</quarkus.package.type>`\
+        \ to the `native` profile `properties` section, given the `native` profile\
+        \ exists in the `pom.xml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/migratequarkusmavenpluginnativeimagegoal"
+      options: []
+    org.openrewrite.java.quarkus.MultiTransformHotStreamToMultiHotStream:
+      name: "org.openrewrite.java.quarkus.MultiTransformHotStreamToMultiHotStream"
+      description: "Replace Mutiny API usages of `multi.transform().toHotStream()`\
+        \ with `multi.toHotStream()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/multitransformhotstreamtomultihotstream"
+      options: []
+    org.openrewrite.java.quarkus.Quarkus1to1_13Migration:
+      name: "org.openrewrite.java.quarkus.Quarkus1to1_13Migration"
+      description: "Migrates Quarkus 1.11 to 1.13."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus1to1_13migration"
+      options: []
+    org.openrewrite.java.quarkus.quarkus2.GrpcServiceAnnotationToGrpcClient:
+      name: "org.openrewrite.java.quarkus.quarkus2.GrpcServiceAnnotationToGrpcClient"
+      description: "The `@GrpcService` annotation is replaced with `@GrpcClient` in\
+        \ Quarkus 2.x. Removes the optional `@GrpcClient.value()` unless the service\
+        \ name is different from the name of annotated element."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/grpcserviceannotationtogrpcclient"
+      options: []
+    org.openrewrite.java.quarkus.quarkus2.Quarkus1to2Migration:
+      name: "org.openrewrite.java.quarkus.quarkus2.Quarkus1to2Migration"
+      description: "Migrates Quarkus 1.x to 2.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/quarkus1to2migration"
+      options: []
+    org.openrewrite.java.quarkus.quarkus2.RemoveAvroMavenPlugin:
+      name: "org.openrewrite.java.quarkus.quarkus2.RemoveAvroMavenPlugin"
+      description: "Removes the `avro-maven-plugin` if the `quarkus-maven-plugin`\
+        \ is found in the project's `pom.xml`. Avro has been integrated with the Quarkus\
+        \ code generation mechanism. This replaces the need to use the Avro plugin."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/removeavromavenplugin"
+      options: []
+    org.openrewrite.java.quarkus.quarkus2.UseIdentifierOnDefaultKafkaBroker:
+      name: "org.openrewrite.java.quarkus.quarkus2.UseIdentifierOnDefaultKafkaBroker"
+      description: "Use `@io.smallrye.common.annotation.Identifier` on default kafka\
+        \ broker configuration."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/useidentifierondefaultkafkabroker"
+      options: []
+    org.openrewrite.java.quarkus.quarkus2.UsePanacheEntityBaseStaticMethods:
+      name: "org.openrewrite.java.quarkus.quarkus2.UsePanacheEntityBaseStaticMethods"
+      description: "The `getEntityManager()` and the `flush()` methods of `PanacheEntityBase`\
+        \ are now static methods."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/usepanacheentitybasestaticmethods"
+      options: []
+    org.openrewrite.java.quarkus.quarkus2.UsePanacheEntityBaseUniT:
+      name: "org.openrewrite.java.quarkus.quarkus2.UsePanacheEntityBaseUniT"
+      description: "The `persist()` and `persistAndFlush()` methods now return an\
+        \ `Uni<T extends PanacheEntityBase>` instead of an `Uni<Void>` to allow chaining\
+        \ the methods."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/usepanacheentitybaseunit"
+      options: []
+    org.openrewrite.java.quarkus.quarkus2.UseReactivePanacheMongoEntityBaseUniT:
+      name: "org.openrewrite.java.quarkus.quarkus2.UseReactivePanacheMongoEntityBaseUniT"
+      description: "The `persist()`, `update()`, and `persistOrUpdate()` methods now\
+        \ return a `Uni<T extends ReactivePanacheMongoEntityBase>` instead of a `Uni<Void>`\
+        \ to allow chaining the methods."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/quarkus/quarkus2/usereactivepanachemongoentitybaseunit"
+      options: []
+rewrite-spring:
+  artifactId: "rewrite-spring"
+  version: "4.30.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.java.spring.AddSpringProperty:
+      name: "org.openrewrite.java.spring.AddSpringProperty"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/addspringproperty"
+      options:
+      - name: "comment"
+        type: "String"
+        required: false
+      - name: "pathExpressions"
+        type: "List"
+        required: false
+      - name: "property"
+        type: "String"
+        required: true
+      - name: "value"
+        type: "String"
+        required: true
+    org.openrewrite.java.spring.BeanMethodsNotPublic:
+      name: "org.openrewrite.java.spring.BeanMethodsNotPublic"
+      description: "Remove public modifier from `@Bean` methods. They no longer have\
+        \ to be public visibility to be usable by Spring."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/beanmethodsnotpublic"
+      options: []
+    org.openrewrite.java.spring.ChangeSpringPropertyKey:
+      name: "org.openrewrite.java.spring.ChangeSpringPropertyKey"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/changespringpropertykey"
+      options:
+      - name: "except"
+        type: "List"
+        required: false
+      - name: "newPropertyKey"
+        type: "String"
+        required: true
+      - name: "oldPropertyKey"
+        type: "String"
+        required: true
+    org.openrewrite.java.spring.DeleteSpringProperty:
+      name: "org.openrewrite.java.spring.DeleteSpringProperty"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/deletespringproperty"
+      options:
+      - name: "propertyKey"
+        type: "String"
+        required: true
+    org.openrewrite.java.spring.ExpandProperties:
+      name: "org.openrewrite.java.spring.ExpandProperties"
+      description: "Expand YAML properties to not use the dot syntax shortcut."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/expandproperties"
+      options:
+      - name: "sourceFileMask"
+        type: "String"
+        required: false
+    org.openrewrite.java.spring.ImplicitWebAnnotationNames:
+      name: "org.openrewrite.java.spring.ImplicitWebAnnotationNames"
+      description: "Removes implicit web annotation names."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/implicitwebannotationnames"
+      options: []
+    org.openrewrite.java.spring.NoAutowiredOnConstructor:
+      name: "org.openrewrite.java.spring.NoAutowiredOnConstructor"
+      description: "Spring can infer an autowired constructor when there is a single\
+        \ constructor on the bean. This recipe removes unneeded `@Autowired` annotations\
+        \ on constructors."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/noautowiredonconstructor"
+      options: []
+    org.openrewrite.java.spring.NoRequestMappingAnnotation:
+      name: "org.openrewrite.java.spring.NoRequestMappingAnnotation"
+      description: "Replace method declaration `@RequestMapping` annotations with\
+        \ `@GetMapping`, `@PostMapping`, etc. when possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/norequestmappingannotation"
+      options: []
+    org.openrewrite.java.spring.SeparateApplicationYamlByProfile:
+      name: "org.openrewrite.java.spring.SeparateApplicationYamlByProfile"
+      description: "The Spring team's recommendation is to separate profile properties\
+        \ into their own YAML files now."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/separateapplicationyamlbyprofile"
+      options: []
+    org.openrewrite.java.spring.UpdateApiManifest:
+      name: "org.openrewrite.java.spring.UpdateApiManifest"
+      description: "Keep a consolidated manifest of the API endpoints that this application\
+        \ exposes up-to-date."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/updateapimanifest"
+      options: []
+    org.openrewrite.java.spring.YamlPropertiesToKebabCase:
+      name: "org.openrewrite.java.spring.YamlPropertiesToKebabCase"
+      description: "Normalize Spring YAML properties to use lowercase and hyphen-separated\
+        \ syntax. For example, changing `spring.main.showBanner` to `spring.main.show-banner`.\
+        \ With [Spring's relaxed binding](https://docs.spring.io/spring-boot/docs/2.5.6/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding),\
+        \ `kebab-case` may be used in properties files and still be converted to configuration\
+        \ beans. Note, an exception to this is the case of `@Value`, which is match-sensitive.\
+        \ For example, `@Value(\"${anExampleValue}\")` will not match `an-example-value`.\
+        \ [The Spring reference documentation recommends using `kebab-case` for properties\
+        \ where possible.](https://docs.spring.io/spring-boot/docs/2.5.6/reference/html/features.html#features.external-config.typesafe-configuration-properties.relaxed-binding)\
+        \ ."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/yamlpropertiestokebabcase"
+      options: []
+    org.openrewrite.java.spring.boot2.ConditionalOnBeanAnyNestedCondition:
+      name: "org.openrewrite.java.spring.boot2.ConditionalOnBeanAnyNestedCondition"
+      description: "Migrate multi-condition `@ConditionalOnBean` annotations to `AnyNestedCondition`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/conditionalonbeananynestedcondition"
+      options: []
+    org.openrewrite.java.spring.boot2.DatabaseComponentAndBeanInitializationOrdering:
+      name: "org.openrewrite.java.spring.boot2.DatabaseComponentAndBeanInitializationOrdering"
+      description: "Beans of certain well-known types, such as JdbcTemplate, will\
+        \ be ordered so that they are initialized after the database has been initialized.\
+        \ If you have a bean that works with the DataSource directly, annotate its\
+        \ class or @Bean method with @DependsOnDatabaseInitialization to ensure that\
+        \ it too is initialized after the database has been initialized."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/databasecomponentandbeaninitializationordering"
+      options: []
+    org.openrewrite.java.spring.boot2.GetErrorAttributes:
+      name: "org.openrewrite.java.spring.boot2.GetErrorAttributes"
+      description: "`ErrorAttributes#getErrorAttributes(WebRequest, boolean)` was\
+        \ deprecated in Spring Boot 2.3."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/geterrorattributes"
+      options: []
+    org.openrewrite.java.spring.boot2.MergeBootstrapYamlWithApplicationYaml:
+      name: "org.openrewrite.java.spring.boot2.MergeBootstrapYamlWithApplicationYaml"
+      description: "In Spring Boot 2.4, support for `bootstrap.yml` was removed. It's\
+        \ properties should be merged with `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/mergebootstrapyamlwithapplicationyaml"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateAbstractHealthIndicatorToPingHealthIndicator:
+      name: "org.openrewrite.java.spring.boot2.MigrateAbstractHealthIndicatorToPingHealthIndicator"
+      description: "`org.springframework.boot.actuate.health.AbstractHealthIndicator`\
+        \ was deprecated in 2.2."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateabstracthealthindicatortopinghealthindicator"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateActuatorMediaTypeToApiVersion:
+      name: "org.openrewrite.java.spring.boot2.MigrateActuatorMediaTypeToApiVersion"
+      description: "Spring-Boot-Actuator `ActuatorMediaType` was deprecated in 2.5\
+        \ in favor of `ApiVersion#getProducedMimeType()`. Replace `MediaType.parseMediaType(ActuatorMediaType.Vx_JSON)`\
+        \ with `MediaType.asMediaType(ApiVersion.Vx.getProducedMimeType())`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateactuatormediatypetoapiversion"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanName:
+      name: "org.openrewrite.java.spring.boot2.MigrateConfigurationPropertiesBindingPostProcessorValidatorBeanName"
+      description: "Replaces field and static access of `ConfigurationPropertiesBindingPostProcessor#VALIDATOR_BEAN_NAME`\
+        \ with `EnableConfigurationProperties#VALIDATOR_BEAN_NAME`. Deprecated in\
+        \ 2.2.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateconfigurationpropertiesbindingpostprocessorvalidatorbeanname"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateDatabaseCredentials:
+      name: "org.openrewrite.java.spring.boot2.MigrateDatabaseCredentials"
+      description: "If you currently define a `spring.flyway.url` or `spring.liquibase.url`\
+        \ you may need to provide additional username and password properties. In\
+        \ earlier versions of Spring Boot, these settings were derived from `spring.datasource`\
+        \ properties but this turned out to be problematic for people that provided\
+        \ their own `DataSource` beans."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratedatabasecredentials"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateDiskSpaceHealthIndicatorConstructor:
+      name: "org.openrewrite.java.spring.boot2.MigrateDiskSpaceHealthIndicatorConstructor"
+      description: "`DiskSpaceHealthIndicator(File, long)` was deprecated in Spring\
+        \ Data 2.1 for removal in 2.2."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratediskspacehealthindicatorconstructor"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateErrorControllerPackageName:
+      name: "org.openrewrite.java.spring.boot2.MigrateErrorControllerPackageName"
+      description: "`org.springframework.boot.autoconfigure.web.ErrorController` was\
+        \ deprecated in 1.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateerrorcontrollerpackagename"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateErrorPropertiesIncludeStackTraceConstants:
+      name: "org.openrewrite.java.spring.boot2.MigrateErrorPropertiesIncludeStackTraceConstants"
+      description: "`ErrorProperties#IncludeStacktrace.ON_TRACE_PARAM` was deprecated\
+        \ in 2.3.x and removed in 2.5.0."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateerrorpropertiesincludestacktraceconstants"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateHibernateContraintsToJavax:
+      name: "org.openrewrite.java.spring.boot2.MigrateHibernateContraintsToJavax"
+      description: "`org.hibernate.validator.constraints` were deprecated in 1.x.\
+        \ in favor of their javax counterparts."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratehibernatecontraintstojavax"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateHsqlEmbeddedDatabaseConnection:
+      name: "org.openrewrite.java.spring.boot2.MigrateHsqlEmbeddedDatabaseConnection"
+      description: "Spring-Boot `EmbeddedDatabaseConnection.HSQL` was deprecated in\
+        \ favor of `EmbeddedDatabaseConnection.HSQLDB` in 2.4."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratehsqlembeddeddatabaseconnection"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateHttpMessageConvertersPackageName:
+      name: "org.openrewrite.java.spring.boot2.MigrateHttpMessageConvertersPackageName"
+      description: "`org.springframework.boot.autoconfigure.web.HttpMessageConverters`\
+        \ was deprecated in 1.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratehttpmessageconverterspackagename"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateLocalServerPortAnnotation:
+      name: "org.openrewrite.java.spring.boot2.MigrateLocalServerPortAnnotation"
+      description: "Updates the package and adds the necessary dependency if `LocalServerPort`\
+        \ is in use. The package of `LocalServerPort` was changed in Spring Boot 2.0,\
+        \ necessitating changes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratelocalserverportannotation"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateLoggingSystemPropertyConstants:
+      name: "org.openrewrite.java.spring.boot2.MigrateLoggingSystemPropertyConstants"
+      description: "Replaces field and static access of deprecated fields in `LoggingSystemProperties`\
+        \ with the recommendations from `LogbackLoggingSystemProperties`. Deprecated\
+        \ in 2.4.x and removed in 2.6.0."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateloggingsystempropertyconstants"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateMultipartConfigFactory:
+      name: "org.openrewrite.java.spring.boot2.MigrateMultipartConfigFactory"
+      description: "Methods to set `DataSize` with primitive arguments were deprecated\
+        \ in 2.1 and removed in 2.2."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratemultipartconfigfactory"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateRestClientBuilderCustomizerPackageName:
+      name: "org.openrewrite.java.spring.boot2.MigrateRestClientBuilderCustomizerPackageName"
+      description: "`org.springframework.boot.autoconfigure.elasticsearch.rest.RestClientBuilderCustomizer`\
+        \ was deprecated in 2.3."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migraterestclientbuildercustomizerpackagename"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateRestTemplateBuilderBasicAuthorization:
+      name: "org.openrewrite.java.spring.boot2.MigrateRestTemplateBuilderBasicAuthorization"
+      description: "`RestTemplateBuilder#basicAuthorization` was deprecated in 2.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateresttemplatebuilderbasicauthorization"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateRestTemplateBuilderTimeoutByInt:
+      name: "org.openrewrite.java.spring.boot2.MigrateRestTemplateBuilderTimeoutByInt"
+      description: "`RestTemplateBuilder#setConnectTimeout(int)` and `RestTemplateBuilder#setReadTimeout(int)`\
+        \ were deprecated in Spring Boot 2.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateresttemplatebuildertimeoutbyint"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateSpringBootServletInitializerPackageName:
+      name: "org.openrewrite.java.spring.boot2.MigrateSpringBootServletInitializerPackageName"
+      description: "`org.springframework.boot.web.support.SpringBootServletInitializer`\
+        \ was deprecated in 1.4.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratespringbootservletinitializerpackagename"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateUndertowServletWebServerFactoryIsEagerInitFilters:
+      name: "org.openrewrite.java.spring.boot2.MigrateUndertowServletWebServerFactoryIsEagerInitFilters"
+      description: "`org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory#isEagerInitFilters`\
+        \ was deprecated in 2.4 and are removed in 2.6."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateundertowservletwebserverfactoryiseagerinitfilters"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateUndertowServletWebServerFactorySetEagerInitFilters:
+      name: "org.openrewrite.java.spring.boot2.MigrateUndertowServletWebServerFactorySetEagerInitFilters"
+      description: "`org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory#setEagerInitFilters`\
+        \ was deprecated in 2.4 and are removed in 2.6."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migrateundertowservletwebserverfactoryseteagerinitfilters"
+      options: []
+    org.openrewrite.java.spring.boot2.MigrateWebTestClientBuilderCustomizerPackageName:
+      name: "org.openrewrite.java.spring.boot2.MigrateWebTestClientBuilderCustomizerPackageName"
+      description: "`org.springframework.boot.test.autoconfigure.web.reactive.WebTestClientBuilderCustomizer`\
+        \ was deprecated in 2.2."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/migratewebtestclientbuildercustomizerpackagename"
+      options: []
+    org.openrewrite.java.spring.boot2.OutputCaptureExtension:
+      name: "org.openrewrite.java.spring.boot2.OutputCaptureExtension"
+      description: "Use the JUnit Jupiter extension instead of JUnit 4 rule."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/outputcaptureextension"
+      options: []
+    org.openrewrite.java.spring.boot2.RemoveObsoleteSpringRunners:
+      name: "org.openrewrite.java.spring.boot2.RemoveObsoleteSpringRunners"
+      description: "Remove obsolete classpath runners."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/removeobsoletespringrunners"
+      options: []
+    org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils:
+      name: "org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils"
+      description: "Replaces any references to the deprecated `EnvironmentTestUtils`\
+        \ with `TestPropertyValues` and the appropriate functionality."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/replacedeprecatedenvironmenttestutils"
+      options: []
+    org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory:
+      name: "org.openrewrite.java.spring.boot2.RestTemplateBuilderRequestFactory"
+      description: "Migrate `RestTemplateBuilder#requestFactory` calls to use a `Supplier`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/resttemplatebuilderrequestfactory"
+      options: []
+    org.openrewrite.java.spring.boot2.SamlRelyingPartyPropertyApplicationPropertiesMove:
+      name: "org.openrewrite.java.spring.boot2.SamlRelyingPartyPropertyApplicationPropertiesMove"
+      description: "Renames spring.security.saml2.relyingparty.registration.(any).identityprovider\
+        \ to spring.security.saml2.relyingparty.registration.(any).assertingparty."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/samlrelyingpartypropertyapplicationpropertiesmove"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBoot1To2Migration:
+      name: "org.openrewrite.java.spring.boot2.SpringBoot1To2Migration"
+      description: "Migrates Spring Boot 1.x to latest version of 2.x, updating tests\
+        \ to JUnit 5, and applying 2.x best practices."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot1to2migration"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBoot2BestPractices:
+      name: "org.openrewrite.java.spring.boot2.SpringBoot2BestPractices"
+      description: "Applies best practices to Spring Boot 2 applications."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot2bestpractices"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration:
+      name: "org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration"
+      description: "Migrates Spring Boot 2.x projects having JUnit 4.x tests to JUnit\
+        \ Jupiter."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springboot2junit4to5migration"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootMavenPluginMigrateAgentToAgents:
+      name: "org.openrewrite.java.spring.boot2.SpringBootMavenPluginMigrateAgentToAgents"
+      description: "Migrate the `spring-boot.run.agent` Maven plugin configuration\
+        \ key to `spring-boot.run.agents`. Deprecated in 2.2.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootmavenpluginmigrateagenttoagents"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootProperties_2_0:
+      name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_0"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_0"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootProperties_2_1:
+      name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_1"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_1"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootProperties_2_2:
+      name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_2"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_2"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootProperties_2_3:
+      name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_3"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_3"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootProperties_2_4:
+      name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_4"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_4"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootProperties_2_5:
+      name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_5"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_5"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootProperties_2_6:
+      name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_6"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_6"
+      options: []
+    org.openrewrite.java.spring.boot2.SpringBootProperties_2_7:
+      name: "org.openrewrite.java.spring.boot2.SpringBootProperties_2_7"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/springbootproperties_2_7"
+      options: []
+    org.openrewrite.java.spring.boot2.UnnecessarySpringExtension:
+      name: "org.openrewrite.java.spring.boot2.UnnecessarySpringExtension"
+      description: "`@SpringBootTest` and all test slice annotations already applies\
+        \ `@SpringExtension` as of Spring Boot 2.1.0."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/unnecessaryspringextension"
+      options: []
+    org.openrewrite.java.spring.boot2.UnnecessarySpringRunWith:
+      name: "org.openrewrite.java.spring.boot2.UnnecessarySpringRunWith"
+      description: "Remove `@RunWith` annotations on Spring tests."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/unnecessaryspringrunwith"
+      options: []
+    org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_0:
+      name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_0"
+      description: "Upgrade to Spring Boot 2.0 from prior 1.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_0"
+      options: []
+    org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_1:
+      name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_1"
+      description: "Upgrade to Spring Boot 2.1 from any prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_1"
+      options: []
+    org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_2:
+      name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_2"
+      description: "Upgrade to Spring Boot 2.2 from any prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_2"
+      options: []
+    org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_3:
+      name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_3"
+      description: "Upgrade to Spring Boot 2.3 from any prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_3"
+      options: []
+    org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4:
+      name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_4"
+      description: "Upgrade to Spring Boot 2.4 from any prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_4"
+      options: []
+    org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5:
+      name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_5"
+      description: "Upgrade to Spring Boot 2.5 from any prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_5"
+      options: []
+    org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6:
+      name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_6"
+      description: "Upgrade to Spring Boot 2.6 from any prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_6"
+      options: []
+    org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7:
+      name: "org.openrewrite.java.spring.boot2.UpgradeSpringBoot_2_7"
+      description: "Upgrade to Spring Boot 2.7 from any prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/upgradespringboot_2_7"
+      options: []
+    org.openrewrite.java.spring.boot2.WebSecurityConfigurerAdapter:
+      name: "org.openrewrite.java.spring.boot2.WebSecurityConfigurerAdapter"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/websecurityconfigureradapter"
+      options: []
+    org.openrewrite.java.spring.boot2.search.CustomizingJooqDefaultConfiguration:
+      name: "org.openrewrite.java.spring.boot2.search.CustomizingJooqDefaultConfiguration"
+      description: "To streamline the customization of jOOQ’s `DefaultConfiguration`,\
+        \ a bean that implements `DefaultConfigurationCustomizer` can now be defined.\
+        \ This customizer callback should be used in favour of defining one or more\
+        \ `*Provider` beans, the support for which has now been deprecated. See [Spring\
+        \ Boot 2.5 jOOQ customization](https://docs.spring.io/spring-boot/docs/2.5.x/reference/htmlsingle/#features.sql.jooq.customizing)."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/customizingjooqdefaultconfiguration"
+      options: []
+    org.openrewrite.java.spring.boot2.search.IntegrationSchedulerPoolRecipe:
+      name: "org.openrewrite.java.spring.boot2.search.IntegrationSchedulerPoolRecipe"
+      description: "Spring Integration now reuses an available TaskScheduler rather\
+        \ than configuring its own. In a typical application setup relying on the\
+        \ auto-configuration, this means that Spring Integration uses the auto-configured\
+        \ task scheduler that has a pool size of 1. To restore Spring Integration’\
+        s default of 10 threads, use the `spring.task.scheduling.pool.size` property."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/integrationschedulerpoolrecipe"
+      options: []
+    org.openrewrite.java.spring.boot2.search.LoggingShutdownHooks:
+      name: "org.openrewrite.java.spring.boot2.search.LoggingShutdownHooks"
+      description: "Spring Boot registers a logging shutdown hook by default for JAR-based\
+        \ applications to ensure that logging resources are released when the JVM\
+        \ exits. If your application is deployed as a WAR then the shutdown hook is\
+        \ not registered since the servlet container usually handles logging concerns.\n\
+        \nMost applications will want the shutdown hook. However, if your application\
+        \ has complex context hierarchies, then you may need to disable it. You can\
+        \ use the `logging.register-shutdown-hook` property to do that."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/loggingshutdownhooks"
+      options: []
+    org.openrewrite.java.spring.boot2.search.MessagesInTheDefaultErrorView:
+      name: "org.openrewrite.java.spring.boot2.search.MessagesInTheDefaultErrorView"
+      description: "As of Spring Boot 2.5 the `message` attribute in the default error\
+        \ view was removed rather than blanked when it is not shown.\n`spring-webmvc`\
+        \ or `spring-webflux` projects that parse the error response JSON may need\
+        \ to deal with the missing item\n([release notes](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes#messages-in-the-default-error-view)).\n\
+        You can still use the `server.error.include-message` property if you want\
+        \ messages to be included.\n"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/messagesinthedefaulterrorview"
+      options: []
+    org.openrewrite.java.spring.boot2.search.UpgradeRequirementsSpringBoot_2_5:
+      name: "org.openrewrite.java.spring.boot2.search.UpgradeRequirementsSpringBoot_2_5"
+      description: "Identify changes needed to upgrade to Spring Boot 2.5.\n"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot2/search/upgraderequirementsspringboot_2_5"
+      options: []
+    org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization:
+      name: "org.openrewrite.java.spring.boot3.ActuatorEndpointSanitization"
+      description: "Spring Boot 3.0 removed the key-based sanitization mechanism used\
+        \ in Spring Boot 2.x in favor of a unified approach. This recipe maintains\
+        \ the previous behavior but adds a warning comment that these settings should\
+        \ be reviewed. See https://github.com/openrewrite/rewrite-spring/issues/228"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/actuatorendpointsanitization"
+      options: []
+    org.openrewrite.java.spring.boot3.LegacyJmxExposure:
+      name: "org.openrewrite.java.spring.boot3.LegacyJmxExposure"
+      description: "Spring Boot 3.0 only exposes the health endpoint via JMX. This\
+        \ change exposes all actuator endpoints via JMX to maintain parity with Spring\
+        \ Boot 2.x. See See https://github.com/openrewrite/rewrite-spring/issues/229"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/legacyjmxexposure"
+      options: []
+    org.openrewrite.java.spring.boot3.MavenPomUpgrade:
+      name: "org.openrewrite.java.spring.boot3.MavenPomUpgrade"
+      description: "Upgrade Maven Pom to Spring Boot 3.0 from prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/mavenpomupgrade"
+      options: []
+    org.openrewrite.java.spring.boot3.PreciseBeanType:
+      name: "org.openrewrite.java.spring.boot3.PreciseBeanType"
+      description: "Replace Bean method return types with concrete types being returned.\
+        \ This is required for Spring 6 AOT."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/precisebeantype"
+      options: []
+    org.openrewrite.java.spring.boot3.RemoveConstructorBindingAnnotation:
+      name: "org.openrewrite.java.spring.boot3.RemoveConstructorBindingAnnotation"
+      description: "As of Boot 3.0 @ConstructorBinding is no longer needed at the\
+        \ type level on @ConfigurationProperties classes and should be removed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/removeconstructorbindingannotation"
+      options: []
+    org.openrewrite.java.spring.boot3.Saml:
+      name: "org.openrewrite.java.spring.boot3.Saml"
+      description: "Renames spring.security.saml2.relyingparty.registration.(any).identityprovider\
+        \ to spring.security.saml2.relyingparty.registration.(any).assertingparty."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/saml"
+      options: []
+    org.openrewrite.java.spring.boot3.SpringBoot2To3Migration:
+      name: "org.openrewrite.java.spring.boot3.SpringBoot2To3Migration"
+      description: "Migrates Spring Boot 2.x to latest version of 3.x"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/springboot2to3migration"
+      options: []
+    org.openrewrite.java.spring.boot3.SpringBootProperties_3_0_0:
+      name: "org.openrewrite.java.spring.boot3.SpringBootProperties_3_0_0"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/springbootproperties_3_0_0"
+      options: []
+    org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0:
+      name: "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_0"
+      description: "Upgrade to Spring Boot 3.0 from prior 2.x version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/boot3/upgradespringboot_3_0"
+      options: []
+    org.openrewrite.java.spring.data.MigrateJpaSort:
+      name: "org.openrewrite.java.spring.data.MigrateJpaSort"
+      description: "Equivalent constructors in `JpaSort` were deprecated in Spring\
+        \ Data 2.3."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/migratejpasort"
+      options: []
+    org.openrewrite.java.spring.data.MigrateQuerydslJpaRepository:
+      name: "org.openrewrite.java.spring.data.MigrateQuerydslJpaRepository"
+      description: "`QuerydslJpaRepository<T, ID extends Serializable>` was deprecated\
+        \ in Spring Data 2.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/migratequerydsljparepository"
+      options: []
+    org.openrewrite.java.spring.data.UpgradeSpringData_2_3:
+      name: "org.openrewrite.java.spring.data.UpgradeSpringData_2_3"
+      description: "Upgrade to Spring Data to 2.3 from any prior version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/upgradespringdata_2_3"
+      options: []
+    org.openrewrite.java.spring.data.UpgradeSpringData_2_5:
+      name: "org.openrewrite.java.spring.data.UpgradeSpringData_2_5"
+      description: "Upgrade to Spring Data to 2.5 from any prior version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/upgradespringdata_2_5"
+      options: []
+    org.openrewrite.java.spring.data.UseJpaRepositoryDeleteAllInBatch:
+      name: "org.openrewrite.java.spring.data.UseJpaRepositoryDeleteAllInBatch"
+      description: "`JpaRepository#deleteInBatch(Iterable)` was deprecated in 2.5."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/usejparepositorydeleteallinbatch"
+      options: []
+    org.openrewrite.java.spring.data.UseJpaRepositoryGetById:
+      name: "org.openrewrite.java.spring.data.UseJpaRepositoryGetById"
+      description: "`JpaRepository#getOne(ID)` was deprecated in 2.5."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/data/usejparepositorygetbyid"
+      options: []
+    org.openrewrite.java.spring.framework.EnvironmentAcceptsProfiles:
+      name: "org.openrewrite.java.spring.framework.EnvironmentAcceptsProfiles"
+      description: "`Environment#acceptsProfiles(String...)` was deprecated in Spring\
+        \ Framework 5.1."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/environmentacceptsprofiles"
+      options: []
+    org.openrewrite.java.spring.framework.JdbcTemplateObjectArrayArgToVarArgs:
+      name: "org.openrewrite.java.spring.framework.JdbcTemplateObjectArrayArgToVarArgs"
+      description: "`JdbcTemplate` signatures with `Object[]` arguments are deprecated,\
+        \ in favor of their existing varargs equivalents."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/jdbctemplateobjectarrayargtovarargs"
+      options: []
+    org.openrewrite.java.spring.framework.MigrateHandlerInterceptor:
+      name: "org.openrewrite.java.spring.framework.MigrateHandlerInterceptor"
+      description: "Deprecated as of 5.3 in favor of implementing `HandlerInterceptor`\
+        \ and/or `AsyncHandlerInterceptor`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/migratehandlerinterceptor"
+      options: []
+    org.openrewrite.java.spring.framework.MigrateInstantiationAwareBeanPostProcessorAdapter:
+      name: "org.openrewrite.java.spring.framework.MigrateInstantiationAwareBeanPostProcessorAdapter"
+      description: "As of Spring-Framework 5.3 `InstantiationAwareBeanPostProcessorAdapter`\
+        \ is deprecated in favor of the existing default methods in `SmartInstantiationAwareBeanPostProcessor`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/migrateinstantiationawarebeanpostprocessoradapter"
+      options: []
+    org.openrewrite.java.spring.framework.MigrateUtf8MediaTypes:
+      name: "org.openrewrite.java.spring.framework.MigrateUtf8MediaTypes"
+      description: "Spring-Web MediaTypes `APPLICATION_JSON_UTF8` and `APPLICATION_PROBLEM_JSON_UTF8`\
+        \ were deprecated in 5.2."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/migrateutf8mediatypes"
+      options: []
+    org.openrewrite.java.spring.framework.MigrateWebMvcConfigurerAdapter:
+      name: "org.openrewrite.java.spring.framework.MigrateWebMvcConfigurerAdapter"
+      description: "As of 5.0 `WebMvcConfigurer` has default methods (made possible\
+        \ by a Java 8 baseline) and can be implemented directly without the need for\
+        \ this adapter."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/migratewebmvcconfigureradapter"
+      options: []
+    org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies:
+      name: "org.openrewrite.java.spring.framework.UpgradeSpringFrameworkDependencies"
+      description: "Upgrade spring-framework 5.x Maven dependencies using a Node Semver\
+        \ advanced range selector."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframeworkdependencies"
+      options:
+      - name: "newVersion"
+        type: "String"
+        required: true
+    org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_0:
+      name: "org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_0"
+      description: "Upgrade to Spring Framework to 5.0 from any prior version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframework_5_0"
+      options: []
+    org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1:
+      name: "org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_1"
+      description: "Upgrade to Spring Framework to 5.1 from any prior version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframework_5_1"
+      options: []
+    org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2:
+      name: "org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_2"
+      description: "Upgrade to Spring Framework to 5.2 from any prior version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframework_5_2"
+      options: []
+    org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3:
+      name: "org.openrewrite.java.spring.framework.UpgradeSpringFramework_5_3"
+      description: "Upgrade to Spring Framework to 5.3 from any prior version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/upgradespringframework_5_3"
+      options: []
+    org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty:
+      name: "org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty"
+      description: "`StringUtils#isEmpty(Object)` was deprecated in 5.3."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/spring/framework/useobjectutilsisempty"
+      options: []
+    org.openrewrite.maven.spring.UpgradeExplicitSpringBootDependencies:
+      name: "org.openrewrite.maven.spring.UpgradeExplicitSpringBootDependencies"
+      description: "Upgrades un-managed spring-boot project dependencies according\
+        \ to the specified spring-boot version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/maven/spring/upgradeexplicitspringbootdependencies"
+      options:
+      - name: "fromVersion"
+        type: "String"
+        required: true
+      - name: "toVersion"
+        type: "String"
+        required: true
+rewrite-terraform:
+  artifactId: "rewrite-terraform"
+  version: "1.14.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.terraform.AddConfiguration:
+      name: "org.openrewrite.terraform.AddConfiguration"
+      description: "If the configuration has a different value, leave it alone. If\
+        \ it is missing, add it."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/addconfiguration"
+      options:
+      - name: "content"
+        type: "String"
+        required: true
+      - name: "resourceName"
+        type: "String"
+        required: true
+    org.openrewrite.terraform.SecureRandom:
+      name: "org.openrewrite.terraform.SecureRandom"
+      description: ""
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/securerandom"
+      options:
+      - name: "byteLength"
+        type: "Integer"
+        required: false
+    org.openrewrite.terraform.aws.AWSBestPractices:
+      name: "org.openrewrite.terraform.aws.AWSBestPractices"
+      description: "Securely operate on Amazon Web Services."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/awsbestpractices"
+      options: []
+    org.openrewrite.terraform.aws.DisableInstanceMetadataServiceV1:
+      name: "org.openrewrite.terraform.aws.DisableInstanceMetadataServiceV1"
+      description: "As a request/response method IMDSv1 is prone to local misconfigurations."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/disableinstancemetadataservicev1"
+      options: []
+    org.openrewrite.terraform.aws.EnableApiGatewayCaching:
+      name: "org.openrewrite.terraform.aws.EnableApiGatewayCaching"
+      description: "Enable caching for all methods of API Gateway."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/enableapigatewaycaching"
+      options: []
+    org.openrewrite.terraform.aws.EnableDynamoDbPITR:
+      name: "org.openrewrite.terraform.aws.EnableDynamoDbPITR"
+      description: "DynamoDB Point-In-Time Recovery (PITR) is an automatic backup\
+        \ service for DynamoDB table data that helps protect your DynamoDB tables\
+        \ from accidental write or delete operations."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/enabledynamodbpitr"
+      options: []
+    org.openrewrite.terraform.aws.EnableECRScanOnPush:
+      name: "org.openrewrite.terraform.aws.EnableECRScanOnPush"
+      description: "ECR Image Scanning assesses and identifies operating system vulnerabilities.\
+        \ Using automated image scans you can ensure container image vulnerabilities\
+        \ are found before getting pushed to production."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/enableecrscanonpush"
+      options: []
+    org.openrewrite.terraform.aws.EncryptAuroraClusters:
+      name: "org.openrewrite.terraform.aws.EncryptAuroraClusters"
+      description: "Native Aurora encryption helps protect your cloud applications\
+        \ and fulfils compliance requirements for data-at-rest encryption."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptauroraclusters"
+      options: []
+    org.openrewrite.terraform.aws.EncryptCodeBuild:
+      name: "org.openrewrite.terraform.aws.EncryptCodeBuild"
+      description: "Build artifacts, such as a cache, logs, exported raw test report\
+        \ data files, and build results, are encrypted by default using CMKs for Amazon\
+        \ S3 that are managed by the AWS Key Management Service."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptcodebuild"
+      options: []
+    org.openrewrite.terraform.aws.EncryptDAXStorage:
+      name: "org.openrewrite.terraform.aws.EncryptDAXStorage"
+      description: "DAX encryption at rest automatically integrates with AWS KMS for\
+        \ managing the single service default key used to encrypt clusters."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptdaxstorage"
+      options: []
+    org.openrewrite.terraform.aws.EncryptDocumentDB:
+      name: "org.openrewrite.terraform.aws.EncryptDocumentDB"
+      description: "The encryption feature available for Amazon DocumentDB clusters\
+        \ provides an additional layer of data protection by helping secure your data\
+        \ against unauthorized access to the underlying storage."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptdocumentdb"
+      options: []
+    org.openrewrite.terraform.aws.EncryptEBSSnapshots:
+      name: "org.openrewrite.terraform.aws.EncryptEBSSnapshots"
+      description: "EBS snapshots should be encrypted, as they often include sensitive\
+        \ information, customer PII or CPNI."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptebssnapshots"
+      options: []
+    org.openrewrite.terraform.aws.EncryptEBSVolumeLaunchConfiguration:
+      name: "org.openrewrite.terraform.aws.EncryptEBSVolumeLaunchConfiguration"
+      description: "EBS volumes allow you to create encrypted launch configurations\
+        \ when creating EC2 instances and auto scaling. When the entire EBS volume\
+        \ is encrypted, data stored at rest on the volume, disk I/O, snapshots created\
+        \ from the volume, and data in-transit between EBS and EC2 are all encrypted."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptebsvolumelaunchconfiguration"
+      options: []
+    org.openrewrite.terraform.aws.EncryptEBSVolumes:
+      name: "org.openrewrite.terraform.aws.EncryptEBSVolumes"
+      description: "Encrypting EBS volumes ensures that replicated copies of your\
+        \ images are secure even if they are accidentally exposed. AWS EBS encryption\
+        \ uses AWS KMS customer master keys (CMK) when creating encrypted volumes\
+        \ and snapshots. Storing EBS volumes in their encrypted state reduces the\
+        \ risk of data exposure or data loss."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptebsvolumes"
+      options: []
+    org.openrewrite.terraform.aws.EncryptEFSVolumesInECSTaskDefinitionsInTransit:
+      name: "org.openrewrite.terraform.aws.EncryptEFSVolumesInECSTaskDefinitionsInTransit"
+      description: "Enable attached EFS definitions in ECS tasks to use encryption\
+        \ in transit."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptefsvolumesinecstaskdefinitionsintransit"
+      options: []
+    org.openrewrite.terraform.aws.EncryptElastiCacheRedisAtRest:
+      name: "org.openrewrite.terraform.aws.EncryptElastiCacheRedisAtRest"
+      description: "ElastiCache for Redis offers default encryption at rest as a service."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptelasticacheredisatrest"
+      options: []
+    org.openrewrite.terraform.aws.EncryptElastiCacheRedisInTransit:
+      name: "org.openrewrite.terraform.aws.EncryptElastiCacheRedisInTransit"
+      description: "ElastiCache for Redis offers optional encryption in transit. In-transit\
+        \ encryption provides an additional layer of data protection when transferring\
+        \ data over standard HTTPS protocol."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptelasticacheredisintransit"
+      options: []
+    org.openrewrite.terraform.aws.EncryptNeptuneStorage:
+      name: "org.openrewrite.terraform.aws.EncryptNeptuneStorage"
+      description: "Encryption of Neptune storage protects data and metadata against\
+        \ unauthorized access."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptneptunestorage"
+      options: []
+    org.openrewrite.terraform.aws.EncryptRDSClusters:
+      name: "org.openrewrite.terraform.aws.EncryptRDSClusters"
+      description: "Native RDS encryption helps protect your cloud applications and\
+        \ fulfils compliance requirements for data-at-rest encryption."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptrdsclusters"
+      options: []
+    org.openrewrite.terraform.aws.EncryptRedshift:
+      name: "org.openrewrite.terraform.aws.EncryptRedshift"
+      description: "Redshift clusters should be securely encrypted at rest."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/encryptredshift"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSCMKRotationIsEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureAWSCMKRotationIsEnabled"
+      description: "Ensure AWS CMK rotation is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawscmkrotationisenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSEFSWithEncryptionForDataAtRestIsEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureAWSEFSWithEncryptionForDataAtRestIsEnabled"
+      description: "Ensure AWS EFS with encryption for data at rest is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawsefswithencryptionfordataatrestisenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSEKSClusterEndpointAccessIsPubliclyDisabled:
+      name: "org.openrewrite.terraform.aws.EnsureAWSEKSClusterEndpointAccessIsPubliclyDisabled"
+      description: "Ensure AWS EKS cluster endpoint access is publicly disabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawseksclusterendpointaccessispubliclydisabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSElasticsearchDomainEncryptionForDataAtRestIsEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureAWSElasticsearchDomainEncryptionForDataAtRestIsEnabled"
+      description: "Ensure AWS Elasticsearch domain encryption for data at rest is\
+        \ enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawselasticsearchdomainencryptionfordataatrestisenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSElasticsearchDomainsHaveEnforceHTTPSEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureAWSElasticsearchDomainsHaveEnforceHTTPSEnabled"
+      description: "Ensure AWS Elasticsearch domains have `EnforceHTTPS` enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawselasticsearchdomainshaveenforcehttpsenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSElasticsearchHasNodeToNodeEncryptionEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureAWSElasticsearchHasNodeToNodeEncryptionEnabled"
+      description: "Ensure AWS Elasticsearch has node-to-node encryption enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawselasticsearchhasnodetonodeencryptionenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSIAMPasswordPolicyHasAMinimumOf14Characters:
+      name: "org.openrewrite.terraform.aws.EnsureAWSIAMPasswordPolicyHasAMinimumOf14Characters"
+      description: "Ensure AWS IAM password policy has a minimum of 14 characters."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawsiampasswordpolicyhasaminimumof14characters"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSLambdaFunctionIsConfiguredForFunctionLevelConcurrentExecutionLimit:
+      name: "org.openrewrite.terraform.aws.EnsureAWSLambdaFunctionIsConfiguredForFunctionLevelConcurrentExecutionLimit"
+      description: "Ensure AWS Lambda function is configured for function-level concurrent\
+        \ execution limit."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawslambdafunctionisconfiguredforfunctionlevelconcurrentexecutionlimit"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSLambdaFunctionsHaveTracingEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureAWSLambdaFunctionsHaveTracingEnabled"
+      description: "Ensure AWS Lambda functions have tracing enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawslambdafunctionshavetracingenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSRDSDatabaseInstanceIsNotPubliclyAccessible:
+      name: "org.openrewrite.terraform.aws.EnsureAWSRDSDatabaseInstanceIsNotPubliclyAccessible"
+      description: "Ensure AWS RDS database instance is not publicly accessible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawsrdsdatabaseinstanceisnotpubliclyaccessible"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAWSS3ObjectVersioningIsEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureAWSS3ObjectVersioningIsEnabled"
+      description: "Ensure AWS S3 object versioning is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureawss3objectversioningisenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureAmazonEKSControlPlaneLoggingEnabledForAllLogTypes:
+      name: "org.openrewrite.terraform.aws.EnsureAmazonEKSControlPlaneLoggingEnabledForAllLogTypes"
+      description: "Ensure Amazon EKS control plane logging enabled for all log types."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureamazonekscontrolplaneloggingenabledforalllogtypes"
+      options: []
+    org.openrewrite.terraform.aws.EnsureCloudTrailLogFileValidationIsEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureCloudTrailLogFileValidationIsEnabled"
+      description: "Ensure CloudTrail log file validation is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurecloudtraillogfilevalidationisenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureDataStoredInAnS3BucketIsSecurelyEncryptedAtRest:
+      name: "org.openrewrite.terraform.aws.EnsureDataStoredInAnS3BucketIsSecurelyEncryptedAtRest"
+      description: "Ensure data stored in an S3 bucket is securely encrypted at rest."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensuredatastoredinans3bucketissecurelyencryptedatrest"
+      options: []
+    org.openrewrite.terraform.aws.EnsureDetailedMonitoringForEC2InstancesIsEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureDetailedMonitoringForEC2InstancesIsEnabled"
+      description: "Ensure detailed monitoring for EC2 instances is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensuredetailedmonitoringforec2instancesisenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureEC2IsEBSOptimized:
+      name: "org.openrewrite.terraform.aws.EnsureEC2IsEBSOptimized"
+      description: "Ensure EC2 is EBS optimized."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureec2isebsoptimized"
+      options: []
+    org.openrewrite.terraform.aws.EnsureECRRepositoriesAreEncrypted:
+      name: "org.openrewrite.terraform.aws.EnsureECRRepositoriesAreEncrypted"
+      description: "Ensure ECR repositories are encrypted."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureecrrepositoriesareencrypted"
+      options: []
+    org.openrewrite.terraform.aws.EnsureEnhancedMonitoringForAmazonRDSInstancesIsEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureEnhancedMonitoringForAmazonRDSInstancesIsEnabled"
+      description: "Ensure enhanced monitoring for Amazon RDS instances is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureenhancedmonitoringforamazonrdsinstancesisenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyExpiresPasswordsWithin90DaysOrLess:
+      name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyExpiresPasswordsWithin90DaysOrLess"
+      description: "Ensure IAM password policy expires passwords within 90 days or\
+        \ less."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyexpirespasswordswithin90daysorless"
+      options: []
+    org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyPreventsPasswordReuse:
+      name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyPreventsPasswordReuse"
+      description: "Ensure IAM password policy prevents password reuse."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicypreventspasswordreuse"
+      options: []
+    org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneLowercaseLetter:
+      name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneLowercaseLetter"
+      description: "Ensure IAM password policy requires at least one lowercase letter."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyrequiresatleastonelowercaseletter"
+      options: []
+    org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneNumber:
+      name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneNumber"
+      description: "Ensure IAM password policy requires at least one number."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyrequiresatleastonenumber"
+      options: []
+    org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneSymbol:
+      name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneSymbol"
+      description: "Ensure IAM password policy requires at least one symbol."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyrequiresatleastonesymbol"
+      options: []
+    org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneUppercaseLetter:
+      name: "org.openrewrite.terraform.aws.EnsureIAMPasswordPolicyRequiresAtLeastOneUppercaseLetter"
+      description: "Ensure IAM password policy requires at least one uppercase letter."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensureiampasswordpolicyrequiresatleastoneuppercaseletter"
+      options: []
+    org.openrewrite.terraform.aws.EnsureKinesisStreamIsSecurelyEncrypted:
+      name: "org.openrewrite.terraform.aws.EnsureKinesisStreamIsSecurelyEncrypted"
+      description: "Ensure Kinesis Stream is securely encrypted."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurekinesisstreamissecurelyencrypted"
+      options: []
+    org.openrewrite.terraform.aws.EnsureRDSDatabaseHasIAMAuthenticationEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureRDSDatabaseHasIAMAuthenticationEnabled"
+      description: "Ensure RDS database has IAM authentication enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurerdsdatabasehasiamauthenticationenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureRDSInstancesHaveMultiAZEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureRDSInstancesHaveMultiAZEnabled"
+      description: "Ensure RDS instances have Multi-AZ enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurerdsinstanceshavemultiazenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureRespectiveLogsOfAmazonRDSAreEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureRespectiveLogsOfAmazonRDSAreEnabled"
+      description: "Ensure respective logs of Amazon RDS are enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurerespectivelogsofamazonrdsareenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureTheS3BucketHasAccessLoggingEnabled:
+      name: "org.openrewrite.terraform.aws.EnsureTheS3BucketHasAccessLoggingEnabled"
+      description: "Ensure the S3 bucket has access logging enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurethes3buckethasaccessloggingenabled"
+      options: []
+    org.openrewrite.terraform.aws.EnsureVPCSubnetsDoNotAssignPublicIPByDefault:
+      name: "org.openrewrite.terraform.aws.EnsureVPCSubnetsDoNotAssignPublicIPByDefault"
+      description: "Ensure VPC subnets do not assign public IP by default."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/ensurevpcsubnetsdonotassignpublicipbydefault"
+      options: []
+    org.openrewrite.terraform.aws.ImmutableECRTags:
+      name: "org.openrewrite.terraform.aws.ImmutableECRTags"
+      description: "Amazon ECR supports immutable tags, preventing image tags from\
+        \ being overwritten. In the past, ECR tags could have been overwritten, this\
+        \ could be overcome by requiring users to uniquely identify an image using\
+        \ a naming convention."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/immutableecrtags"
+      options: []
+    org.openrewrite.terraform.aws.UseHttpsForCloudfrontDistribution:
+      name: "org.openrewrite.terraform.aws.UseHttpsForCloudfrontDistribution"
+      description: "Secure communication by default."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/aws/usehttpsforcloudfrontdistribution"
+      options: []
+    org.openrewrite.terraform.azure.AzureBestPractices:
+      name: "org.openrewrite.terraform.azure.AzureBestPractices"
+      description: "Securely operate on Microsoft Azure."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/azurebestpractices"
+      options: []
+    org.openrewrite.terraform.azure.DisableKubernetesDashboard:
+      name: "org.openrewrite.terraform.azure.DisableKubernetesDashboard"
+      description: "Disabling the dashboard eliminates it as an attack vector. The\
+        \ dashboard add-on is disabled by default for all new clusters created on\
+        \ Kubernetes 1.18 or greater."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/disablekubernetesdashboard"
+      options: []
+    org.openrewrite.terraform.azure.EnableAzureStorageAccountTrustedMicrosoftServicesAccess:
+      name: "org.openrewrite.terraform.azure.EnableAzureStorageAccountTrustedMicrosoftServicesAccess"
+      description: "Certain Microsoft services that interact with storage accounts\
+        \ operate from networks that cannot be granted access through network rules.\
+        \ Using this configuration, you can allow the set of trusted Microsoft services\
+        \ to bypass those network rules."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/enableazurestorageaccounttrustedmicrosoftservicesaccess"
+      options: []
+    org.openrewrite.terraform.azure.EnableAzureStorageSecureTransferRequired:
+      name: "org.openrewrite.terraform.azure.EnableAzureStorageSecureTransferRequired"
+      description: "Microsoft recommends requiring secure transfer for all storage\
+        \ accounts."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/enableazurestoragesecuretransferrequired"
+      options: []
+    org.openrewrite.terraform.azure.EnableGeoRedundantBackupsOnPostgreSQLServer:
+      name: "org.openrewrite.terraform.azure.EnableGeoRedundantBackupsOnPostgreSQLServer"
+      description: "Ensure PostgreSQL server enables geo-redundant backups."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/enablegeoredundantbackupsonpostgresqlserver"
+      options: []
+    org.openrewrite.terraform.azure.EncryptAzureVMDataDiskWithADECMK:
+      name: "org.openrewrite.terraform.azure.EncryptAzureVMDataDiskWithADECMK"
+      description: "Ensure Azure VM data disk is encrypted with ADE/CMK."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/encryptazurevmdatadiskwithadecmk"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAKSPoliciesAddOn:
+      name: "org.openrewrite.terraform.azure.EnsureAKSPoliciesAddOn"
+      description: "Azure Policy Add-on for Kubernetes service (AKS) extends Gatekeeper\
+        \ v3, an admission controller webhook for Open Policy Agent (OPA), to apply\
+        \ at-scale enforcements and safeguards on your clusters in a centralized,\
+        \ consistent manner."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureakspoliciesaddon"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAKVSecretsHaveAnExpirationDateSet:
+      name: "org.openrewrite.terraform.azure.EnsureAKVSecretsHaveAnExpirationDateSet"
+      description: "Ensure AKV secrets have an expiration date set."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureakvsecretshaveanexpirationdateset"
+      options: []
+    org.openrewrite.terraform.azure.EnsureASecurityContactPhoneNumberIsPresent:
+      name: "org.openrewrite.terraform.azure.EnsureASecurityContactPhoneNumberIsPresent"
+      description: "Ensure a security contact phone number is present."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureasecuritycontactphonenumberispresent"
+      options: []
+    org.openrewrite.terraform.azure.EnsureActivityLogRetentionIsSetTo365DaysOrGreater:
+      name: "org.openrewrite.terraform.azure.EnsureActivityLogRetentionIsSetTo365DaysOrGreater"
+      description: "Ensure activity log retention is set to 365 days or greater."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureactivitylogretentionissetto365daysorgreater"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAllKeysHaveAnExpirationDate:
+      name: "org.openrewrite.terraform.azure.EnsureAllKeysHaveAnExpirationDate"
+      description: "Ensure all keys have an expiration date."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureallkeyshaveanexpirationdate"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAppServiceEnablesDetailedErrorMessages:
+      name: "org.openrewrite.terraform.azure.EnsureAppServiceEnablesDetailedErrorMessages"
+      description: "Ensure app service enables detailed error messages."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureappserviceenablesdetailederrormessages"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAppServiceEnablesFailedRequestTracing:
+      name: "org.openrewrite.terraform.azure.EnsureAppServiceEnablesFailedRequestTracing"
+      description: "Ensure app service enables failed request tracing."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureappserviceenablesfailedrequesttracing"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAppServiceEnablesHTTPLogging:
+      name: "org.openrewrite.terraform.azure.EnsureAppServiceEnablesHTTPLogging"
+      description: "Ensure app service enables HTTP logging."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureappserviceenableshttplogging"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAppServicesUseAzureFiles:
+      name: "org.openrewrite.terraform.azure.EnsureAppServicesUseAzureFiles"
+      description: "Ensure app services use Azure files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureappservicesuseazurefiles"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAzureAppServiceWebAppRedirectsHTTPToHTTPS:
+      name: "org.openrewrite.terraform.azure.EnsureAzureAppServiceWebAppRedirectsHTTPToHTTPS"
+      description: "Ensure Azure App Service Web app redirects HTTP to HTTPS."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazureappservicewebappredirectshttptohttps"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAzureApplicationGatewayHasWAFEnabled:
+      name: "org.openrewrite.terraform.azure.EnsureAzureApplicationGatewayHasWAFEnabled"
+      description: "Ensure Azure application gateway has WAF enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazureapplicationgatewayhaswafenabled"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAzureKeyVaultIsRecoverable:
+      name: "org.openrewrite.terraform.azure.EnsureAzureKeyVaultIsRecoverable"
+      description: "Ensure Azure key vault is recoverable."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazurekeyvaultisrecoverable"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAzureNetworkWatcherNSGFlowLogsRetentionIsGreaterThan90Days:
+      name: "org.openrewrite.terraform.azure.EnsureAzureNetworkWatcherNSGFlowLogsRetentionIsGreaterThan90Days"
+      description: "Ensure Azure Network Watcher NSG flow logs retention is greater\
+        \ than 90 days."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazurenetworkwatchernsgflowlogsretentionisgreaterthan90days"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAzurePostgreSQLDatabaseServerWithSSLConnectionIsEnabled:
+      name: "org.openrewrite.terraform.azure.EnsureAzurePostgreSQLDatabaseServerWithSSLConnectionIsEnabled"
+      description: "Ensure Azure PostgreSQL database server with SSL connection is\
+        \ enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazurepostgresqldatabaseserverwithsslconnectionisenabled"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAzureSQLServerAuditLogRetentionIsGreaterThan90Days:
+      name: "org.openrewrite.terraform.azure.EnsureAzureSQLServerAuditLogRetentionIsGreaterThan90Days"
+      description: "Ensure Azure SQL server audit log retention is greater than 90\
+        \ days."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazuresqlserverauditlogretentionisgreaterthan90days"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAzureSQLServerSendAlertsToFieldValueIsSet:
+      name: "org.openrewrite.terraform.azure.EnsureAzureSQLServerSendAlertsToFieldValueIsSet"
+      description: "Ensure Azure SQL server send alerts to field value is set."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazuresqlserversendalertstofieldvalueisset"
+      options: []
+    org.openrewrite.terraform.azure.EnsureAzureSQLServerThreatDetectionAlertsAreEnabledForAllThreatTypes:
+      name: "org.openrewrite.terraform.azure.EnsureAzureSQLServerThreatDetectionAlertsAreEnabledForAllThreatTypes"
+      description: "Ensure Azure SQL Server threat detection alerts are enabled for\
+        \ all threat types."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureazuresqlserverthreatdetectionalertsareenabledforallthreattypes"
+      options: []
+    org.openrewrite.terraform.azure.EnsureFTPDeploymentsAreDisabled:
+      name: "org.openrewrite.terraform.azure.EnsureFTPDeploymentsAreDisabled"
+      description: "Ensure FTP Deployments are disabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensureftpdeploymentsaredisabled"
+      options: []
+    org.openrewrite.terraform.azure.EnsureKeyVaultAllowsFirewallRulesSettings:
+      name: "org.openrewrite.terraform.azure.EnsureKeyVaultAllowsFirewallRulesSettings"
+      description: "Ensure key vault allows firewall rules settings."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurekeyvaultallowsfirewallrulessettings"
+      options: []
+    org.openrewrite.terraform.azure.EnsureKeyVaultEnablesPurgeProtection:
+      name: "org.openrewrite.terraform.azure.EnsureKeyVaultEnablesPurgeProtection"
+      description: "Ensure key vault enables purge protection."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurekeyvaultenablespurgeprotection"
+      options: []
+    org.openrewrite.terraform.azure.EnsureKeyVaultKeyIsBackedByHSM:
+      name: "org.openrewrite.terraform.azure.EnsureKeyVaultKeyIsBackedByHSM"
+      description: "Ensure key vault key is backed by HSM."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurekeyvaultkeyisbackedbyhsm"
+      options: []
+    org.openrewrite.terraform.azure.EnsureKeyVaultSecretsHaveContentTypeSet:
+      name: "org.openrewrite.terraform.azure.EnsureKeyVaultSecretsHaveContentTypeSet"
+      description: "Ensure key vault secrets have `content_type` set."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurekeyvaultsecretshavecontenttypeset"
+      options: []
+    org.openrewrite.terraform.azure.EnsureLogProfileIsConfiguredToCaptureAllActivities:
+      name: "org.openrewrite.terraform.azure.EnsureLogProfileIsConfiguredToCaptureAllActivities"
+      description: "Ensure log profile is configured to capture all activities."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurelogprofileisconfiguredtocaptureallactivities"
+      options: []
+    org.openrewrite.terraform.azure.EnsureMSSQLServersHaveEmailServiceAndCoAdministratorsEnabled:
+      name: "org.openrewrite.terraform.azure.EnsureMSSQLServersHaveEmailServiceAndCoAdministratorsEnabled"
+      description: "Ensure MSSQL servers have email service and co-administrators\
+        \ enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremssqlservershaveemailserviceandcoadministratorsenabled"
+      options: []
+    org.openrewrite.terraform.azure.EnsureManagedIdentityProviderIsEnabledForAppServices:
+      name: "org.openrewrite.terraform.azure.EnsureManagedIdentityProviderIsEnabledForAppServices"
+      description: "Ensure managed identity provider is enabled for app services."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremanagedidentityproviderisenabledforappservices"
+      options: []
+    org.openrewrite.terraform.azure.EnsureMySQLIsUsingTheLatestVersionOfTLSEncryption:
+      name: "org.openrewrite.terraform.azure.EnsureMySQLIsUsingTheLatestVersionOfTLSEncryption"
+      description: "Ensure MySQL is using the latest version of TLS encryption."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlisusingthelatestversionoftlsencryption"
+      options: []
+    org.openrewrite.terraform.azure.EnsureMySQLServerDatabasesHaveEnforceSSLConnectionEnabled:
+      name: "org.openrewrite.terraform.azure.EnsureMySQLServerDatabasesHaveEnforceSSLConnectionEnabled"
+      description: "Ensure MySQL server databases have Enforce SSL connection enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlserverdatabaseshaveenforcesslconnectionenabled"
+      options: []
+    org.openrewrite.terraform.azure.EnsureMySQLServerDisablesPublicNetworkAccess:
+      name: "org.openrewrite.terraform.azure.EnsureMySQLServerDisablesPublicNetworkAccess"
+      description: "Ensure MySQL server disables public network access."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlserverdisablespublicnetworkaccess"
+      options: []
+    org.openrewrite.terraform.azure.EnsureMySQLServerEnablesGeoRedundantBackups:
+      name: "org.openrewrite.terraform.azure.EnsureMySQLServerEnablesGeoRedundantBackups"
+      description: "Ensure MySQL server enables geo-redundant backups."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlserverenablesgeoredundantbackups"
+      options: []
+    org.openrewrite.terraform.azure.EnsureMySQLServerEnablesThreatDetectionPolicy:
+      name: "org.openrewrite.terraform.azure.EnsureMySQLServerEnablesThreatDetectionPolicy"
+      description: "Ensure MySQL server enables Threat Detection policy."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuremysqlserverenablesthreatdetectionpolicy"
+      options: []
+    org.openrewrite.terraform.azure.EnsurePostgreSQLServerDisablesPublicNetworkAccess:
+      name: "org.openrewrite.terraform.azure.EnsurePostgreSQLServerDisablesPublicNetworkAccess"
+      description: "Ensure PostgreSQL server disables public network access."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurepostgresqlserverdisablespublicnetworkaccess"
+      options: []
+    org.openrewrite.terraform.azure.EnsurePostgreSQLServerEnablesInfrastructureEncryption:
+      name: "org.openrewrite.terraform.azure.EnsurePostgreSQLServerEnablesInfrastructureEncryption"
+      description: "Ensure PostgreSQL server enables infrastructure encryption."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurepostgresqlserverenablesinfrastructureencryption"
+      options: []
+    org.openrewrite.terraform.azure.EnsurePostgreSQLServerEnablesThreatDetectionPolicy:
+      name: "org.openrewrite.terraform.azure.EnsurePostgreSQLServerEnablesThreatDetectionPolicy"
+      description: "Ensure PostgreSQL server enables Threat Detection policy."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurepostgresqlserverenablesthreatdetectionpolicy"
+      options: []
+    org.openrewrite.terraform.azure.EnsurePublicNetworkAccessEnabledIsSetToFalseForMySQLServers:
+      name: "org.openrewrite.terraform.azure.EnsurePublicNetworkAccessEnabledIsSetToFalseForMySQLServers"
+      description: "Ensure public network access enabled is set to False for mySQL\
+        \ servers."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurepublicnetworkaccessenabledissettofalseformysqlservers"
+      options: []
+    org.openrewrite.terraform.azure.EnsureSendEmailNotificationForHighSeverityAlertsIsEnabled:
+      name: "org.openrewrite.terraform.azure.EnsureSendEmailNotificationForHighSeverityAlertsIsEnabled"
+      description: "Ensure Send email notification for high severity alerts is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuresendemailnotificationforhighseverityalertsisenabled"
+      options: []
+    org.openrewrite.terraform.azure.EnsureSendEmailNotificationForHighSeverityAlertsToAdminsIsEnabled:
+      name: "org.openrewrite.terraform.azure.EnsureSendEmailNotificationForHighSeverityAlertsToAdminsIsEnabled"
+      description: "Ensure Send email notification for high severity alerts to admins\
+        \ is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensuresendemailnotificationforhighseverityalertstoadminsisenabled"
+      options: []
+    org.openrewrite.terraform.azure.EnsureStandardPricingTierIsSelected:
+      name: "org.openrewrite.terraform.azure.EnsureStandardPricingTierIsSelected"
+      description: "Ensure standard pricing tier is selected."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurestandardpricingtierisselected"
+      options: []
+    org.openrewrite.terraform.azure.EnsureStorageAccountUsesLatestTLSVersion:
+      name: "org.openrewrite.terraform.azure.EnsureStorageAccountUsesLatestTLSVersion"
+      description: "Communication between an Azure Storage account and a client application\
+        \ is encrypted using Transport Layer Security (TLS). Microsoft recommends\
+        \ using the latest version of TLS for all your Microsoft Azure App Service\
+        \ web applications."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurestorageaccountuseslatesttlsversion"
+      options: []
+    org.openrewrite.terraform.azure.EnsureTheStorageContainerStoringActivityLogsIsNotPubliclyAccessible:
+      name: "org.openrewrite.terraform.azure.EnsureTheStorageContainerStoringActivityLogsIsNotPubliclyAccessible"
+      description: "Ensure the storage container storing activity logs is not publicly\
+        \ accessible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurethestoragecontainerstoringactivitylogsisnotpubliclyaccessible"
+      options: []
+    org.openrewrite.terraform.azure.EnsureWebAppHasIncomingClientCertificatesEnabled:
+      name: "org.openrewrite.terraform.azure.EnsureWebAppHasIncomingClientCertificatesEnabled"
+      description: "Ensure Web App has incoming client certificates enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurewebapphasincomingclientcertificatesenabled"
+      options: []
+    org.openrewrite.terraform.azure.EnsureWebAppUsesTheLatestVersionOfHTTP:
+      name: "org.openrewrite.terraform.azure.EnsureWebAppUsesTheLatestVersionOfHTTP"
+      description: "Ensure Web App uses the latest version of HTTP."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurewebappusesthelatestversionofhttp"
+      options: []
+    org.openrewrite.terraform.azure.EnsureWebAppUsesTheLatestVersionOfTLSEncryption:
+      name: "org.openrewrite.terraform.azure.EnsureWebAppUsesTheLatestVersionOfTLSEncryption"
+      description: "Ensure Web App uses the latest version of TLS encryption."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/ensurewebappusesthelatestversionoftlsencryption"
+      options: []
+    org.openrewrite.terraform.azure.SetAzureStorageAccountDefaultNetworkAccessToDeny:
+      name: "org.openrewrite.terraform.azure.SetAzureStorageAccountDefaultNetworkAccessToDeny"
+      description: "Ensure Azure Storage Account default network access is set to\
+        \ Deny."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/azure/setazurestorageaccountdefaultnetworkaccesstodeny"
+      options: []
+    org.openrewrite.terraform.gcp.EnablePodSecurityPolicyControllerOnGKEClusters:
+      name: "org.openrewrite.terraform.gcp.EnablePodSecurityPolicyControllerOnGKEClusters"
+      description: "Ensure `PodSecurityPolicy` controller is enabled on Google Kubernetes\
+        \ Engine (GKE) clusters."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/enablepodsecuritypolicycontrollerongkeclusters"
+      options: []
+    org.openrewrite.terraform.gcp.EnableVPCFlowLogsAndIntranodeVisibility:
+      name: "org.openrewrite.terraform.gcp.EnableVPCFlowLogsAndIntranodeVisibility"
+      description: "Enable VPC flow logs and intranode visibility."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/enablevpcflowlogsandintranodevisibility"
+      options: []
+    org.openrewrite.terraform.gcp.EnableVPCFlowLogsForSubnetworks:
+      name: "org.openrewrite.terraform.gcp.EnableVPCFlowLogsForSubnetworks"
+      description: "Ensure GCP VPC flow logs for subnets are enabled. Flow Logs capture\
+        \ information on IP traffic moving through network interfaces. This information\
+        \ can be used to monitor anomalous traffic and provide security insights."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/enablevpcflowlogsforsubnetworks"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureBinaryAuthorizationIsUsed:
+      name: "org.openrewrite.terraform.gcp.EnsureBinaryAuthorizationIsUsed"
+      description: "Ensure binary authorization is used."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensurebinaryauthorizationisused"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureComputeInstancesLaunchWithShieldedVMEnabled:
+      name: "org.openrewrite.terraform.gcp.EnsureComputeInstancesLaunchWithShieldedVMEnabled"
+      description: "Ensure compute instances launch with shielded VM enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensurecomputeinstanceslaunchwithshieldedvmenabled"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureGCPCloudStorageBucketWithUniformBucketLevelAccessAreEnabled:
+      name: "org.openrewrite.terraform.gcp.EnsureGCPCloudStorageBucketWithUniformBucketLevelAccessAreEnabled"
+      description: "Ensure GCP cloud storage bucket with uniform bucket-level access\
+        \ are enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuregcpcloudstoragebucketwithuniformbucketlevelaccessareenabled"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureGCPKubernetesClusterNodeAutoRepairConfigurationIsEnabled:
+      name: "org.openrewrite.terraform.gcp.EnsureGCPKubernetesClusterNodeAutoRepairConfigurationIsEnabled"
+      description: "Ensure GCP Kubernetes cluster node auto-repair configuration is\
+        \ enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuregcpkubernetesclusternodeautorepairconfigurationisenabled"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureGCPKubernetesEngineClustersHaveLegacyComputeEngineMetadataEndpointsDisabled:
+      name: "org.openrewrite.terraform.gcp.EnsureGCPKubernetesEngineClustersHaveLegacyComputeEngineMetadataEndpointsDisabled"
+      description: "Ensure GCP Kubernetes engine clusters have legacy compute engine\
+        \ metadata endpoints disabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuregcpkubernetesengineclustershavelegacycomputeenginemetadataendpointsdisabled"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureGCPVMInstancesHaveBlockProjectWideSSHKeysFeatureEnabled:
+      name: "org.openrewrite.terraform.gcp.EnsureGCPVMInstancesHaveBlockProjectWideSSHKeysFeatureEnabled"
+      description: "Ensure GCP VM instances have block project-wide SSH keys feature\
+        \ enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuregcpvminstanceshaveblockprojectwidesshkeysfeatureenabled"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureIPForwardingOnInstancesIsDisabled:
+      name: "org.openrewrite.terraform.gcp.EnsureIPForwardingOnInstancesIsDisabled"
+      description: "Ensure IP forwarding on instances is disabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensureipforwardingoninstancesisdisabled"
+      options: []
+    org.openrewrite.terraform.gcp.EnsurePrivateClusterIsEnabledWhenCreatingKubernetesClusters:
+      name: "org.openrewrite.terraform.gcp.EnsurePrivateClusterIsEnabledWhenCreatingKubernetesClusters"
+      description: "Ensure private cluster is enabled when creating Kubernetes clusters."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensureprivateclusterisenabledwhencreatingkubernetesclusters"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureSecureBootForShieldedGKENodesIsEnabled:
+      name: "org.openrewrite.terraform.gcp.EnsureSecureBootForShieldedGKENodesIsEnabled"
+      description: "Ensure secure boot for shielded GKE nodes is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensuresecurebootforshieldedgkenodesisenabled"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureShieldedGKENodesAreEnabled:
+      name: "org.openrewrite.terraform.gcp.EnsureShieldedGKENodesAreEnabled"
+      description: "Ensure shielded GKE nodes are enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensureshieldedgkenodesareenabled"
+      options: []
+    org.openrewrite.terraform.gcp.EnsureTheGKEMetadataServerIsEnabled:
+      name: "org.openrewrite.terraform.gcp.EnsureTheGKEMetadataServerIsEnabled"
+      description: "Ensure the GKE metadata server is enabled."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/ensurethegkemetadataserverisenabled"
+      options: []
+    org.openrewrite.terraform.gcp.GCPBestPractices:
+      name: "org.openrewrite.terraform.gcp.GCPBestPractices"
+      description: "Securely operate on Google Cloud Platform."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/gcp/gcpbestpractices"
+      options: []
+    org.openrewrite.terraform.search.FindResource:
+      name: "org.openrewrite.terraform.search.FindResource"
+      description: "Find a Terraform resource by resource type."
+      docLink: "https://docs.openrewrite.org/reference/recipes/terraform/search/findresource"
+      options:
+      - name: "resourceName"
+        type: "String"
+        required: true
+rewrite-testing-frameworks:
+  artifactId: "rewrite-testing-frameworks"
+  version: "1.31.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.java.testing.assertj.Assertj:
+      name: "org.openrewrite.java.testing.assertj.Assertj"
+      description: "Migrates JUnit asserts to AssertJ and applies best practices to\
+        \ assertions."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/assertj"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertArrayEqualsToAssertThat:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertArrayEqualsToAssertThat"
+      description: "Convert JUnit-style `assertArrayEquals()` to assertJ's `assertThat().contains()`\
+        \ equivalents."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertarrayequalstoassertthat"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertEqualsToAssertThat:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertEqualsToAssertThat"
+      description: "Convert JUnit-style `assertEquals()` to AssertJ's `assertThat().isEqualTo()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertequalstoassertthat"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertFalseToAssertThat:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertFalseToAssertThat"
+      description: "Convert JUnit-style `assertFalse()` to AssertJ's `assertThat().isFalse()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertfalsetoassertthat"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertNotEqualsToAssertThat:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertNotEqualsToAssertThat"
+      description: "Convert JUnit-style `assertNotEquals()` to AssertJ's `assertThat().isNotEqualTo()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertnotequalstoassertthat"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertNotNullToAssertThat:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertNotNullToAssertThat"
+      description: "Convert JUnit-style `assertNotNull()` to AssertJ's `assertThat().isNotNull()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertnotnulltoassertthat"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertNullToAssertThat:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertNullToAssertThat"
+      description: "Convert JUnit-style `assertNull()` to AssertJ's `assertThat().isNull()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertnulltoassertthat"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertSameToAssertThat:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertSameToAssertThat"
+      description: "Convert JUnit-style `assertSame()` to AssertJ's `assertThat().isSameAs()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertsametoassertthat"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertThrowsToAssertExceptionType:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertThrowsToAssertExceptionType"
+      description: "Convert `JUnit#AssertThrows` to `AssertJ#assertThatExceptionOfType`\
+        \ to allow for chained assertions on the thrown exception."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitassertthrowstoassertexceptiontype"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitAssertTrueToAssertThat:
+      name: "org.openrewrite.java.testing.assertj.JUnitAssertTrueToAssertThat"
+      description: "Convert JUnit-style `assertTrue()` to AssertJ's `assertThat().isTrue()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitasserttruetoassertthat"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitFailToAssertJFail:
+      name: "org.openrewrite.java.testing.assertj.JUnitFailToAssertJFail"
+      description: "Convert JUnit-style `fail()` to AssertJ's `fail()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junitfailtoassertjfail"
+      options: []
+    org.openrewrite.java.testing.assertj.JUnitToAssertj:
+      name: "org.openrewrite.java.testing.assertj.JUnitToAssertj"
+      description: "AssertJ provides a rich set of assertions, truly helpful error\
+        \ messages, improves test code readability."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/junittoassertj"
+      options: []
+    org.openrewrite.java.testing.assertj.StaticImports:
+      name: "org.openrewrite.java.testing.assertj.StaticImports"
+      description: "Consistently use a static import rather than inlining the `Assertions`\
+        \ class name in tests."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/assertj/staticimports"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertEqualsNullToAssertNull:
+      name: "org.openrewrite.java.testing.cleanup.AssertEqualsNullToAssertNull"
+      description: "Using `assertNull(a)` is simpler and more clear."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertequalsnulltoassertnull"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertFalseEqualsToAssertNotEquals:
+      name: "org.openrewrite.java.testing.cleanup.AssertFalseEqualsToAssertNotEquals"
+      description: "Using `assertNotEquals(a,b)` is simpler and more clear."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertfalseequalstoassertnotequals"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertFalseNegationToAssertTrue:
+      name: "org.openrewrite.java.testing.cleanup.AssertFalseNegationToAssertTrue"
+      description: "Using `assertTrue` is simpler and more clear."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertfalsenegationtoasserttrue"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertFalseNullToAssertNotNull:
+      name: "org.openrewrite.java.testing.cleanup.AssertFalseNullToAssertNotNull"
+      description: "Using `assertNotNull(a)` is simpler and more clear."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertfalsenulltoassertnotnull"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertTrueComparisonToAssertEquals:
+      name: "org.openrewrite.java.testing.cleanup.AssertTrueComparisonToAssertEquals"
+      description: "Using `assertEquals(a,b)` is simpler and more clear."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/asserttruecomparisontoassertequals"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertTrueEqualsToAssertEquals:
+      name: "org.openrewrite.java.testing.cleanup.AssertTrueEqualsToAssertEquals"
+      description: "Using `assertEquals(a,b)` is simpler and more clear."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/asserttrueequalstoassertequals"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertTrueNegationToAssertFalse:
+      name: "org.openrewrite.java.testing.cleanup.AssertTrueNegationToAssertFalse"
+      description: "Using `assertFalse` is simpler and more clear."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/asserttruenegationtoassertfalse"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertTrueNullToAssertNull:
+      name: "org.openrewrite.java.testing.cleanup.AssertTrueNullToAssertNull"
+      description: "Using `assertNull(a)` is simpler and more clear."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/asserttruenulltoassertnull"
+      options: []
+    org.openrewrite.java.testing.cleanup.AssertionsArgumentOrder:
+      name: "org.openrewrite.java.testing.cleanup.AssertionsArgumentOrder"
+      description: "Assertions such as `org.junit.Assert.assertEquals` expect the\
+        \ first argument to be the expected value and the second argument to be the\
+        \ actual value; for `org.testng.Assert`, it’s the other way around.  This\
+        \ recipe detects `J.Literal`, `J.NewArray`, and `java.util.Iterable` arguments\
+        \ swapping them if necessary so that the error messages will be confusing."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/assertionsargumentorder"
+      options: []
+    org.openrewrite.java.testing.cleanup.BestPractices:
+      name: "org.openrewrite.java.testing.cleanup.BestPractices"
+      description: "Applies best practices to tests."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/bestpractices"
+      options: []
+    org.openrewrite.java.testing.cleanup.RemoveEmptyTests:
+      name: "org.openrewrite.java.testing.cleanup.RemoveEmptyTests"
+      description: "Removes empty methods with a `@Test` annotation if the body does\
+        \ not have comments."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/removeemptytests"
+      options: []
+    org.openrewrite.java.testing.cleanup.RemoveTestPrefix:
+      name: "org.openrewrite.java.testing.cleanup.RemoveTestPrefix"
+      description: "Remove `test` from methods with `@Test`, `@ParameterizedTest`,\
+        \ `@RepeatedTest` or `@TestFactory`. They no longer have to prefix test to\
+        \ be usable by JUnit 5."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/removetestprefix"
+      options: []
+    org.openrewrite.java.testing.cleanup.TestsShouldIncludeAssertions:
+      name: "org.openrewrite.java.testing.cleanup.TestsShouldIncludeAssertions"
+      description: "For tests not having any assertions, wrap the statements with\
+        \ JUnit Jupiter's `Assertions#assertThrowDoesNotThrow(..)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/testsshouldincludeassertions"
+      options:
+      - name: "additionalAsserts"
+        type: "String"
+        required: false
+    org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic:
+      name: "org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic"
+      description: "Remove `public` and optionally `protected` modifiers from methods\
+        \ with `@Test`, `@ParameterizedTest`, `@RepeatedTest`, `@TestFactory`, `@BeforeEach`\
+        \ or `@AfterEach`. They no longer have to be public visibility to be usable\
+        \ by JUnit 5."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cleanup/testsshouldnotbepublic"
+      options:
+      - name: "removeProtectedModifiers"
+        type: "Boolean"
+        required: false
+    org.openrewrite.java.testing.cucumber.CucumberAnnotationToSuite:
+      name: "org.openrewrite.java.testing.cucumber.CucumberAnnotationToSuite"
+      description: "Replace @Cucumber with @Suite and @SelectClasspathResource(\"\
+        cucumber/annotated/class/package\")."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumberannotationtosuite"
+      options: []
+    org.openrewrite.java.testing.cucumber.CucumberJava8HookDefinitionToCucumberJava:
+      name: "org.openrewrite.java.testing.cucumber.CucumberJava8HookDefinitionToCucumberJava"
+      description: "Replace LamdbaGlue hook definitions with new annotated methods\
+        \ with the same body."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumberjava8hookdefinitiontocucumberjava"
+      options: []
+    org.openrewrite.java.testing.cucumber.CucumberJava8StepDefinitionToCucumberJava:
+      name: "org.openrewrite.java.testing.cucumber.CucumberJava8StepDefinitionToCucumberJava"
+      description: "Replace StepDefinitionBody methods with StepDefinitionAnnotations\
+        \ on new methods with the same body."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumberjava8stepdefinitiontocucumberjava"
+      options: []
+    org.openrewrite.java.testing.cucumber.CucumberJava8ToJava:
+      name: "org.openrewrite.java.testing.cucumber.CucumberJava8ToJava"
+      description: "Migrates Cucumber-Java8 step definitions and LambdaGlue hooks\
+        \ to Cucumber-Java annotated methods."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumberjava8tojava"
+      options: []
+    org.openrewrite.java.testing.cucumber.CucumberToJunitPlatformSuite:
+      name: "org.openrewrite.java.testing.cucumber.CucumberToJunitPlatformSuite"
+      description: "Migrates Cucumber tests to Junit Test Suites."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/cucumbertojunitplatformsuite"
+      options: []
+    org.openrewrite.java.testing.cucumber.DropSummaryPrinter:
+      name: "org.openrewrite.java.testing.cucumber.DropSummaryPrinter"
+      description: "Replace SummaryPrinter with Plugin, if not already present."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/dropsummaryprinter"
+      options: []
+    org.openrewrite.java.testing.cucumber.RegexToCucumberExpression:
+      name: "org.openrewrite.java.testing.cucumber.RegexToCucumberExpression"
+      description: "Strip regex prefix and suffix from step annotation expressions\
+        \ arguments where possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/regextocucumberexpression"
+      options: []
+    org.openrewrite.java.testing.cucumber.UpgradeCucumber2x:
+      name: "org.openrewrite.java.testing.cucumber.UpgradeCucumber2x"
+      description: "Upgrade to Cucumber-JVM 2.x from any previous version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/upgradecucumber2x"
+      options: []
+    org.openrewrite.java.testing.cucumber.UpgradeCucumber5x:
+      name: "org.openrewrite.java.testing.cucumber.UpgradeCucumber5x"
+      description: "Upgrade to Cucumber-JVM 5.x from any previous version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/upgradecucumber5x"
+      options: []
+    org.openrewrite.java.testing.cucumber.UpgradeCucumber7x:
+      name: "org.openrewrite.java.testing.cucumber.UpgradeCucumber7x"
+      description: "Upgrade to Cucumber-JVM 7.x from any previous version."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/cucumber/upgradecucumber7x"
+      options: []
+    org.openrewrite.java.testing.hamcrest.AddHamcrestIfUsed:
+      name: "org.openrewrite.java.testing.hamcrest.AddHamcrestIfUsed"
+      description: "JUnit Jupiter does not include hamcrest as a transitive dependency.\
+        \ If needed, add a direct dependency."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/hamcrest/addhamcrestifused"
+      options: []
+    org.openrewrite.java.testing.junit5.AddMissingNested:
+      name: "org.openrewrite.java.testing.junit5.AddMissingNested"
+      description: "Adds `@Nested` to inner classes that contain JUnit 5 tests."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/addmissingnested"
+      options: []
+    org.openrewrite.java.testing.junit5.AssertToAssertions:
+      name: "org.openrewrite.java.testing.junit5.AssertToAssertions"
+      description: "Change JUnit 4's `org.junit.Assert` into JUnit Jupiter's `org.junit.jupiter.api.Assertions`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/asserttoassertions"
+      options: []
+    org.openrewrite.java.testing.junit5.CategoryToTag:
+      name: "org.openrewrite.java.testing.junit5.CategoryToTag"
+      description: "Transforms the JUnit 4 `@Category`, which can list multiple categories,\
+        \ into one `@Tag` annotation per category listed."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/categorytotag"
+      options: []
+    org.openrewrite.java.testing.junit5.CleanupAssertions:
+      name: "org.openrewrite.java.testing.junit5.CleanupAssertions"
+      description: "Simplifies JUnit Jupiter assertions to their most-direct equivalents"
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/cleanupassertions"
+      options: []
+    org.openrewrite.java.testing.junit5.CleanupJUnitImports:
+      name: "org.openrewrite.java.testing.junit5.CleanupJUnitImports"
+      description: "Removes unused `org.junit` import symbols."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/cleanupjunitimports"
+      options: []
+    org.openrewrite.java.testing.junit5.EnclosedToNested:
+      name: "org.openrewrite.java.testing.junit5.EnclosedToNested"
+      description: "Removes the `Enclosed` specification from a class, and adds `Nested`\
+        \ to its inner classes."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/enclosedtonested"
+      options: []
+    org.openrewrite.java.testing.junit5.ExpectedExceptionToAssertThrows:
+      name: "org.openrewrite.java.testing.junit5.ExpectedExceptionToAssertThrows"
+      description: "Replace usages of JUnit 4's `@Rule ExpectedException` with JUnit\
+        \ 5's `Assertions.assertThrows()`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/expectedexceptiontoassertthrows"
+      options: []
+    org.openrewrite.java.testing.junit5.IgnoreToDisabled:
+      name: "org.openrewrite.java.testing.junit5.IgnoreToDisabled"
+      description: "Migrates JUnit 4.x `@Ignore` to JUnit Jupiter `@Disabled`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/ignoretodisabled"
+      options: []
+    org.openrewrite.java.testing.junit5.JUnit4to5Migration:
+      name: "org.openrewrite.java.testing.junit5.JUnit4to5Migration"
+      description: "Migrates JUnit 4.x tests to JUnit Jupiter."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/junit4to5migration"
+      options: []
+    org.openrewrite.java.testing.junit5.JUnit5BestPractices:
+      name: "org.openrewrite.java.testing.junit5.JUnit5BestPractices"
+      description: "Applies best practices to tests."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/junit5bestpractices"
+      options: []
+    org.openrewrite.java.testing.junit5.JUnitParamsRunnerToParameterized:
+      name: "org.openrewrite.java.testing.junit5.JUnitParamsRunnerToParameterized"
+      description: "Convert Pragmatists Parameterized test to the JUnit Jupiter ParameterizedTest\
+        \ equivalent."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/junitparamsrunnertoparameterized"
+      options: []
+    org.openrewrite.java.testing.junit5.LifecycleNonPrivate:
+      name: "org.openrewrite.java.testing.junit5.LifecycleNonPrivate"
+      description: "Make JUnit 5's `@AfterAll`, `@AfterEach`, `@BeforeAll` and `@BeforeEach`\
+        \ non private."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/lifecyclenonprivate"
+      options: []
+    org.openrewrite.java.testing.junit5.MigrateJUnitTestCase:
+      name: "org.openrewrite.java.testing.junit5.MigrateJUnitTestCase"
+      description: "Convert JUnit 4 `TestCase` to JUnit Jupiter."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/migratejunittestcase"
+      options: []
+    org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension:
+      name: "org.openrewrite.java.testing.junit5.MockitoJUnitToMockitoExtension"
+      description: "Replaces `MockitoJUnit` rules with `MockitoExtension`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/mockitojunittomockitoextension"
+      options: []
+    org.openrewrite.java.testing.junit5.ParameterizedRunnerToParameterized:
+      name: "org.openrewrite.java.testing.junit5.ParameterizedRunnerToParameterized"
+      description: "Convert JUnit4 parameterized runner the JUnit Jupiter parameterized\
+        \ test equivalent."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/parameterizedrunnertoparameterized"
+      options: []
+    org.openrewrite.java.testing.junit5.RemoveObsoleteRunners:
+      name: "org.openrewrite.java.testing.junit5.RemoveObsoleteRunners"
+      description: "Some JUnit4 `@RunWith` annotations do not require replacement\
+        \ with an equivalent JUnit Jupiter `@ExtendsWith` annotation. This can be\
+        \ used to remove those runners that either do not have a JUnit Jupiter equivalent\
+        \ or do not require a replacement as part of JUnit 4 to 5 migration."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/removeobsoleterunners"
+      options:
+      - name: "obsoleteRunners"
+        type: "List"
+        required: true
+    org.openrewrite.java.testing.junit5.RunnerToExtension:
+      name: "org.openrewrite.java.testing.junit5.RunnerToExtension"
+      description: "Replace runners with the JUnit Jupiter extension equivalent."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/runnertoextension"
+      options:
+      - name: "extension"
+        type: "String"
+        required: true
+      - name: "runners"
+        type: "List"
+        required: true
+    org.openrewrite.java.testing.junit5.StaticImports:
+      name: "org.openrewrite.java.testing.junit5.StaticImports"
+      description: "Always use a static import for assertion methods."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/staticimports"
+      options: []
+    org.openrewrite.java.testing.junit5.TempDirNonFinal:
+      name: "org.openrewrite.java.testing.junit5.TempDirNonFinal"
+      description: "Make JUnit 5's `org.junit.jupiter.api.io.TempDir` fields non final."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/tempdirnonfinal"
+      options: []
+    org.openrewrite.java.testing.junit5.TemporaryFolderToTempDir:
+      name: "org.openrewrite.java.testing.junit5.TemporaryFolderToTempDir"
+      description: "Translates JUnit4's `org.junit.rules.TemporaryFolder` into JUnit\
+        \ 5's `org.junit.jupiter.api.io.TempDir`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/temporaryfoldertotempdir"
+      options: []
+    org.openrewrite.java.testing.junit5.TestRuleToTestInfo:
+      name: "org.openrewrite.java.testing.junit5.TestRuleToTestInfo"
+      description: "Replace usages of JUnit 4's `@Rule TestName` with JUnit 5's TestInfo."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/testruletotestinfo"
+      options: []
+    org.openrewrite.java.testing.junit5.UpdateBeforeAfterAnnotations:
+      name: "org.openrewrite.java.testing.junit5.UpdateBeforeAfterAnnotations"
+      description: "Replace JUnit 4's `@Before`, `@BeforeClass`, `@After`, and `@AfterClass`\
+        \ annotations with their JUnit Jupiter equivalents."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/updatebeforeafterannotations"
+      options: []
+    org.openrewrite.java.testing.junit5.UpdateMockWebServer:
+      name: "org.openrewrite.java.testing.junit5.UpdateMockWebServer"
+      description: "Replace usages of okhttp3 3.x @Rule MockWebServer with 4.x MockWebServer."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/updatemockwebserver"
+      options: []
+    org.openrewrite.java.testing.junit5.UpdateTestAnnotation:
+      name: "org.openrewrite.java.testing.junit5.UpdateTestAnnotation"
+      description: "Update usages of JUnit 4's `@org.junit.Test` annotation to JUnit5's\
+        \ `org.junit.jupiter.api.Test` annotation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/updatetestannotation"
+      options: []
+    org.openrewrite.java.testing.junit5.UseHamcrestAssertThat:
+      name: "org.openrewrite.java.testing.junit5.UseHamcrestAssertThat"
+      description: "JUnit 4's `Assert#assertThat(..)` This method was deprecated in\
+        \ JUnit 4 and removed in JUnit Jupiter."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/usehamcrestassertthat"
+      options: []
+    org.openrewrite.java.testing.junit5.UseMockitoExtension:
+      name: "org.openrewrite.java.testing.junit5.UseMockitoExtension"
+      description: "Migrate uses of `@RunWith(MockitoJUnitRunner.class)` (and similar\
+        \ annotations) to `@ExtendWith(MockitoExtension.class)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/usemockitoextension"
+      options: []
+    org.openrewrite.java.testing.junit5.UseTestMethodOrder:
+      name: "org.openrewrite.java.testing.junit5.UseTestMethodOrder"
+      description: "JUnit optionally allows test method execution order to be specified.\
+        \ This Recipe replaces JUnit4 test execution ordering annotations with JUnit5\
+        \ replacements."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/usetestmethodorder"
+      options: []
+    org.openrewrite.java.testing.junit5.UseWiremockExtension:
+      name: "org.openrewrite.java.testing.junit5.UseWiremockExtension"
+      description: "As of 2.31.0, wiremock [supports JUnit 5](http://wiremock.org/docs/junit-jupiter/)\
+        \ via an extension."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/usewiremockextension"
+      options: []
+    org.openrewrite.java.testing.junit5.VertxUnitToVertxJunit5:
+      name: "org.openrewrite.java.testing.junit5.VertxUnitToVertxJunit5"
+      description: "Migrates Vertx `@RunWith` `VertxUnitRunner` to the JUnit Jupiter\
+        \ `@ExtendWith` `VertxExtension`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/junit5/vertxunittovertxjunit5"
+      options: []
+    org.openrewrite.java.testing.mockito.CleanupMockitoImports:
+      name: "org.openrewrite.java.testing.mockito.CleanupMockitoImports"
+      description: "Removes unused `org.mockito` import symbols, unless its possible\
+        \ they are associated with method invocations having null or unknown type\
+        \ information."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/cleanupmockitoimports"
+      options: []
+    org.openrewrite.java.testing.mockito.MockUtilsToStatic:
+      name: "org.openrewrite.java.testing.mockito.MockUtilsToStatic"
+      description: "Best-effort attempt to remove Mockito `MockUtil` instances."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/mockutilstostatic"
+      options: []
+    org.openrewrite.java.testing.mockito.Mockito1to3Migration:
+      name: "org.openrewrite.java.testing.mockito.Mockito1to3Migration"
+      description: "Upgrade Mockito from 1.x to 3.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/mockito1to3migration"
+      options: []
+    org.openrewrite.java.testing.mockito.Mockito1to4Migration:
+      name: "org.openrewrite.java.testing.mockito.Mockito1to4Migration"
+      description: "Upgrade Mockito from 1.x to 4.x."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/mockito1to4migration"
+      options: []
+    org.openrewrite.java.testing.mockito.MockitoJUnitRunnerSilentToExtension:
+      name: "org.openrewrite.java.testing.mockito.MockitoJUnitRunnerSilentToExtension"
+      description: "Replace `@RunWith(MockitoJUnitRunner.Silent.class)` with `@ExtendWith(MockitoExtension.class)`\
+        \ and `@MockitoSettings(strictness = Strictness.LENIENT)`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/java/testing/mockito/mockitojunitrunnersilenttoextension"
+      options: []
+rewrite-xml:
+  artifactId: "rewrite-xml"
+  version: "7.33.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.xml.AddCommentToXmlTag:
+      name: "org.openrewrite.xml.AddCommentToXmlTag"
+      description: "Adds a comment as the first element in a `XML` tag."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/addcommenttoxmltag"
+      options:
+      - name: "commentText"
+        type: "String"
+        required: true
+      - name: "xPath"
+        type: "String"
+        required: true
+    org.openrewrite.xml.ChangeTagAttribute:
+      name: "org.openrewrite.xml.ChangeTagAttribute"
+      description: "Alters XML Attribute value within specified element."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/changetagattribute"
+      options:
+      - name: "attributeName"
+        type: "String"
+        required: true
+      - name: "elementName"
+        type: "String"
+        required: true
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newValue"
+        type: "String"
+        required: true
+      - name: "oldValue"
+        type: "String"
+        required: false
+    org.openrewrite.xml.ChangeTagName:
+      name: "org.openrewrite.xml.ChangeTagName"
+      description: "Alters the name of XML tags matching the provided expression."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/changetagname"
+      options:
+      - name: "elementName"
+        type: "String"
+        required: true
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newName"
+        type: "String"
+        required: true
+    org.openrewrite.xml.RemoveTrailingWhitespace:
+      name: "org.openrewrite.xml.RemoveTrailingWhitespace"
+      description: "Remove any extra trailing whitespace from the end of each line."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/removetrailingwhitespace"
+      options: []
+    org.openrewrite.xml.format.AutoFormat:
+      name: "org.openrewrite.xml.format.AutoFormat"
+      description: "Indents XML using the most common indentation size and tabs or\
+        \ space choice in use in the file."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/autoformat"
+      options: []
+    org.openrewrite.xml.format.LineBreaks:
+      name: "org.openrewrite.xml.format.LineBreaks"
+      description: "Add line breaks at appropriate places between XML syntax elements."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/linebreaks"
+      options: []
+    org.openrewrite.xml.format.NormalizeFormat:
+      name: "org.openrewrite.xml.format.NormalizeFormat"
+      description: "Move whitespace to the outermost AST element possible."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/normalizeformat"
+      options: []
+    org.openrewrite.xml.format.NormalizeLineBreaks:
+      name: "org.openrewrite.xml.format.NormalizeLineBreaks"
+      description: "Consistently use either Windows style (CRLF) or Linux style (LF)\
+        \ line breaks. If no `GeneralFormatStyle` is specified this will use whichever\
+        \ style of line endings are more common."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/normalizelinebreaks"
+      options: []
+    org.openrewrite.xml.format.NormalizeTabsOrSpaces:
+      name: "org.openrewrite.xml.format.NormalizeTabsOrSpaces"
+      description: "Consistently use either tabs or spaces in indentation."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/normalizetabsorspaces"
+      options: []
+    org.openrewrite.xml.format.TabsAndIndents:
+      name: "org.openrewrite.xml.format.TabsAndIndents"
+      description: "Format tabs and indents in XML code."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/format/tabsandindents"
+      options: []
+    org.openrewrite.xml.search.FindTags:
+      name: "org.openrewrite.xml.search.FindTags"
+      description: "Find XML tags by XPath expression."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/search/findtags"
+      options:
+      - name: "xPath"
+        type: "String"
+        required: true
+    org.openrewrite.xml.security.AddOwaspDateBoundSuppressions:
+      name: "org.openrewrite.xml.security.AddOwaspDateBoundSuppressions"
+      description: "Adds an expiration date to all OWASP suppressions in order to\
+        \ ensure that they are periodically reviewed. For use with the OWASP `dependency-check`\
+        \ tool. More details: https://jeremylong.github.io/DependencyCheck/general/suppression.html."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/security/addowaspdateboundsuppressions"
+      options:
+      - name: "untilDate"
+        type: "String"
+        required: false
+    org.openrewrite.xml.security.RemoveOwaspSuppressions:
+      name: "org.openrewrite.xml.security.RemoveOwaspSuppressions"
+      description: "Remove all OWASP suppressions with a suppression end date in the\
+        \ past, as these are no longer valid. For use with the OWASP `dependency-check`\
+        \ tool. More details on OWASP suppression files: https://jeremylong.github.io/DependencyCheck/general/suppression.html."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/security/removeowaspsuppressions"
+      options: []
+    org.openrewrite.xml.security.UpdateOwaspSuppressionDate:
+      name: "org.openrewrite.xml.security.UpdateOwaspSuppressionDate"
+      description: "Updates the expiration date for OWASP suppressions having a matching\
+        \ cve tag. For use with the OWASP `dependency-check` tool. More details: https://jeremylong.github.io/DependencyCheck/general/suppression.html."
+      docLink: "https://docs.openrewrite.org/reference/recipes/xml/security/updateowaspsuppressiondate"
+      options:
+      - name: "cveList"
+        type: "List"
+        required: true
+      - name: "untilDate"
+        type: "String"
+        required: false
+rewrite-yaml:
+  artifactId: "rewrite-yaml"
+  version: "7.33.0"
+  markdownRecipeDescriptors:
+    org.openrewrite.yaml.ChangeKey:
+      name: "org.openrewrite.yaml.ChangeKey"
+      description: "Change a YAML mapping entry key leaving the value intact."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/changekey"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newKey"
+        type: "String"
+        required: true
+      - name: "oldKeyPath"
+        type: "String"
+        required: true
+    org.openrewrite.yaml.ChangePropertyKey:
+      name: "org.openrewrite.yaml.ChangePropertyKey"
+      description: "Change a YAML property key leaving the value intact. Nested YAML\
+        \ mappings are interpreted as dot separated property names, i.e. as Spring\
+        \ Boot interprets application.yml files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/changepropertykey"
+      options:
+      - name: "except"
+        type: "List"
+        required: false
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newPropertyKey"
+        type: "String"
+        required: true
+      - name: "oldPropertyKey"
+        type: "String"
+        required: true
+      - name: "relaxedBinding"
+        type: "Boolean"
+        required: false
+    org.openrewrite.yaml.ChangeValue:
+      name: "org.openrewrite.yaml.ChangeValue"
+      description: "Change a YAML mapping entry value leaving the key intact."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/changevalue"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "oldKeyPath"
+        type: "String"
+        required: true
+      - name: "value"
+        type: "String"
+        required: true
+    org.openrewrite.yaml.CoalesceProperties:
+      name: "org.openrewrite.yaml.CoalesceProperties"
+      description: "Simplify nested map hierarchies into their simplest dot separated\
+        \ property form, i.e. as Spring Boot interprets application.yml files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/coalesceproperties"
+      options: []
+    org.openrewrite.yaml.CopyValue:
+      name: "org.openrewrite.yaml.CopyValue"
+      description: "Copies a YAML value from one key to another. The existing key/value\
+        \ pair remains unaffected by this change. If either the source or destination\
+        \ key path does not exist, no value will be copied. Furthermore, copies are\
+        \ limited to scalar values, not whole YAML blocks."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/copyvalue"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "newKey"
+        type: "String"
+        required: true
+      - name: "oldKeyPath"
+        type: "String"
+        required: true
+    org.openrewrite.yaml.DeleteKey:
+      name: "org.openrewrite.yaml.DeleteKey"
+      description: "Delete a YAML mapping entry key."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/deletekey"
+      options:
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "keyPath"
+        type: "String"
+        required: true
+    org.openrewrite.yaml.DeleteProperty:
+      name: "org.openrewrite.yaml.DeleteProperty"
+      description: "Delete a YAML property. Nested YAML mappings are interpreted as\
+        \ dot separated property names, i.e.  as Spring Boot interprets application.yml\
+        \ files like `a.b.c.d` or `a.b.c:d`."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/deleteproperty"
+      options:
+      - name: "coalesce"
+        type: "Boolean"
+        required: false
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "propertyKey"
+        type: "String"
+        required: true
+      - name: "relaxedBinding"
+        type: "Boolean"
+        required: false
+    org.openrewrite.yaml.MergeYaml:
+      name: "org.openrewrite.yaml.MergeYaml"
+      description: "Merge a YAML snippet with an existing YAML document."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/mergeyaml"
+      options:
+      - name: "acceptTheirs"
+        type: "Boolean"
+        required: false
+      - name: "fileMatcher"
+        type: "String"
+        required: false
+      - name: "key"
+        type: "String"
+        required: true
+      - name: "objectIdentifyingProperty"
+        type: "String"
+        required: false
+      - name: "yaml"
+        type: "String"
+        required: true
+    org.openrewrite.yaml.cleanup.RemoveUnused:
+      name: "org.openrewrite.yaml.cleanup.RemoveUnused"
+      description: "Remove YAML mapping and sequence keys that have no value."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/cleanup/removeunused"
+      options: []
+    org.openrewrite.yaml.format.Indents:
+      name: "org.openrewrite.yaml.format.Indents"
+      description: "Format tabs and indents in YAML."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/format/indents"
+      options: []
+    org.openrewrite.yaml.search.FindKey:
+      name: "org.openrewrite.yaml.search.FindKey"
+      description: "Find YAML entries by JsonPath expression."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/search/findkey"
+      options:
+      - name: "key"
+        type: "String"
+        required: true
+    org.openrewrite.yaml.search.FindProperty:
+      name: "org.openrewrite.yaml.search.FindProperty"
+      description: "Find a YAML property. Nested YAML mappings are interpreted as\
+        \ dot separated property names, i.e.  as Spring Boot interprets `application.yml`\
+        \ files."
+      docLink: "https://docs.openrewrite.org/reference/recipes/yaml/search/findproperty"
+      options:
+      - name: "propertyKey"
+        type: "String"
+        required: true
+      - name: "relaxedBinding"
+        type: "Boolean"
+        required: false


### PR DESCRIPTION
* Adds a new ChangedRecipe class which contains all the information about a recipe needed for the CHANGELOG
* Updates the MarkdownRecipeArtifact class to have a map of recipe names to descriptors to assist in detection of changes
* Updates the RecipeMarkdownGenerator class to build the CHANGELOG when run
* Updates the recipeDescriptors to have the latest information with the latest style so this can work next time
* An example of what this CHANGELOG would look like can be found here: https://gist.github.com/mike-solomon/16727159ec86ee0f0406ba389cbaecb1