### PR TITLE
Use versionless Maven commands

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -876,7 +876,7 @@ class RecipeMarkdownGenerator : Runnable {
                         {% tab title="Maven Command Line" %}
                         {% code title="shell" %}
                         ```shell
-                        mvn org.openrewrite.maven:rewrite-maven-plugin:$mavenPluginVersion:run \
+                        mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
                           -DactiveRecipes=${recipeDescriptor.name}
                         ```
                         {% endcode %}
@@ -949,8 +949,8 @@ class RecipeMarkdownGenerator : Runnable {
                         {% tab title="Maven Command Line" %}
                         {% code title="shell" %}
                         ```shell
-                        mvn org.openrewrite.maven:rewrite-maven-plugin:$mavenPluginVersion:run \
-                          -Drewrite.recipeArtifactCoordinates=${origin.groupId}:${origin.artifactId}:${origin.version} \
+                        mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
+                          -Drewrite.recipeArtifactCoordinates=${origin.groupId}:${origin.artifactId}:LATEST \
                           -DactiveRecipes=${recipeDescriptor.name}
                         ```
                         {% endcode %}


### PR DESCRIPTION
Fixes https://github.com/openrewrite/rewrite-docs/issues/120

Has a slight potential to make it harder to debug when a user reports a bug in say january, and we don't immediately know what version they used. But the versions will still be in the logs, and the convenience might out weigh the negative.