### PR TITLE
Correctly link refaster recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,9 @@ dependencies {
     implementation("io.github.java-diff-utils:java-diff-utils:4.11")
     runtimeOnly("org.slf4j:slf4j-simple:1.7.30")
 
+    testImplementation("org.junit.jupiter:junit-jupiter-api:latest.release")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:latest.release")
+
     "recipe"(platform("org.openrewrite:rewrite-bom:$rewriteVersion"))
     "recipe"("org.openrewrite:rewrite-core")
     "recipe"("org.openrewrite:rewrite-groovy")
@@ -109,6 +112,10 @@ java {
 tasks.named<JavaCompile>("compileJava") {
     sourceCompatibility = JavaVersion.VERSION_17.toString()
     targetCompatibility = JavaVersion.VERSION_17.toString()
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }
 
 application {

--- a/src/main/kotlin/org/openrewrite/RecipeOrigin.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeOrigin.kt
@@ -18,7 +18,7 @@ class RecipeOrigin(
     fun isFromCoreLibrary() = groupId == "org.openrewrite" && coreLibs.contains(artifactId)
 
     private fun convertNameToJavaPath(recipeName: String): String =
-        recipeName.replace('.', '/').removeSuffix("Recipe") + ".java"
+        recipeName.replace('.', '/').replace(Regex("Recipes\\$?.*"), "") + ".java"
 
     fun githubUrl(recipeName: String, source: URI): String {
         val sourceString = source.toString()

--- a/src/test/kotlin/org/openrewrite/RecipeOriginTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeOriginTest.kt
@@ -1,0 +1,21 @@
+package org.openrewrite
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.net.URI
+
+class RecipeOriginTest {
+    @Test
+    fun githubUrl() {
+        val githubUrl = RecipeOrigin(
+            "org.openrewrite.recipe", "rewrite-migrate-java", "2.4.2", URI.create("file:///tmp/foo")
+        ).githubUrl(
+            "org.openrewrite.java.migrate.apache.commons.lang.ApacheCommonsStringUtilsRecipes\$AbbreviateRecipe",
+            URI("https://github.com")
+        )
+        assertEquals(
+            "https://github.com/openrewrite/rewrite-migrate-java/blob/main/src/main/java/org/openrewrite/java/migrate/apache/commons/lang/ApacheCommonsStringUtils.java",
+            githubUrl
+        )
+    }
+}


### PR DESCRIPTION
## What's changed?
Use regex to remove `Recipes$Foo` when linking to GitHub.
Add a first minimal test to allow components to be tested.

## What's your motivation?
Fix broken links.
Make it easier to evolve and resolve.