### PR TITLE
Change hardcoded version of Gradle's rewrite plugin to "latest.release"

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -1849,7 +1849,7 @@ import TabItem from '@theme/TabItem';
             1. Add the following to your `build.gradle` file:
             ```groovy title="build.gradle"
             plugins {
-                id("org.openrewrite.rewrite") version("{{VERSION_REWRITE_GRADLE_PLUGIN}}")
+                id("org.openrewrite.rewrite") version("latest.release")
             }
             
             rewrite {
@@ -1932,7 +1932,7 @@ $cliSnippet
 
             ```groovy title="build.gradle"
             plugins {
-                id("org.openrewrite.rewrite") version("{{VERSION_REWRITE_GRADLE_PLUGIN}}")
+                id("org.openrewrite.rewrite") version("latest.release")
             }
             
             rewrite {
@@ -2031,7 +2031,7 @@ $cliSnippet
 
             ```groovy title="build.gradle"
             plugins {
-                id("org.openrewrite.rewrite") version("{{VERSION_REWRITE_GRADLE_PLUGIN}}")
+                id("org.openrewrite.rewrite") version("latest.release")
             }
             
             rewrite {
@@ -2162,7 +2162,7 @@ $cliSnippet
 
             ```groovy title="build.gradle"
             plugins {
-                id("org.openrewrite.rewrite") version("{{VERSION_REWRITE_GRADLE_PLUGIN}}")
+                id("org.openrewrite.rewrite") version("latest.release")
             }
             
             rewrite {


### PR DESCRIPTION
## What's changed?
The documentation shows

```groovy
plugins {
    id("org.openrewrite.rewrite") version("latest.release")
}
```
 
instead of

```groovy
plugins {
    id("org.openrewrite.rewrite") version("7.8.0")
}
```

