### PR TITLE
fix license URI and description to meet textual requirements better

### DIFF
--- a/src/main/kotlin/org/openrewrite/Licenses.kt
+++ b/src/main/kotlin/org/openrewrite/Licenses.kt
@@ -14,12 +14,12 @@ data class License (val uri: URI, val name: String) {
 
 data object Licenses {
     private val Apache_URI = "https://www.apache.org/licenses/LICENSE-2.0"
-    private val MSAL_URI = "https://docs.moderne.io/licensing/moderne-source-available-license/"
-    private val Proprietary_URI = "https://docs.moderne.io/licensing/overview/"
+    private val MSAL_URI = "https://docs.moderne.io/licensing/moderne-source-available-license"
+    private val Proprietary_URI = "https://docs.moderne.io/licensing/overview"
 
     val Apache2 = License(URI(Apache_URI), "Apache License Version 2.0")
-    val Proprietary = License(URI(Proprietary_URI), "Moderne Proprietary")
-    val MSAL = License(URI(MSAL_URI), "Moderne Source Available")
+    val Proprietary = License(URI(Proprietary_URI), "Moderne Proprietary License")
+    val MSAL = License(URI(MSAL_URI), "Moderne Source Available License")
     val Unknown = License(URI(""), "License Unknown")
 
     fun get(url: String?, name: String?): License = when {

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1311,8 +1311,7 @@ import TabItem from '@theme/TabItem';
     private fun BufferedWriter.writeLicense(origin: RecipeOrigin) {
         val licenseText = when (origin.license) {
             Licenses.Unknown -> "The license for this recipe is unknown."
-            Licenses.Apache2 -> "This recipe is available under the ${origin.license.markdown()}."
-            Licenses.Proprietary, Licenses.MSAL -> "This recipe is available under the ${origin.license.markdown()} License."
+            Licenses.Apache2, Licenses.Proprietary, Licenses.MSAL -> "This recipe is available under the ${origin.license.markdown()}."
             else -> "This recipe is available under the ${origin.license.markdown()} License, as defined by the recipe authors."
         }
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
There were '/' to much in the URIs to match the licenses at read. Know we use the correct one and therefore the textual representation is aligned.

## What's your motivation?
Align docs with definitions

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
