### PR TITLE
Fix formatting for multiline examples

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -840,7 +840,16 @@ class RecipeMarkdownGenerator : Runnable {
                     if (option.valid?.isNotEmpty()?: false) {
                         description += " Valid options: " + option.valid?.joinToString { "`$it`" }
                     }
-                    val example = if (option.example != null) "`${option.example}`" else ""
+                    // Preserve table cell formatting for multiline examples
+                    val example = if (option.example != null) {
+                        if (option.example.contains("\n")) {
+                            "<pre>${option.example.replace("<", "\\<")}</pre>".replace("\n", "<br />")
+                        } else {
+                            "`${option.example}`"
+                        }
+                    } else {
+                        ""
+                    }
                     writeln(
                         """
                         | `${option.type}` | ${option.name} | $description | $example |


### PR DESCRIPTION
## What's changed?
Using `<pre>` for multiline examples + escaping tags inside the example value (e.g. for XML examples).

With the proposed changes it looks like this ([createxmlfile.md](https://github.com/openrewrite/rewrite-docs/blob/master/reference/recipes/xml/createxmlfile.md)):
![image](https://github.com/openrewrite/rewrite-recipe-markdown-generator/assets/39240633/22239740-89cf-4cf8-82d0-9042621936eb)
_Note: There is a `\n` missing in [CreateXmlFile.java](https://github.com/openrewrite/rewrite/blob/e32535eeccc97f2ac33af74257accbe13888334c/rewrite-xml/src/main/java/org/openrewrite/xml/CreateXmlFile.java#L49-L50)_

## What's your motivation?
For option examples that are multiline the table cell formatting is broken, see [mergeyaml.md](https://github.com/openrewrite/rewrite-docs/blob/master/reference/recipes/yaml/mergeyaml.md), [createxmlfile.md](https://github.com/openrewrite/rewrite-docs/blob/master/reference/recipes/xml/createxmlfile.md), [createyamlfile.md](https://github.com/openrewrite/rewrite-docs/blob/master/reference/recipes/yaml/createyamlfile.md)
E.g. [createxmlfile.md](https://github.com/openrewrite/rewrite-docs/blob/master/reference/recipes/xml/createxmlfile.md):
![image](https://github.com/openrewrite/rewrite-recipe-markdown-generator/assets/39240633/43c2262e-4be5-4d2f-859a-7518a995a524)

This is due to the replacement of `\n` with an actual line break, which does not render properly when using "`" inside a table:
```md

| Type | Name | Description | Example |
| -- | -- | -- | -- |
| `String` | relativeFileName | File path of new file. | `foo/bar/baz.xml` |
                        | `String` | fileContents | *Optional*. Multiline text content for the file. | `<?xml version="1.0" encoding="UTF-8"?>
<root>
    <child>1</child></root>` |
| `Boolean` | overwriteExisting | *Optional*. If there is an existing file, should it be overwritten. |  |
```

## Anything in particular you'd like reviewers to focus on?
-

## Anyone you would like to review specifically?
-

## Have you considered any alternatives or workarounds?
No

## Any additional context
-

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
