### PR TITLE
Jackson BOM version 2.14.2 -> 2.15.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,8 +49,8 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("info.picocli:picocli:latest.release")
     implementation("org.openrewrite:rewrite-core:$rewriteVersion")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2")
     implementation("io.github.java-diff-utils:java-diff-utils:4.11")
     runtimeOnly("org.slf4j:slf4j-simple:1.7.30")
 


### PR DESCRIPTION
## What's changed?
jackson-bom.version 2.15.0 -> 2.15.2

## What's your motivation?
Vulnerability report.

## Any additional context
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.1 https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.2 https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.3 (withheld, as BOM missing)