### PR TITLE
Specify that a recipe is a composite recipe

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -650,6 +650,7 @@ class RecipeMarkdownGenerator : Runnable {
                     appendLine("## Composite Recipes")
                     appendLine()
                     appendLine("_Recipes that include further recipes, often including the individual recipes below._")
+                    appendLine()
 
                     for (recipe in recipes) {
                         val recipeSimpleName = recipe.name.substring(recipe.name.lastIndexOf('.') + 1).lowercase()

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -647,19 +647,34 @@ class RecipeMarkdownGenerator : Runnable {
                 }
 
                 if (recipes.isNotEmpty()) {
-                    appendLine("## Recipes")
+                    appendLine("## Composite Recipes")
                     appendLine()
+                    appendLine("_Recipes that include further recipes, often including the individual recipes below._")
+
                     for (recipe in recipes) {
                         val recipeSimpleName = recipe.name.substring(recipe.name.lastIndexOf('.') + 1).lowercase()
 
                         // Anything except a relative link ending in .md will be mangled.
-                        // If you touch this line double check that it works when imported into gitbo
+                        // If you touch this line double check that it works when imported into gitbook
                         if (recipe.recipeList.isNotEmpty()) {
-                            appendLine("* (Composite) [${recipe.displayName}](./${recipeSimpleName}.md)")
-                        } else {
                             appendLine("* [${recipe.displayName}](./${recipeSimpleName}.md)")
                         }
                     }
+
+                    appendLine()
+                    appendLine("## Recipes")
+                    appendLine()
+
+                    for (recipe in recipes) {
+                        val recipeSimpleName = recipe.name.substring(recipe.name.lastIndexOf('.') + 1).lowercase()
+
+                        // Anything except a relative link ending in .md will be mangled.
+                        // If you touch this line double check that it works when imported into gitbook
+                        if (recipe.recipeList.isEmpty()) {
+                            appendLine("* [${recipe.displayName}](./${recipeSimpleName}.md)")
+                        }
+                    }
+
                     appendLine()
                 }
 

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -651,9 +651,14 @@ class RecipeMarkdownGenerator : Runnable {
                     appendLine()
                     for (recipe in recipes) {
                         val recipeSimpleName = recipe.name.substring(recipe.name.lastIndexOf('.') + 1).lowercase()
+
                         // Anything except a relative link ending in .md will be mangled.
-                        // If you touch this line double check that it works when imported into gitbook
-                        appendLine("* [${recipe.displayName}](./${recipeSimpleName}.md)")
+                        // If you touch this line double check that it works when imported into gitbo
+                        if (recipe.recipeList.isNotEmpty()) {
+                            appendLine("* (Composite) [${recipe.displayName}](./${recipeSimpleName}.md)")
+                        } else {
+                            appendLine("* [${recipe.displayName}](./${recipeSimpleName}.md)")
+                        }
                     }
                     appendLine()
                 }

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -647,36 +647,48 @@ class RecipeMarkdownGenerator : Runnable {
                 }
 
                 if (recipes.isNotEmpty()) {
-                    appendLine("## Composite Recipes")
-                    appendLine()
-                    appendLine("_Recipes that include further recipes, often including the individual recipes below._")
-                    appendLine()
+                    val compositeRecipes: MutableList<RecipeDescriptor> = mutableListOf()
+                    val normalRecipes: MutableList<RecipeDescriptor> = mutableListOf()
 
                     for (recipe in recipes) {
-                        val recipeSimpleName = recipe.name.substring(recipe.name.lastIndexOf('.') + 1).lowercase()
-
-                        // Anything except a relative link ending in .md will be mangled.
-                        // If you touch this line double check that it works when imported into gitbook
                         if (recipe.recipeList.isNotEmpty()) {
-                            appendLine("* [${recipe.displayName}](./${recipeSimpleName}.md)")
+                            compositeRecipes.add(recipe)
+                        } else {
+                            normalRecipes.add(recipe)
                         }
                     }
 
-                    appendLine()
-                    appendLine("## Recipes")
-                    appendLine()
+                    if (compositeRecipes.isNotEmpty()) {
+                        appendLine("## Composite Recipes")
+                        appendLine()
+                        appendLine("_Recipes that include further recipes, often including the individual recipes below._")
+                        appendLine()
 
-                    for (recipe in recipes) {
-                        val recipeSimpleName = recipe.name.substring(recipe.name.lastIndexOf('.') + 1).lowercase()
+                        for (recipe in compositeRecipes) {
+                            val recipeSimpleName = recipe.name.substring(recipe.name.lastIndexOf('.') + 1).lowercase()
 
-                        // Anything except a relative link ending in .md will be mangled.
-                        // If you touch this line double check that it works when imported into gitbook
-                        if (recipe.recipeList.isEmpty()) {
+                            // Anything except a relative link ending in .md will be mangled.
+                            // If you touch this line double check that it works when imported into gitbook
                             appendLine("* [${recipe.displayName}](./${recipeSimpleName}.md)")
                         }
+
+                        appendLine()
                     }
 
-                    appendLine()
+                    if (normalRecipes.isNotEmpty()) {
+                        appendLine("## Recipes")
+                        appendLine()
+
+                        for (recipe in normalRecipes) {
+                            val recipeSimpleName = recipe.name.substring(recipe.name.lastIndexOf('.') + 1).lowercase()
+
+                            // Anything except a relative link ending in .md will be mangled.
+                            // If you touch this line double check that it works when imported into gitbook
+                            appendLine("* [${recipe.displayName}](./${recipeSimpleName}.md)")
+                        }
+
+                        appendLine()
+                    }
                 }
 
             }.toString()


### PR DESCRIPTION
Fixes: https://github.com/openrewrite/rewrite-docs/issues/139

@sambsnyd @timtebeek Would people know what a `Composite` recipe means? Should I perhaps use a different word or address this in a different way?

Here's what the `JUnit` page looks like with this change:

# JUnit Jupiter

_Best practices for JUnit Jupiter tests._

## Composite Recipes

_Recipes that include further recipes, often including the individual recipes below._
* [Clean Up Assertions](./cleanupassertions.md)
* [JUnit Jupiter best practices](./junit5bestpractices.md)
* [JUnit Jupiter migration from JUnit 4.x](./junit4to5migration.md)
* [OkHttp 3.x `MockWebServer` `@Rule` To 4.x `MockWebServer`](./updatemockwebserver.md)
* [Statically import JUnit Jupiter assertions](./staticimports.md)
* [Use `Assertions#assume*(..)` and Hamcrest's `MatcherAssume#assume*(..)`](./migrateassumptions.md)
* [Use JUnit Jupiter `@Disabled`](./ignoretodisabled.md)
* [Use JUnit Jupiter `Executable`](./throwingrunnabletoexecutable.md)
* [Use `MatcherAssert#assertThat(..)`](./usehamcrestassertthat.md)
* [Use Mockito JUnit Jupiter extension](./usemockitoextension.md)
* [Use OkHttp 3 MockWebServer for JUnit 5](./upgradeokhttpmockwebserver.md)
* [Use Vert.x JUnit 5 Extension](./vertxunittovertxjunit5.md)
* [Use wiremock extension](./usewiremockextension.md)

## Recipes

* [Add missing @ParameterizedTest annotation when @ValueSource is used or replace @Test with @ParameterizedTest](./addparameterizedtestannotation.md)
* [Cleanup JUnit imports](./cleanupjunitimports.md)
* [JUnit 4 `@Category` to JUnit Jupiter `@Tag`](./categorytotag.md)
* [JUnit 4 `@RunWith` to JUnit Jupiter `@ExtendWith`](./runnertoextension.md)
* [JUnit 4 `@RunWith(Enclosed.class)` to JUnit Jupiter `@Nested`](./enclosedtonested.md)
* [JUnit 4 `@RunWith(Parameterized.class)` to JUnit Jupiter parameterized tests](./parameterizedrunnertoparameterized.md)
* [JUnit 4 `Assert` To JUnit Jupiter `Assertions`](./asserttoassertions.md)
* [JUnit 4 `ExpectedException` To JUnit Jupiter's `assertThrows()`](./expectedexceptiontoassertthrows.md)
* [JUnit 4 `MockitoJUnit` to JUnit Jupiter `MockitoExtension`](./mockitojunittomockitoextension.md)
* [JUnit 5 inner test classes should be annotated with `@Nested`](./addmissingnested.md)
* [JUnit TestName @Rule to JUnit Jupiter TestInfo](./testruletotestinfo.md)
* [Make `@TempDir` fields non final](./tempdirnonfinal.md)
* [Make lifecycle methods non private](./lifecyclenonprivate.md)
* [Migrate JUnit 4 `@Test` annotations to JUnit 5](./updatetestannotation.md)
* [Migrate JUnit 4 `TestCase` to JUnit Jupiter](./migratejunittestcase.md)
* [Migrate JUnit 4 lifecycle annotations to JUnit Jupiter](./updatebeforeafterannotations.md)
* [Migrate from JUnit 4 `@FixedMethodOrder` to JUnit 5 `@TestMethodOrder`](./usetestmethodorder.md)
* [Pragmatists @RunWith(JUnitParamsRunner.class) to JUnit Jupiter Parameterized Tests](./junitparamsrunnertoparameterized.md)
* [Remove JUnit 4 `@RunWith` annotations that do not require an `@ExtendsWith` replacement](./removeobsoleterunners.md)
* [Remove duplicates uses of @TestTemplate implementations for a single method](./removeduplicatetesttemplates.md)
* [Use JUnit Jupiter `@TempDir`](./temporaryfoldertotempdir.md)