### PR TITLE
Use formattedDisplayName in RecipesWithDataTables section as in other sections

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -2368,7 +2368,10 @@ $cliSnippet
             for (recipe in recipesWithDataTables) {
                 val recipePath = recipePath(recipe.name)
 
-                writeln("### [${recipe.displayName}](../${recipePath}.md)\n ")
+                val formattedDisplayName = recipe.displayName
+                        .replace(Regex("\\[([^]]+)]\\([^)]+\\)"), "$1") // Removes URLs from the displayName
+
+                writeln("### [${formattedDisplayName}](../${recipePath}.md)\n ")
                 writeln("_${recipe.name}_\n")
                 writeln("${recipe.description}\n")
                 writeln("#### Data tables:\n")


### PR DESCRIPTION
Copied code from elsewhere in this file for use in the RecipesWithDataTables section to remove URLs from recipe name so it can be displayed correctly in the markdown