### PR TITLE
Refactor Spring Boot upgrade recipe path generation to be future-proof

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -217,6 +217,8 @@ class RecipeMarkdownGenerator : Runnable {
 
 
     companion object {
+        private val SPRING_BOOT_UPGRADE_PATTERN = Regex("^(io\\.moderne|org\\.openrewrite)\\.java\\.spring\\.boot(\\d+)\\.UpgradeSpringBoot_(\\d+)_(\\d+)$")
+
         /**
          * Call Closable.use() together with apply() to avoid adding two levels of indentation
          */
@@ -233,11 +235,9 @@ class RecipeMarkdownGenerator : Runnable {
             // docs so that they parse correctly.
             if (recipePathToDocusaurusRenamedPath.containsKey(recipe.name)) {
                 recipePathToDocusaurusRenamedPath[recipe.name]!!
-            } else if (recipe.name == "io.moderne.java.spring.boot3.UpgradeSpringBoot_3_4") {
+            } else if (recipe.name.matches(SPRING_BOOT_UPGRADE_PATTERN)) {
                 // The spring boot recipes clashes with one another so let's make them distinct
-                "java/spring/boot3/upgradespringboot_3_4-moderne-edition"
-            } else if (recipe.name == "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_4") {
-                "java/spring/boot3/upgradespringboot_3_4-community-edition"
+                generateSpringBootUpgradePath(recipe.name)
             } else if (recipe.name.startsWith("org.openrewrite")) {
                 // If the recipe path only has two periods, it's part of the core recipes and should be adjusted accordingly.
                 if (recipe.name.count { it == '.' } == 2) {
@@ -269,6 +269,18 @@ class RecipeMarkdownGenerator : Runnable {
             "org.openrewrite.java.migrate.javaee7" to "java/migrate/javaee7-recipe",
             "org.openrewrite.java.migrate.javaee8" to "java/migrate/javaee8-recipe"
         )
+
+        private fun generateSpringBootUpgradePath(recipeName: String): String {
+            val matchResult = SPRING_BOOT_UPGRADE_PATTERN.find(recipeName)
+
+            return if (matchResult != null) {
+                val (organization, majorVersion, upgradeMajor, upgradeMinor) = matchResult.destructured
+                val edition = if (organization == "io.moderne") "moderne-edition" else "community-edition"
+                "java/spring/boot$majorVersion/upgradespringboot_${upgradeMajor}_$upgradeMinor-$edition"
+            } else {
+                throw RuntimeException("Invalid Spring Boot upgrade recipe format: $recipeName")
+            }
+        }
 
         @JvmStatic
         fun main(args: Array<String>) {

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -235,8 +235,8 @@ class RecipeMarkdownGenerator : Runnable {
             // docs so that they parse correctly.
             if (recipePathToDocusaurusRenamedPath.containsKey(recipe.name)) {
                 recipePathToDocusaurusRenamedPath[recipe.name]!!
-            } else if (recipe.name.matches(SPRING_BOOT_UPGRADE_PATTERN)) {
-                // The spring boot recipes clashes with one another so let's make them distinct
+            } else if (isSpringBoot34OrHigher(recipe.name)) {
+                // The moderne and community spring boot recipes clashes with one another (deviating since 3.4) so let's make them distinct
                 generateSpringBootUpgradePath(recipe.name)
             } else if (recipe.name.startsWith("org.openrewrite")) {
                 // If the recipe path only has two periods, it's part of the core recipes and should be adjusted accordingly.
@@ -269,6 +269,14 @@ class RecipeMarkdownGenerator : Runnable {
             "org.openrewrite.java.migrate.javaee7" to "java/migrate/javaee7-recipe",
             "org.openrewrite.java.migrate.javaee8" to "java/migrate/javaee8-recipe"
         )
+
+        private fun isSpringBoot34OrHigher(recipeName: String): Boolean {
+            val matchResult = SPRING_BOOT_UPGRADE_PATTERN.find(recipeName) ?: return false
+            val (_, _, upgradeMajor, upgradeMinor) = matchResult.destructured
+            val upgradeMajorInt = upgradeMajor.toInt()
+            val upgradeMinorInt = upgradeMinor.toInt()
+            return upgradeMajorInt > 3 || (upgradeMajorInt == 3 && upgradeMinorInt >= 4)
+        }
 
         private fun generateSpringBootUpgradePath(recipeName: String): String {
             val matchResult = SPRING_BOOT_UPGRADE_PATTERN.find(recipeName)

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -36,4 +36,52 @@ class RecipeMarkdownGeneratorTest {
         val contents = Files.readString(latestVersionsMd)
         assertTrue(contents.contains("2.x"), contents)
     }
+
+    @Test
+    fun testGetRecipePathForSpringBootUpgrades() {
+        // Test existing Spring Boot 3.4 versions (both Moderne and OpenRewrite)
+        val moderneRecipe34 = getRecipePath("io.moderne.java.spring.boot3.UpgradeSpringBoot_3_4")
+        val communityRecipe34 = getRecipePath("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_4")
+
+        assertEquals("java/spring/boot3/upgradespringboot_3_4-moderne-edition", moderneRecipe34)
+        assertEquals("java/spring/boot3/upgradespringboot_3_4-community-edition", communityRecipe34)
+
+        // Test future Spring Boot 4.x versions
+        val springBoot4Moderne = getRecipePath("io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0")
+        val springBoot4Community = getRecipePath("org.openrewrite.java.spring.boot4.UpgradeSpringBoot_4_2")
+
+        assertEquals("java/spring/boot4/upgradespringboot_4_0-moderne-edition", springBoot4Moderne)
+        assertEquals("java/spring/boot4/upgradespringboot_4_2-community-edition", springBoot4Community)
+
+        // Test future Spring Boot 3.x minor versions
+        val springBoot35Moderne = getRecipePath("io.moderne.java.spring.boot3.UpgradeSpringBoot_3_5")
+        val springBoot36Community = getRecipePath("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_6")
+
+        assertEquals("java/spring/boot3/upgradespringboot_3_5-moderne-edition", springBoot35Moderne)
+        assertEquals("java/spring/boot3/upgradespringboot_3_6-community-edition", springBoot36Community)
+
+        // Test future Spring Boot 5.x versions
+        val springBoot5Community = getRecipePath("org.openrewrite.java.spring.boot5.UpgradeSpringBoot_5_1")
+        assertEquals("java/spring/boot5/upgradespringboot_5_1-community-edition", springBoot5Community)
+    }
+
+    private fun getRecipePath(recipeName: String): String {
+        return RecipeMarkdownGenerator.getRecipePath(
+            org.openrewrite.config.RecipeDescriptor(
+                recipeName,
+                recipeName,
+                "",
+                "Test recipe",
+                mutableSetOf(),
+                java.time.Duration.ZERO,
+                mutableListOf(),
+                mutableListOf(),
+                mutableListOf(),
+                mutableListOf(),
+                mutableListOf(),
+                mutableListOf(),
+                java.net.URI.create("test://test")
+            )
+        )
+    }
 }

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -55,10 +55,11 @@ class RecipeMarkdownGeneratorTest {
 
         // Test future Spring Boot 3.x minor versions
         val springBoot35Moderne = getRecipePath("io.moderne.java.spring.boot3.UpgradeSpringBoot_3_5")
-        val springBoot36Community = getRecipePath("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_6")
-
         assertEquals("java/spring/boot3/upgradespringboot_3_5-moderne-edition", springBoot35Moderne)
-        assertEquals("java/spring/boot3/upgradespringboot_3_6-community-edition", springBoot36Community)
+
+        // No change for recipes up to 3.3
+        val springBoot33Community = getRecipePath("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_3")
+        assertEquals("java/spring/boot3/upgradespringboot_3_3", springBoot33Community)
 
         // Test future Spring Boot 5.x versions
         val springBoot5Community = getRecipePath("org.openrewrite.java.spring.boot5.UpgradeSpringBoot_5_1")


### PR DESCRIPTION
  - Replace hardcoded if statements with generic regex pattern matcher
  - Support any Spring Boot major/minor version combinations (3.x, 4.x...)
  - Maintain separate moderne-edition and community-edition path handling
  - Add comprehensive tests covering current and future Spring Boot versions
