### PR TITLE
Remove bellwether from generated yaml

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeDescriptorExtensions.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeDescriptorExtensions.kt
@@ -26,6 +26,11 @@ fun RecipeDescriptor.asYaml(): String {
     if (recipeList.isNotEmpty()) {
         s.appendLine("recipeList:")
         for (subRecipe in recipeList) {
+            // https://github.com/openrewrite/rewrite-docs/issues/250
+            if (subRecipe.name.contains("Bellwether")) {
+                continue;
+            }
+
             s.append("  - ${subRecipe.name}")
             if (subRecipe.options.isEmpty()) {
                 s.appendLine()


### PR DESCRIPTION
Related to issue: https://github.com/openrewrite/rewrite-docs/issues/250

You can see there is no bellwether in the yaml recipe list generated:

![image](https://github.com/openrewrite/rewrite-recipe-markdown-generator/assets/1187834/bc2a611a-c79f-4763-9688-45f080823c7c)
