### PR TITLE
Add link to snapshot guide in snapshot changelogs

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -332,6 +332,14 @@ class RecipeMarkdownGenerator : Runnable {
         // Clear the file in case this is being generated multiple times
         changelog.writeText("")
 
+        if (deployType == "snapshot") {
+            changelog.appendText("# Snapshot ($formatted)")
+
+            changelog.appendText("\n\n{% hint style=\"info\" %}")
+            changelog.appendText("\nWant to learn how to use snapshot versions in your project? Check out our [snapshot version guide](/reference/snapshot-instructions.md).")
+            changelog.appendText("\n{% endhint %}\n\n")
+        }
+
         // An example of what the changelog could look like after the below statements can be found here:
         // https://gist.github.com/mike-solomon/16727159ec86ee0f0406ba389cbaecb1
         if (newArtifacts.isNotEmpty()) {


### PR DESCRIPTION
Here's an example of what this would look like on a snapshot changelog: https://docs.openrewrite.org/changelog/snapshot-2023-01-30 