### PR TITLE
Replace `<PATH>` with `.` to make it copy paste safe

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1226,7 +1226,7 @@ class RecipeMarkdownGenerator : Runnable {
 
                 {% code title="shell" %}
                 ```shell
-                mod run <PATH> --recipe $trimmedRecipeName
+                mod run . --recipe $trimmedRecipeName
                 ```
                 {% endcode %}
                 {% endtab %}


### PR DESCRIPTION
Now users need to replace that path whereas `.` would work both for individual projects, as well as a folder containing multiple repositories.

We could also add a hint or tip right above or below that the CLI can run against multiple projects. It's likely to be spotted in the docs for folks new to OpenRewrite, and yet another nudge to try it out.

We can even make the Mod CLI tab the first one, as that would work for both users of Maven and Gradle. 🤔 