### PR TITLE
Add CLI version to the OR changelogs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2")
     implementation("io.github.java-diff-utils:java-diff-utils:4.11")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     runtimeOnly("org.slf4j:slf4j-simple:1.7.30")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.+")

--- a/src/main/kotlin/org/openrewrite/CliVersion.kt
+++ b/src/main/kotlin/org/openrewrite/CliVersion.kt
@@ -1,0 +1,40 @@
+package org.openrewrite
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+fun getLatestStableVersion(): String? {
+    val releases = getCliVersion("https://api.github.com/repos/moderneinc/moderne-cli-releases/releases/latest")
+    return releases?.get("tag_name")?.asText()
+}
+
+fun getLatestStagingVersion(): String? {
+    val releases = getCliVersion("https://api.github.com/repos/moderneinc/moderne-cli-releases/releases")
+    if (releases != null && releases.isArray && releases.size() > 0) {
+        return releases[0].get("tag_name")?.asText()
+    }
+    return null
+}
+
+private fun getCliVersion(url: String): JsonNode? {
+    return try {
+        OkHttpClient()
+            .newCall(Request.Builder().url(url).build())
+            .execute()
+            .use { response ->
+                if (response.isSuccessful) {
+                    val responseBody = response.body?.string() ?: return null
+                    val mapper = ObjectMapper()
+                    mapper.readTree(responseBody)
+                } else {
+                    System.err.println("Failed to get latest version from GitHub: ${response.code}")
+                    null
+                }
+            }
+    } catch (e: Exception) {
+        System.err.println("Failed to get latest version from GitHub: ${e.message}")
+        null
+    }
+}


### PR DESCRIPTION
The code for obtaining the CLI version is largely a duplicate of the SaaS code - just converted from Java to Kotlin - with a different HTTP library.