### PR TITLE
Show --init-script command in shell block

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1632,9 +1632,11 @@ $cliSnippet
                             ```
                             {% endcode %}
                             2. Run the recipe.
+                            {% code title="shell" overflow="wrap"%}
                             ```shell
                             gradle --init-script init.gradle rewriteRun
                             ```
+                            {% endcode %}
                             {% endtab %}
                             """.trimIndent()
 
@@ -1760,9 +1762,11 @@ $cliSnippet
                             ```
                             {% endcode %}
                             2. Run the recipe.
+                            {% code title="shell" overflow="wrap"%}
                             ```shell
                             gradle --init-script init.gradle rewriteRun
                             ```
+                            {% endcode %}
                             {% endtab %}
                             """.trimIndent()
 

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1631,7 +1631,10 @@ $cliSnippet
                             }
                             ```
                             {% endcode %}
-                            2. Run `gradle --init-script init.gradle rewriteRun` to run the recipe.
+                            2. Run the recipe.
+                            ```shell
+                            gradle --init-script init.gradle rewriteRun
+                            ```
                             {% endtab %}
                             """.trimIndent()
 
@@ -1756,7 +1759,10 @@ $cliSnippet
                             }
                             ```
                             {% endcode %}
-                            2. Run `gradle --init-script init.gradle rewriteRun` to run the recipe.
+                            2. Run the recipe.
+                            ```shell
+                            gradle --init-script init.gradle rewriteRun
+                            ```
                             {% endtab %}
                             """.trimIndent()
 


### PR DESCRIPTION
Such that a copy-paste button is rendered for easier access.

Right now we see
![image](https://github.com/user-attachments/assets/d74c5aed-652d-47b8-9e40-b6a7f7dbddb1)

After this change I hope the command is also rendered in a block with a copy paste button top right.