### PR TITLE
Show recipe option example values in table

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,6 +161,7 @@ defaultTasks = mutableListOf("run")
 
 tasks.withType<MarkdownToHtmlTask> {
     dependsOn("run")
+    all = true
     sourceDir = file("build/docs")
     outputDir = file("build/html")
     doLast {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,9 +161,10 @@ defaultTasks = mutableListOf("run")
 
 tasks.withType<MarkdownToHtmlTask> {
     dependsOn("run")
-    all = true
     sourceDir = file("build/docs")
     outputDir = file("build/html")
+    fencedCodeBlocks = true
+    tables = true
     doLast {
         this as MarkdownToHtmlTask
         @Suppress("UNNECESSARY_NOT_NULL_ASSERTION") // IntelliJ says this is unnecessary, kotlin compiler disagrees

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1043,6 +1043,9 @@ class RecipeMarkdownGenerator : Runnable {
                 """.trimIndent()
                 )
                 for (option in recipeDescriptor.options) {
+                    if (!option.isRequired && option.example == null) {
+                        continue
+                    }
                     val ex = if (option.example != null && "String" == option.type
                         && (option.example.matches("^[{}\\[\\],`|=%@*!?-].*".toRegex())
                                 || option.example.matches(".*:\\s.*".toRegex()))

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -151,7 +151,7 @@ class RecipeMarkdownGenerator : Runnable {
             val recipeOptions = TreeSet<RecipeOption>()
             for (recipeOption in recipeDescriptor.options) {
                 val name = recipeOption.name as String
-                val ro = RecipeOption(name, recipeOption.type, recipeOption.isRequired)
+                val ro = RecipeOption(name, recipeOption.type, recipeOption.example, recipeOption.isRequired)
                 recipeOptions.add(ro)
             }
 
@@ -610,7 +610,7 @@ class RecipeMarkdownGenerator : Runnable {
             } else {
                 // Some nested recipes have a `github` path which gets converted into `Github` when it should be `GitHub`.
                 if (displayName == "Github") {
-                    displayName = "GitHub";
+                    displayName = "GitHub"
                 }
 
                 result.appendLine("$indent* [$displayName](reference/recipes/$path/README.md)")
@@ -816,8 +816,8 @@ class RecipeMarkdownGenerator : Runnable {
                         """
                     ## Options
                     
-                    | Type | Name | Description |
-                    | -- | -- | -- |
+                    | Type | Name | Description | Example |
+                    | -- | -- | -- | -- |
                 """.trimIndent()
                 )
                 for (option in recipeDescriptor.options) {
@@ -837,7 +837,7 @@ class RecipeMarkdownGenerator : Runnable {
                     }
                     writeln(
                             """
-                        | `${option.type}` | ${option.name} | $description |
+                        | `${option.type}` | ${option.name} | $description | `${option.example}` |
                     """.trimIndent()
                     )
                 }

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -643,7 +643,7 @@ class RecipeMarkdownGenerator : Runnable {
                 @Suppress("SENSELESS_COMPARISON")
                 if (descriptor != null && descriptor.description != null) {
                     appendLine()
-                    if (descriptor.description.contains("\n") || descriptor.description.contains("_")){
+                    if (descriptor.description.contains("\n") || descriptor.description.contains("_")) {
                         appendLine(descriptor.description)
                     } else {
                         appendLine("_${descriptor.description}_")
@@ -813,7 +813,7 @@ class RecipeMarkdownGenerator : Runnable {
             // Options
             if (recipeDescriptor.options.isNotEmpty()) {
                 writeln(
-                        """
+                    """
                     ## Options
                     
                     | Type | Name | Description | Example |
@@ -843,8 +843,8 @@ class RecipeMarkdownGenerator : Runnable {
                         }
                     }
                     writeln(
-                            """
-                        | `${option.type}` | ${option.name} | $description | `${option.example}` |
+                        """
+                        | `${option.type}` | ${option.name} | $description | `${option.example ?: ""}` |
                     """.trimIndent()
                     )
                 }
@@ -874,19 +874,23 @@ class RecipeMarkdownGenerator : Runnable {
             }
 
             for (dataTable in filteredDataTables) {
-                writeln("""
+                writeln(
+                    """
                     ### ${dataTable.displayName}
 
                     _${dataTable.description}_
 
                     | Column Name | Description |
                     | ----------- | ----------- |
-                """.trimIndent())
+                """.trimIndent()
+                )
 
                 for (column in dataTable.columns) {
-                    writeln("""
+                    writeln(
+                        """
                        | ${column.displayName} | ${column.description} |
-                    """.trimIndent())
+                    """.trimIndent()
+                    )
                 }
 
                 newLine()
@@ -1001,7 +1005,7 @@ class RecipeMarkdownGenerator : Runnable {
 
                                 writeln("{% code %}")
                                 writeln(
-                                        """
+                                    """
                                 |```diff
                                 |${diff}```
                                 """.trimMargin()
@@ -1178,14 +1182,15 @@ class RecipeMarkdownGenerator : Runnable {
             if (recipeDescriptor.contributors.isNotEmpty()) {
                 newLine()
                 writeln("## Contributors")
-                writeln(recipeDescriptor.contributors.stream()
-                    .map { contributor: Contributor ->
-                        if (contributor.email.contains("noreply")) {
-                            contributor.name
-                        } else {
-                            "[" + contributor.name + "](mailto:" + contributor.email + ")"
-                        }
-                    }.collect(Collectors.joining(", "))
+                writeln(
+                    recipeDescriptor.contributors.stream()
+                        .map { contributor: Contributor ->
+                            if (contributor.email.contains("noreply")) {
+                                contributor.name
+                            } else {
+                                "[" + contributor.name + "](mailto:" + contributor.email + ")"
+                            }
+                        }.collect(Collectors.joining(", "))
                 )
             }
         }
@@ -1207,8 +1212,8 @@ class RecipeMarkdownGenerator : Runnable {
             val revisedLines = revised.lines()
 
             diffContent.append("@@ -${delta.source.position + 1},${delta.source.size()} ")
-                    .append("+${delta.target.position + 1},${delta.target.size()} @@")
-                    .append("\n")
+                .append("+${delta.target.position + 1},${delta.target.size()} @@")
+                .append("\n")
 
             // print shared context
             val startIndex = maxOf(0, delta.source.position - contextLinesBefore)
@@ -1218,12 +1223,14 @@ class RecipeMarkdownGenerator : Runnable {
             }
 
             for (i in delta.source.position until delta.source.position + delta.source.size()) {
-                val trimmedLine = if (originalLines[i].startsWith(" ")) originalLines[i].replaceFirst(" ", "") else originalLines[i]
+                val trimmedLine =
+                    if (originalLines[i].startsWith(" ")) originalLines[i].replaceFirst(" ", "") else originalLines[i]
                 diffContent.append("-").append(trimmedLine).append("\n")
             }
 
             for (i in delta.target.position until delta.target.position + delta.target.size()) {
-                val trimmedLine = if (revisedLines[i].startsWith(" ")) revisedLines[i].replaceFirst(" ", "") else revisedLines[i]
+                val trimmedLine =
+                    if (revisedLines[i].startsWith(" ")) revisedLines[i].replaceFirst(" ", "") else revisedLines[i]
                 diffContent.append("+").append(trimmedLine).append("\n")
             }
 

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -836,11 +836,8 @@ class RecipeMarkdownGenerator : Runnable {
                         "[${match.value}](/reference/method-patterns.md)"
                     }
                     // Add valid options to description
-                    if (option.valid != null && option.valid.isNotEmpty()) {
-                        description += "\n\nValid options:\n"
-                        option.valid.forEach { validOption ->
-                            description += "* `$validOption`\n"
-                        }
+                    if (option.valid?.isNotEmpty()?: false) {
+                        description += " Valid options: " + option.valid?.joinToString { "`$it`" }
                     }
                     writeln(
                         """

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -835,6 +835,13 @@ class RecipeMarkdownGenerator : Runnable {
                     description = description.replace("method patterns?".toRegex(RegexOption.IGNORE_CASE)) { match ->
                         "[${match.value}](/reference/method-patterns.md)"
                     }
+                    // Add valid options to description
+                    if (option.valid != null && option.valid.isNotEmpty()) {
+                        description += "\n\nValid options:\n"
+                        option.valid.forEach { validOption ->
+                            description += "* `$validOption`\n"
+                        }
+                    }
                     writeln(
                             """
                         | `${option.type}` | ${option.name} | $description | `${option.example}` |

--- a/src/main/kotlin/org/openrewrite/RecipeOption.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeOption.kt
@@ -1,8 +1,11 @@
 package org.openrewrite
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+
 data class RecipeOption(
     val name: String,
     val type: String,
+    @JsonIgnore
     val example: String?,
     val required: Boolean
 ): Comparable<RecipeOption> {

--- a/src/main/kotlin/org/openrewrite/RecipeOption.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeOption.kt
@@ -3,14 +3,14 @@ package org.openrewrite
 data class RecipeOption(
     val name: String,
     val type: String,
+    val example: String?,
     val required: Boolean
 ): Comparable<RecipeOption> {
     override fun compareTo(other: RecipeOption): Int {
-        if (this.name != other.name) return this.name.compareTo(other.name)
-        if (this.type != other.type) return this.type.compareTo(other.type)
-        if (this.required && !other.required) return 1
-        if (!this.required && other.required) return -1
-
-        return 0
+        return compareBy(RecipeOption::name)
+            .then(compareBy(RecipeOption::type))
+            .then(compareBy(RecipeOption::example))
+            .then(compareBy(RecipeOption::required))
+            .compare(this, other)
     }
 }


### PR DESCRIPTION
## What's changed?
Add a fourth options column with example values, as indicated on the option annotations.

## What's your motivation?
Helps users see what type of input is expected.

## Have you considered any alternatives or workarounds?
We could add the same value to the description instead of a fourth column, as it might be missing frequently.

## Any additional context
Reported through OSS Slack: 
https://rewriteoss.slack.com/archives/C01A843MWG5/p1702462745389259