### PR TITLE
Use false for boolean values; not null

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1030,7 +1030,7 @@ class RecipeMarkdownGenerator : Runnable {
                         "'" + option.example + "'"
                     } else if (option.type == "boolean") {
                         "false"
-                    }else {
+                    } else {
                         option.example
                     }
                     writeln("      ${option.name}: $ex")

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1028,7 +1028,9 @@ class RecipeMarkdownGenerator : Runnable {
                                 || option.example.matches(".*:\\s.*".toRegex()))
                     ) {
                         "'" + option.example + "'"
-                    } else {
+                    } else if (option.type == "boolean") {
+                        "false"
+                    }else {
                         option.example
                     }
                     writeln("      ${option.name}: $ex")


### PR DESCRIPTION
As seen on: https://docs.openrewrite.org/recipes/java/migrate/usetabsorspaces
![image](https://github.com/openrewrite/rewrite-recipe-markdown-generator/assets/1027334/ac77b027-4539-49b1-9e12-b9e31bab4f21)

That `null` is rather awkward; `false` is likely a better option for required configuration parameters.