### PR TITLE
Adopt `setExportDatatables(true)` for Gradle to support .kts too

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1533,7 +1533,7 @@ import TabItem from '@theme/TabItem';
                             
                             rewrite {
                                 activeRecipe("$exampleRecipeName")
-                                exportDatatables(true)
+                                setExportDatatables(true)
                             }
                             
                             repositories {
@@ -1606,7 +1606,7 @@ $cliSnippet
                             
                             rewrite {
                                 activeRecipe("$exampleRecipeName")
-                                exportDatatables(true)
+                                setExportDatatables(true)
                             }
                             
                             repositories {
@@ -1695,7 +1695,7 @@ $cliSnippet
                             
                             rewrite {
                                 activeRecipe("${recipeDescriptor.name}")
-                                exportDatatables(true)
+                                setExportDatatables(true)
                             }
                             
                             repositories {
@@ -1724,7 +1724,7 @@ $cliSnippet
                                 }
                                 rewrite {
                                     activeRecipe("${recipeDescriptor.name}")
-                                    exportDatatables(true)
+                                    setExportDatatables(true)
                                 }
                                 afterEvaluate {
                                     if (repositories.isEmpty()) {
@@ -1822,7 +1822,7 @@ $cliSnippet
                             
                             rewrite {
                                 activeRecipe("${recipeDescriptor.name}")
-                                exportDatatables(true)
+                                setExportDatatables(true)
                             }
                             
                             repositories {
@@ -1855,7 +1855,7 @@ $cliSnippet
                                 }
                                 rewrite {
                                     activeRecipe("${recipeDescriptor.name}")
-                                    exportDatatables(true)
+                                    setExportDatatables(true)
                                 }
                                 afterEvaluate {
                                     if (repositories.isEmpty()) {

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1533,7 +1533,7 @@ import TabItem from '@theme/TabItem';
                             
                             rewrite {
                                 activeRecipe("$exampleRecipeName")
-                                exportDatatables = true
+                                exportDatatables(true)
                             }
                             
                             repositories {
@@ -1606,7 +1606,7 @@ $cliSnippet
                             
                             rewrite {
                                 activeRecipe("$exampleRecipeName")
-                                exportDatatables = true
+                                exportDatatables(true)
                             }
                             
                             repositories {
@@ -1695,7 +1695,7 @@ $cliSnippet
                             
                             rewrite {
                                 activeRecipe("${recipeDescriptor.name}")
-                                exportDatatables = true
+                                exportDatatables(true)
                             }
                             
                             repositories {
@@ -1724,7 +1724,7 @@ $cliSnippet
                                 }
                                 rewrite {
                                     activeRecipe("${recipeDescriptor.name}")
-                                    exportDatatables = true
+                                    exportDatatables(true)
                                 }
                                 afterEvaluate {
                                     if (repositories.isEmpty()) {
@@ -1822,7 +1822,7 @@ $cliSnippet
                             
                             rewrite {
                                 activeRecipe("${recipeDescriptor.name}")
-                                exportDatatables = true
+                                exportDatatables(true)
                             }
                             
                             repositories {
@@ -1855,7 +1855,7 @@ $cliSnippet
                                 }
                                 rewrite {
                                     activeRecipe("${recipeDescriptor.name}")
-                                    exportDatatables = true
+                                    exportDatatables(true)
                                 }
                                 afterEvaluate {
                                     if (repositories.isEmpty()) {


### PR DESCRIPTION
- Fixes https://github.com/openrewrite/rewrite-spring/issues/618

I think this ought to work for both; even if pending this issue we don't yet change the build.gradle.kts files:
- https://github.com/openrewrite/rewrite/issues/3291