### PR TITLE
Don't produce newlines in tables

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -809,7 +809,6 @@ class RecipeMarkdownGenerator : Runnable {
                 )
             }
 
-
             // Options
             if (recipeDescriptor.options.isNotEmpty()) {
                 writeln(
@@ -843,7 +842,7 @@ class RecipeMarkdownGenerator : Runnable {
                     writeln(
                         """
                         | `${option.type}` | ${option.name} | $description | $example |
-                    """.trimIndent()
+                    """.trimIndent().replace("\n", "<br/>")
                     )
                 }
                 newLine()


### PR DESCRIPTION
Ought to fix the shift seen on
 - https://openrewrite.github.io/rewrite-recipe-markdown-generator/reference/recipes/properties/createpropertiesfile.html
 - https://docs.openrewrite.org/recipes/properties/createpropertiesfile