### PR TITLE
Fix incorrect information about running recipes

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -883,10 +883,12 @@ class RecipeMarkdownGenerator : Runnable {
                         {% endtab %}
     
                         {% tab title="Maven Command Line" %}
+                        You will need to have [Maven](https://maven.apache.org/download.cgi) installed on your machine before you can run the following command.
+
                         {% code title="shell" %}
                         ```shell
-                        ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
-                          -DactiveRecipes=${recipeDescriptor.name}
+                        mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
+                          -Drewrite.activeRecipes=${recipeDescriptor.name}
                         ```
                         {% endcode %}
                         {% endtab %}
@@ -958,10 +960,12 @@ class RecipeMarkdownGenerator : Runnable {
     
                         {% tab title="Maven Command Line" %}
                         {% code title="shell" %}
+                        You will need to have [Maven](https://maven.apache.org/download.cgi) installed on your machine before you can run the following command.
+
                         ```shell
-                        ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
+                        mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
                           -Drewrite.recipeArtifactCoordinates=${origin.groupId}:${origin.artifactId}:LATEST \
-                          -DactiveRecipes=${recipeDescriptor.name}
+                          -Drewrite.activeRecipes=${recipeDescriptor.name}
                         ```
                         {% endcode %}
                         {% endtab %}

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -830,7 +830,6 @@ class RecipeMarkdownGenerator : Runnable {
                     """.trimIndent()
                     )
                 }
-                writeln("Recipes can also be activated directly from the command line by adding the argument `-Drewrite.activeRecipes=${exampleRecipeName}`")
             } else {
                 if (origin.isFromCoreLibrary()) {
                     writeln(
@@ -886,7 +885,7 @@ class RecipeMarkdownGenerator : Runnable {
                         {% tab title="Maven Command Line" %}
                         {% code title="shell" %}
                         ```shell
-                        mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
+                        ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
                           -DactiveRecipes=${recipeDescriptor.name}
                         ```
                         {% endcode %}
@@ -897,8 +896,9 @@ class RecipeMarkdownGenerator : Runnable {
                     )
                 } else {
                     writeln(
-                        "This recipe has no required configuration options and can be activated directly after " +
-                                "taking a dependency on ${origin.groupId}:${origin.artifactId}:${origin.version} in your build file:"
+                        "This recipe has no required configuration options. It can be activated by adding a dependency on " +
+                                "`${origin.groupId}:${origin.artifactId}:${origin.version}` in your build file or by running a shell " +
+                                "command (in which case no build changes are needed): "
                     )
                     writeln(
                         """
@@ -959,7 +959,7 @@ class RecipeMarkdownGenerator : Runnable {
                         {% tab title="Maven Command Line" %}
                         {% code title="shell" %}
                         ```shell
-                        mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
+                        ./mvnw -U org.openrewrite.maven:rewrite-maven-plugin:run \
                           -Drewrite.recipeArtifactCoordinates=${origin.groupId}:${origin.artifactId}:LATEST \
                           -DactiveRecipes=${recipeDescriptor.name}
                         ```
@@ -970,7 +970,6 @@ class RecipeMarkdownGenerator : Runnable {
                     """.trimIndent()
                     )
                 }
-                writeln("Recipes can also be activated directly from the command line by adding the argument `-Drewrite.activeRecipes=${recipeDescriptor.name}`")
             }
 
             if (recipeDescriptor.recipeList.isNotEmpty()) {


### PR DESCRIPTION
* Removes a line talking about activating a recipe directly from the command line that doesn't appear to be relevant anymore.
* Clarifies you need to install Maven for the command to work
* Removes a sentence saying you need to add a dependency when you don't.