### PR TITLE
Include license in latest version table

### DIFF
--- a/src/main/kotlin/org/openrewrite/Licenses.kt
+++ b/src/main/kotlin/org/openrewrite/Licenses.kt
@@ -5,16 +5,17 @@ enum class License {
     MSAL,
     Proprietary;
 
-    fun label() = when(this) {
+    private fun label() = when(this) {
         Apache2 -> "Apache License Version 2.0"
         MSAL -> "Moderne Source Available"
         Proprietary -> "Moderne Proprietary"
     }
-    fun url() = when(this) {
+    private fun url() = when(this) {
         Apache2 -> "https://www.apache.org/licenses/LICENSE-2.0"
         MSAL -> "https://docs.moderne.io/licensing/moderne-source-available-license"
         Proprietary -> "https://docs.moderne.io/licensing/overview"
     }
+    fun markdown() = "[${label()}](${url()})"
 }
 
 fun getLicense(recipeOrigin: RecipeOrigin): License {

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -399,9 +399,9 @@ class RecipeMarkdownGenerator : Runnable {
 
                 | Module                                                                                                                | Version    | License |
                 |-----------------------------------------------------------------------------------------------------------------------| ---------- | ------- |
-                | [**org.openrewrite.recipe:rewrite-recipe-bom**](https://github.com/openrewrite/rewrite-recipe-bom)                    | **${bomLink}** | Apache License Version 2.0 |
-                | [**org.openrewrite:rewrite-maven-plugin**](https://github.com/openrewrite/rewrite-maven-plugin)                       | **${mavenLink}** | Moderne Source Available   |
-                | [**org.openrewrite:rewrite-gradle-plugin**](https://github.com/openrewrite/rewrite-gradle-plugin)                     | **${gradleLink}** | Moderne Source Available   |
+                | [**org.openrewrite.recipe:rewrite-recipe-bom**](https://github.com/openrewrite/rewrite-recipe-bom)                    | **${bomLink}** | ${License.Apache2.markdown()} |
+                | [**org.openrewrite:rewrite-maven-plugin**](https://github.com/openrewrite/rewrite-maven-plugin)                       | **${mavenLink}** | ${License.MSAL.markdown()} |
+                | [**org.openrewrite:rewrite-gradle-plugin**](https://github.com/openrewrite/rewrite-gradle-plugin)                     | **${gradleLink}** |${License.MSAL.markdown()} |
                 """.trimIndent()
             )
             var cliInstallGavs = ""
@@ -410,9 +410,7 @@ class RecipeMarkdownGenerator : Runnable {
                 cliInstallGavs += "${origin.groupId}:${origin.artifactId}:${versionPlaceholder} "
                 val repoLink = "[${origin.groupId}:${origin.artifactId}](${origin.githubUrl()})"
                 val releaseLink = "[${origin.version}](${origin.githubUrl()}/releases/tag/v${origin.version})"
-                val license = getLicense(origin)
-                val licenseLink = "[${license.label()}](${license.url()})"
-                writeln("| ${repoLink.padEnd(117)} | ${releaseLink.padEnd(90)} | ${licenseLink} |")
+                writeln("| ${repoLink.padEnd(117)} | ${releaseLink.padEnd(90)} | ${getLicense(origin).markdown()} |")
             }
             //language=markdown
             writeln(


### PR DESCRIPTION
Includes the License in the table showing the latest versions, as a replacement for the now separately and manually maintained:
https://docs.openrewrite.org/licensing/repository-licensing

I think we can likely drop that other page to have one quick source of truth that's updated as we add new modules.