### PR TITLE
Fix compilation issues

### DIFF
--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -176,7 +176,8 @@ class ListsOfRecipesWriter(
 
     fun createStandaloneRecipes(
         recipeContainedBy: MutableMap<String, MutableSet<RecipeDescriptor>>,
-        recipeOrigins: Map<URI, RecipeOrigin>
+        recipeOrigins: Map<URI, RecipeOrigin>,
+        recipeToSource: Map<String, URI>
     ) {
         val standaloneRecipes = allRecipeDescriptors.filterNot { recipe ->
             recipeContainedBy.contains(recipe.name)
@@ -208,7 +209,10 @@ class ListsOfRecipesWriter(
 
             // Group by package for better organization
             val recipesByArtifact = standaloneRecipes
-                .groupBy { recipe -> recipeOrigins[recipe.source]?.artifactId ?: "other" }
+                .groupBy { recipe ->
+                    val source = recipeToSource[recipe.name]
+                    recipeOrigins[source]?.artifactId ?: "other"
+                }
                 .toSortedMap()
             for ((artifact, recipes) in recipesByArtifact) {
                 writeln("## ${artifact}\n")
@@ -230,7 +234,8 @@ class ListsOfRecipesWriter(
 
     fun createScanningRecipes(
         scanningRecipes: List<Recipe>,
-        recipeOrigins: Map<URI, RecipeOrigin>
+        recipeOrigins: Map<URI, RecipeOrigin>,
+        recipeToSource: Map<String, URI>
     ) {
         val markdown = outputPath.resolve("scanning-recipes.md")
         Files.newBufferedWriter(markdown, StandardOpenOption.CREATE).useAndApply {
@@ -250,7 +255,10 @@ class ListsOfRecipesWriter(
 
 
             val recipesByArtifact = scanningRecipes
-                .groupBy { recipe -> recipeOrigins[recipe.descriptor.source]?.artifactId ?: "other" }
+                .groupBy { recipe ->
+                    val source = recipeToSource[recipe.descriptor.name]
+                    recipeOrigins[source]?.artifactId ?: "other"
+                }
                 .toSortedMap()
             for ((artifact, recipes) in recipesByArtifact) {
                 writeln("## ${artifact}\n")

--- a/src/main/resources/8-66-1-Release.md
+++ b/src/main/resources/8-66-1-Release.md
@@ -1,0 +1,91 @@
+---
+description: What's changed in OpenRewrite version 8.66.1.
+---
+
+# 8.66.1 release (2025-11-11)
+
+_Total recipe count: 4972_
+
+:::info
+This changelog only shows what recipes have been added, removed, or changed. OpenRewrite may do releases that do not include these types of changes. To see these changes, please go to the [releases page](https://github.com/openrewrite/rewrite/releases).
+:::
+
+## Corresponding CLI version
+
+* Stable CLI version `v3.50.1`
+* Staging CLI version: `v3.50.1`
+
+## New Recipes
+
+* [com.google.guava.InlineGuavaMethods](https://docs.openrewrite.org/recipes/com/google/guava/inlineguavamethods): Automatically generated recipes to inline method calls based on `@InlineMe` annotations discovered in the type table. 
+* [io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-moderne-edition): Migrate applications to the latest Spring Boot 4.0 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. This recipe will also chain additional framework migrations (Spring Framework, Spring Data, etc) that are required as part of the migration to Spring Boot 4.0. 
+* [io.moderne.java.spring.framework.NullableSpringWebParameters](https://docs.openrewrite.org/recipes/java/spring/framework/nullablespringwebparameters): In Spring Boot 4, JSpecify's `@Nullable` annotation should be used to indicate that a parameter can be null. This recipe adds `@Nullable` to parameters annotated with `@PathVariable(required = false)` or `@RequestParam(required = false)` and removes the now-redundant `required = false` attribute. 
+* [org.apache.logging.log4j.InlineLog4jApiMethods](https://docs.openrewrite.org/recipes/org/apache/logging/log4j/inlinelog4japimethods): Automatically generated recipes to inline method calls based on `@InlineMe` annotations discovered in the type table. 
+* [org.openrewrite.github.MigrateSetupUvV6ToV7](https://docs.openrewrite.org/recipes/github/migratesetupuvv6tov7): Migrates `astral-sh/setup-uv` from v6 to v7. Updates the action version and removes the deprecated `server-url` input. See the [v7.0.0 release notes](https://github.com/astral-sh/setup-uv/releases/tag/v7.0.0) for breaking changes. 
+* [org.openrewrite.gradle.MigrateDependenciesToVersionCatalog](https://docs.openrewrite.org/recipes/gradle/migratedependenciestoversioncatalog): Migrates Gradle project dependencies to use the [version catalog](https://docs.gradle.org/current/userguide/platforms.html) feature. Supports migrating dependency declarations of various forms:
+ * `String` notation: `"group:artifact:version"`
+ * `Map` notation: `group: 'group', name: 'artifact', version: 'version'`
+ * Property references: `"group:artifact:$version"` or `"group:artifact:${version}"`
+
+The recipe will:
+ * Create a `gradle/libs.versions.toml` file with version declarations
+ * Replace dependency declarations with catalog references (e.g., `libs.springCore`)
+ * Migrate version properties from `gradle.properties` to the version catalog
+ * Preserve project dependencies unchanged
+
+**Note:** If a version catalog already exists, the recipe will not modify it. 
+* [org.openrewrite.java.migrate.guava.NoGuavaCollections2Transform](https://docs.openrewrite.org/recipes/java/migrate/guava/noguavacollections2transform): Prefer `Collection.stream().map(Function)` over `Collections2.transform(Collection, Function)`. 
+* [org.openrewrite.java.migrate.guava.NoGuavaFunctionsCompose](https://docs.openrewrite.org/recipes/java/migrate/guava/noguavafunctionscompose): Prefer `Function.compose(Function)` over `Functions.compose(Function, Function)`. 
+* [org.openrewrite.java.migrate.guava.NoGuavaIterablesAnyFilter](https://docs.openrewrite.org/recipes/java/migrate/guava/noguavaiterablesanyfilter): Prefer `Collection.stream().anyMatch(Predicate)` over `Iterables.any(Collection, Predicate)`. 
+* [org.openrewrite.java.migrate.guava.NoGuavaIterablesTransform](https://docs.openrewrite.org/recipes/java/migrate/guava/noguavaiterablestransform): Prefer `Collection.stream().map(Function)` over `Iterables.transform(Collection, Function)`. 
+* [org.openrewrite.java.migrate.guava.NoGuavaOptionalAsSet](https://docs.openrewrite.org/recipes/java/migrate/guava/noguavaoptionalasset): Prefer `Optional.stream().collect(Collectors.toSet())` over `Optional.asSet()`. 
+* [org.openrewrite.java.migrate.guava.NoGuavaPredicate](https://docs.openrewrite.org/recipes/java/migrate/guava/noguavapredicate): Change the type only where no methods are used that explicitly require a Guava `Predicate`. 
+* [org.openrewrite.java.migrate.guava.NoGuavaPredicatesEqualTo](https://docs.openrewrite.org/recipes/java/migrate/guava/noguavapredicatesequalto): Prefer `Predicate.isEqual(Object)` over `Predicates.equalTo(Object)`. 
+* [org.openrewrite.java.migrate.guava.NoGuavaSetsFilter](https://docs.openrewrite.org/recipes/java/migrate/guava/noguavasetsfilter): Prefer `Collection.stream().filter(Predicate)` over `Sets.filter(Set, Predicate)`. 
+* [org.openrewrite.java.migrate.jakarta.JettyUpgradeEE10](https://docs.openrewrite.org/recipes/java/migrate/jakarta/jettyupgradeee10): Update Jetty dependencies from EE9 to EE10, changing the groupId and artifactIds as needed. 
+* [org.openrewrite.java.spring.PropertiesToKebabCaseProperties](https://docs.openrewrite.org/recipes/java/spring/propertiestokebabcaseproperties): Normalize Spring `application*.properties` properties to kebab-case. 
+* [org.openrewrite.java.spring.PropertiesToKebabCaseYaml](https://docs.openrewrite.org/recipes/java/spring/propertiestokebabcaseyaml): Normalize Spring `application*.{yml,yaml}` properties to kebab-case. 
+* [org.openrewrite.java.spring.boot2.MigrateDatabaseCredentialsForToolProperties](https://docs.openrewrite.org/recipes/java/spring/boot2/migratedatabasecredentialsfortoolproperties): Migrate null credentials. 
+* [org.openrewrite.java.spring.boot2.MigrateDatabaseCredentialsForToolYaml](https://docs.openrewrite.org/recipes/java/spring/boot2/migratedatabasecredentialsfortoolyaml): Migrate null credentials. 
+* [org.openrewrite.java.spring.boot4.SpringBootProperties_4_0](https://docs.openrewrite.org/recipes/java/spring/boot4/springbootproperties_4_0): Migrate properties found in `application.properties` and `application.yml`. 
+* [org.openrewrite.java.spring.boot4.UpgradeSpringBoot_4_0](https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-community-edition): Migrate applications to the latest Spring Boot 4.0 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs. 
+* [org.openrewrite.java.spring.framework.UpgradeSpringFramework_7_0](https://docs.openrewrite.org/recipes/java/spring/framework/upgradespringframework_7_0): Migrate applications to the latest Spring Framework 7.0 release. 
+* [org.openrewrite.java.spring.search.FindConfigurationProperties](https://docs.openrewrite.org/recipes/java/spring/search/findconfigurationproperties): Find all classes annotated with `@ConfigurationProperties` and extract their prefix values. This is useful for discovering all externalized configuration properties in Spring Boot applications. 
+* [org.openrewrite.java.springdoc.ApiInfoBuilderToInfo](https://docs.openrewrite.org/recipes/java/springdoc/apiinfobuildertoinfo): Migrate SpringFox's `ApiInfoBuilder` to Swagger's `Info`. 
+* [org.openrewrite.java.springdoc.SecurityContextToSecurityScheme](https://docs.openrewrite.org/recipes/java/springdoc/securitycontexttosecurityscheme): Replace `ApiKey`, `AuthorizationScope`, and `SecurityScheme` elements with Swagger's equivalents. 
+* [org.openrewrite.java.testing.assertj.SimplifySequencedCollectionAssertions](https://docs.openrewrite.org/recipes/java/testing/assertj/simplifysequencedcollectionassertions): Simplify AssertJ assertions on SequencedCollection by using dedicated assertion methods. For example, `assertThat(sequencedCollection.getLast())` can be simplified to `assertThat(sequencedCollection).last()`. 
+* [org.openrewrite.staticanalysis.ReorderAnnotationAttributes](https://docs.openrewrite.org/recipes/staticanalysis/reorderannotationattributes): Reorder annotation attributes to be alphabetical. Positional arguments (those without explicit attribute names) are left in their original position. 
+* [org.openrewrite.staticanalysis.ReplaceStringConcatenationWithStringValueOf](https://docs.openrewrite.org/recipes/staticanalysis/replacestringconcatenationwithstringvalueof): Replace inefficient string concatenation patterns like `"" + ...` with `String.valueOf(...)`. This improves code readability and may have minor performance benefits. 
+* [tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$FluxTimeoutFluxEmptyRecipe](https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$fluxtimeoutfluxemptyrecipe): Prefer `Flux#timeout(Duration, Publisher)` over more contrived or less performant alternatives. 
+* [tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationMonoEmptyRecipe](https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutdurationmonoemptyrecipe): Prefer `Mono#timeout(Duration, Mono)` over more contrived or less performant alternatives. 
+* [tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationMonoJustRecipe](https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutdurationmonojustrecipe): Prefer `Mono#timeout(Duration, Mono)` over more contrived or less performant alternatives. 
+* [tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationRecipe](https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutdurationrecipe): Prefer `Mono#timeout(Duration, Mono)` over more contrived or less performant alternatives. 
+* [tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherMonoEmptyRecipe](https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutpublishermonoemptyrecipe): Prefer `Mono#timeout(Publisher, Mono)` over more contrived or less performant alternatives. 
+* [tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherMonoJustRecipe](https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutpublishermonojustrecipe): Prefer `Mono#timeout(Publisher, Mono)` over more contrived or less performant alternatives. 
+* [tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherRecipe](https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutpublisherrecipe): Prefer `Mono#timeout(Publisher, Mono)` over more contrived or less performant alternatives. 
+
+## Removed Recipes
+
+* **io.moderne.java.spring.security6.UpgradeSpringSecurity_6_4**: Migrate applications to the latest Spring Security 6.4 release. This recipe will modify an application's build files, make changes to deprecated/preferred APIs, and migrate configuration settings that have changes between versions. 
+* **org.openrewrite.java.logging.log4j.InlineMethods**: Automatically generated recipes to inline method calls based on `@InlineMe` annotations discovered in the type table. 
+* **org.openrewrite.java.migrate.UpdateJakartaAnnotationsIfExistsForJakarta**: Counteract the `jakarta.annotation-api` by updating to `jakarta` namespace 
+* **org.openrewrite.java.migrate.UpdateJakartaAnnotationsIfForJavax**: Counteract the `jakarta.annotation-api` by updating to `jakarta` namespace 
+* **org.openrewrite.java.migrate.guava.NoGuavaInlineMeMethods**: Automatically generated recipes to inline method calls based on `@InlineMe` annotations discovered in the type table. 
+
+## Changed Recipes
+
+* [org.openrewrite.java.format.AutoFormat](https://docs.openrewrite.org/recipes/java/format/autoformat) was changed:
+  * Old Options:
+    * `None`
+  * New Options:
+    * `style: { type: String, required: false }`
+* [org.openrewrite.java.dependencies.DependencyVulnerabilityCheck](https://docs.openrewrite.org/recipes/java/dependencies/dependencyvulnerabilitycheck) was changed:
+  * Old Options:
+    * `maximumUpgradeDelta: { type: UpgradeDelta, required: false }`
+    * `overrideTransitive: { type: Boolean, required: false }`
+    * `scope: { type: String, required: false }`
+  * New Options:
+    * `maximumUpgradeDelta: { type: UpgradeDelta, required: false }`
+    * `minimumSeverity: { type: String, required: false }`
+    * `overrideTransitive: { type: Boolean, required: false }`
+    * `scope: { type: String, required: false }`

--- a/src/main/resources/recipeDescriptors.yml
+++ b/src/main/resources/recipeDescriptors.yml
@@ -1,6 +1,6 @@
 rewrite-ai-search:
   artifactId: "rewrite-ai-search"
-  version: "0.31.1"
+  version: "0.32.0"
   markdownRecipeDescriptors:
     io.moderne.ai.FindCommentsLanguage:
       name: "io.moderne.ai.FindCommentsLanguage"
@@ -75,7 +75,7 @@ rewrite-ai-search:
       artifactId: "rewrite-ai-search"
 rewrite-all:
   artifactId: "rewrite-all"
-  version: "1.22.2"
+  version: "1.23.0"
   markdownRecipeDescriptors:
     org.openrewrite.FindCallGraph:
       name: "org.openrewrite.FindCallGraph"
@@ -107,7 +107,7 @@ rewrite-all:
       artifactId: "rewrite-all"
 rewrite-analysis:
   artifactId: "rewrite-analysis"
-  version: "2.28.0"
+  version: "2.29.0"
   markdownRecipeDescriptors:
     org.openrewrite.analysis.controlflow.ControlFlowVisualization:
       name: "org.openrewrite.analysis.controlflow.ControlFlowVisualization"
@@ -170,7 +170,7 @@ rewrite-analysis:
       artifactId: "rewrite-analysis"
 rewrite-android:
   artifactId: "rewrite-android"
-  version: "0.13.1"
+  version: "0.14.0"
   markdownRecipeDescriptors:
     org.openrewrite.android.ChangeAndroidSdkVersion:
       name: "org.openrewrite.android.ChangeAndroidSdkVersion"
@@ -297,7 +297,7 @@ rewrite-android:
       artifactId: "rewrite-android"
 rewrite-apache:
   artifactId: "rewrite-apache"
-  version: "2.19.0"
+  version: "2.20.0"
   markdownRecipeDescriptors:
     org.openrewrite.apache.commons.codec.ApacheBase64ToJavaBase64:
       name: "org.openrewrite.apache.commons.codec.ApacheBase64ToJavaBase64"
@@ -1156,7 +1156,7 @@ rewrite-apache:
       artifactId: "rewrite-apache"
 rewrite-azul:
   artifactId: "rewrite-azul"
-  version: "0.7.1"
+  version: "0.8.0"
   markdownRecipeDescriptors:
     io.moderne.azul.EliminateUnusedClasses:
       name: "io.moderne.azul.EliminateUnusedClasses"
@@ -1197,7 +1197,7 @@ rewrite-azul:
       artifactId: "rewrite-azul"
 rewrite-circleci:
   artifactId: "rewrite-circleci"
-  version: "3.8.1"
+  version: "3.9.0"
   markdownRecipeDescriptors:
     org.openrewrite.circleci.InstallOrb:
       name: "org.openrewrite.circleci.InstallOrb"
@@ -1225,7 +1225,7 @@ rewrite-circleci:
       artifactId: "rewrite-circleci"
 rewrite-codemods:
   artifactId: "rewrite-codemods"
-  version: "0.20.1"
+  version: "0.21.0"
   markdownRecipeDescriptors:
     org.openrewrite.codemods.ApplyCodemod:
       name: "org.openrewrite.codemods.ApplyCodemod"
@@ -1613,8 +1613,8 @@ rewrite-codemods:
       artifactId: "rewrite-codemods"
     org.openrewrite.codemods.cleanup.javascript.NoLonelyIf:
       name: "org.openrewrite.codemods.cleanup.javascript.NoLonelyIf"
-      description: "Disallow `if` statements as the only statement in `if` blocks\
-        \ without `else`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-lonely-if.md)\n"
+      description: "Disallow if statements as the only statement in else blocks \n\
+        See [rule details](https://eslint.org/docs/latest/rules/no-lonely-if)\n"
       docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nolonelyif"
       options: []
       isImperative: false
@@ -4749,7 +4749,7 @@ rewrite-codemods:
       artifactId: "rewrite-codemods"
 rewrite-codemods-ng:
   artifactId: "rewrite-codemods-ng"
-  version: "0.14.4"
+  version: "0.15.0"
   markdownRecipeDescriptors:
     org.openrewrite.codemods.migrate.angular.ApplyAngularCLI:
       name: "org.openrewrite.codemods.migrate.angular.ApplyAngularCLI"
@@ -4799,7 +4799,7 @@ rewrite-codemods-ng:
       artifactId: "rewrite-codemods-ng"
 rewrite-compiled-analysis:
   artifactId: "rewrite-compiled-analysis"
-  version: "0.9.1"
+  version: "0.10.0"
   markdownRecipeDescriptors:
     io.moderne.compiled.verification.ChangeListMethodAndVerify:
       name: "io.moderne.compiled.verification.ChangeListMethodAndVerify"
@@ -4821,7 +4821,7 @@ rewrite-compiled-analysis:
       artifactId: "rewrite-compiled-analysis"
 rewrite-comprehension:
   artifactId: "rewrite-comprehension"
-  version: "0.8.1"
+  version: "0.9.0"
   markdownRecipeDescriptors:
     io.moderne.knowledge.ComprehendCode:
       name: "io.moderne.knowledge.ComprehendCode"
@@ -4877,7 +4877,7 @@ rewrite-comprehension:
       artifactId: "rewrite-comprehension"
 rewrite-concourse:
   artifactId: "rewrite-concourse"
-  version: "3.8.1"
+  version: "3.9.0"
   markdownRecipeDescriptors:
     org.openrewrite.concourse.ChangeResourceVersion:
       name: "org.openrewrite.concourse.ChangeResourceVersion"
@@ -4957,7 +4957,7 @@ rewrite-concourse:
       artifactId: "rewrite-concourse"
 rewrite-core:
   artifactId: "rewrite-core"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.AddToGitignore:
       name: "org.openrewrite.AddToGitignore"
@@ -5348,7 +5348,7 @@ rewrite-core:
       artifactId: "rewrite-core"
 rewrite-cryptography:
   artifactId: "rewrite-cryptography"
-  version: "0.10.1"
+  version: "0.11.0"
   markdownRecipeDescriptors:
     io.moderne.cryptography.FindRSAKeyGenParameters:
       name: "io.moderne.cryptography.FindRSAKeyGenParameters"
@@ -9720,7 +9720,7 @@ rewrite-csharp:
       artifactId: "rewrite-csharp"
 rewrite-cucumber-jvm:
   artifactId: "rewrite-cucumber-jvm"
-  version: "2.10.1"
+  version: "2.11.0"
   markdownRecipeDescriptors:
     org.openrewrite.cucumber.jvm.CucumberAnnotationToSuite:
       name: "org.openrewrite.cucumber.jvm.CucumberAnnotationToSuite"
@@ -9799,7 +9799,7 @@ rewrite-cucumber-jvm:
       artifactId: "rewrite-cucumber-jvm"
 rewrite-devcenter:
   artifactId: "rewrite-devcenter"
-  version: "1.10.1"
+  version: "1.11.0"
   markdownRecipeDescriptors:
     io.moderne.devcenter.ApacheDevCenter:
       name: "io.moderne.devcenter.ApacheDevCenter"
@@ -9985,7 +9985,7 @@ rewrite-devcenter:
       artifactId: "rewrite-devcenter"
 rewrite-docker:
   artifactId: "rewrite-docker"
-  version: "2.13.0"
+  version: "2.14.0"
   markdownRecipeDescriptors:
     org.openrewrite.docker.search.FindDockerImageUses:
       name: "org.openrewrite.docker.search.FindDockerImageUses"
@@ -9997,7 +9997,7 @@ rewrite-docker:
       artifactId: "rewrite-docker"
 rewrite-dotnet:
   artifactId: "rewrite-dotnet"
-  version: "0.13.5"
+  version: "0.14.0"
   markdownRecipeDescriptors:
     org.openrewrite.dotnet.MigrateToNet6:
       name: "org.openrewrite.dotnet.MigrateToNet6"
@@ -10060,7 +10060,7 @@ rewrite-dotnet:
       artifactId: "rewrite-dotnet"
 rewrite-dropwizard:
   artifactId: "rewrite-dropwizard"
-  version: "0.7.1"
+  version: "0.8.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.dropwizard.AddActuatorConfiguration:
       name: "org.openrewrite.java.dropwizard.AddActuatorConfiguration"
@@ -10068,21 +10068,21 @@ rewrite-dropwizard:
         \ application.properties."
       docLink: "https://docs.openrewrite.org/recipes/java/dropwizard/addactuatorconfiguration"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-dropwizard"
     org.openrewrite.java.dropwizard.AddCoreExampleProperties:
       name: "org.openrewrite.java.dropwizard.AddCoreExampleProperties"
       description: "Adds core example properties to the application.properties file."
       docLink: "https://docs.openrewrite.org/recipes/java/dropwizard/addcoreexampleproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-dropwizard"
     org.openrewrite.java.dropwizard.AddHibernateConfiguration:
       name: "org.openrewrite.java.dropwizard.AddHibernateConfiguration"
       description: "Configures Spring Boot Hibernate and JPA settings in application.properties."
       docLink: "https://docs.openrewrite.org/recipes/java/dropwizard/addhibernateconfiguration"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-dropwizard"
     org.openrewrite.java.dropwizard.AddJerseyConfiguration:
       name: "org.openrewrite.java.dropwizard.AddJerseyConfiguration"
@@ -10090,7 +10090,7 @@ rewrite-dropwizard:
         \ the JerseyConfig class."
       docLink: "https://docs.openrewrite.org/recipes/java/dropwizard/addjerseyconfiguration"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-dropwizard"
     org.openrewrite.java.dropwizard.AddMissingApplicationProperties:
       name: "org.openrewrite.java.dropwizard.AddMissingApplicationProperties"
@@ -10098,7 +10098,7 @@ rewrite-dropwizard:
         \ folder if it does not exist."
       docLink: "https://docs.openrewrite.org/recipes/java/dropwizard/addmissingapplicationproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-dropwizard"
     org.openrewrite.java.dropwizard.CodeCleanup:
       name: "org.openrewrite.java.dropwizard.CodeCleanup"
@@ -10312,7 +10312,7 @@ rewrite-dropwizard:
       artifactId: "rewrite-dropwizard"
 rewrite-elastic:
   artifactId: "rewrite-elastic"
-  version: "0.3.1"
+  version: "0.4.0"
   markdownRecipeDescriptors:
     io.moderne.elastic.elastic9.ChangeApiNumericFieldType:
       name: "io.moderne.elastic.elastic9.ChangeApiNumericFieldType"
@@ -10434,7 +10434,7 @@ rewrite-elastic:
       artifactId: "rewrite-elastic"
 rewrite-feature-flags:
   artifactId: "rewrite-feature-flags"
-  version: "1.15.0"
+  version: "1.16.0"
   markdownRecipeDescriptors:
     org.openrewrite.featureflags.RemoveBooleanFlag:
       name: "org.openrewrite.featureflags.RemoveBooleanFlag"
@@ -10740,7 +10740,7 @@ rewrite-feature-flags:
       artifactId: "rewrite-feature-flags"
 rewrite-github-actions:
   artifactId: "rewrite-github-actions"
-  version: "3.13.0"
+  version: "3.14.0"
   markdownRecipeDescriptors:
     org.openrewrite.github.AddCronTrigger:
       name: "org.openrewrite.github.AddCronTrigger"
@@ -10849,6 +10849,16 @@ rewrite-github-actions:
       docLink: "https://docs.openrewrite.org/recipes/github/findmissingtimeout"
       options: []
       isImperative: true
+      artifactId: "rewrite-github-actions"
+    org.openrewrite.github.MigrateSetupUvV6ToV7:
+      name: "org.openrewrite.github.MigrateSetupUvV6ToV7"
+      description: "Migrates `astral-sh/setup-uv` from v6 to v7. Updates the action\
+        \ version and removes the deprecated `server-url` input. See the [v7.0.0 release\
+        \ notes](https://github.com/astral-sh/setup-uv/releases/tag/v7.0.0) for breaking\
+        \ changes."
+      docLink: "https://docs.openrewrite.org/recipes/github/migratesetupuvv6tov7"
+      options: []
+      isImperative: false
       artifactId: "rewrite-github-actions"
     org.openrewrite.github.MigrateTibdexGitHubAppTokenToActions:
       name: "org.openrewrite.github.MigrateTibdexGitHubAppTokenToActions"
@@ -11272,7 +11282,7 @@ rewrite-github-actions:
       artifactId: "rewrite-github-actions"
 rewrite-gitlab:
   artifactId: "rewrite-gitlab"
-  version: "0.16.1"
+  version: "0.17.0"
   markdownRecipeDescriptors:
     org.openrewrite.gitlab.AddComponent:
       name: "org.openrewrite.gitlab.AddComponent"
@@ -11388,7 +11398,7 @@ rewrite-gitlab:
       artifactId: "rewrite-gitlab"
 rewrite-gradle:
   artifactId: "rewrite-gradle"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.gradle.AddDependency:
       name: "org.openrewrite.gradle.AddDependency"
@@ -11737,6 +11747,22 @@ rewrite-gradle:
       docLink: "https://docs.openrewrite.org/recipes/gradle/gradlebestpractices"
       options: []
       isImperative: false
+      artifactId: "rewrite-gradle"
+    org.openrewrite.gradle.MigrateDependenciesToVersionCatalog:
+      name: "org.openrewrite.gradle.MigrateDependenciesToVersionCatalog"
+      description: "Migrates Gradle project dependencies to use the [version catalog](https://docs.gradle.org/current/userguide/platforms.html)\
+        \ feature. Supports migrating dependency declarations of various forms:\n\
+        \ * `String` notation: `\"group:artifact:version\"`\n * `Map` notation: `group:\
+        \ 'group', name: 'artifact', version: 'version'`\n * Property references:\
+        \ `\"group:artifact:$version\"` or `\"group:artifact:${version}\"`\n\nThe\
+        \ recipe will:\n * Create a `gradle/libs.versions.toml` file with version\
+        \ declarations\n * Replace dependency declarations with catalog references\
+        \ (e.g., `libs.springCore`)\n * Migrate version properties from `gradle.properties`\
+        \ to the version catalog\n * Preserve project dependencies unchanged\n\n**Note:**\
+        \ If a version catalog already exists, the recipe will not modify it."
+      docLink: "https://docs.openrewrite.org/recipes/gradle/migratedependenciestoversioncatalog"
+      options: []
+      isImperative: true
       artifactId: "rewrite-gradle"
     org.openrewrite.gradle.MigrateToGradle5:
       name: "org.openrewrite.gradle.MigrateToGradle5"
@@ -12334,7 +12360,7 @@ rewrite-gradle:
       artifactId: "rewrite-gradle"
 rewrite-groovy:
   artifactId: "rewrite-groovy"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.groovy.format.AutoFormat:
       name: "org.openrewrite.groovy.format.AutoFormat"
@@ -12370,7 +12396,7 @@ rewrite-groovy:
       artifactId: "rewrite-groovy"
 rewrite-hcl:
   artifactId: "rewrite-hcl"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.hcl.DeleteContent:
       name: "org.openrewrite.hcl.DeleteContent"
@@ -12483,7 +12509,7 @@ rewrite-hcl:
       artifactId: "rewrite-hcl"
 rewrite-hibernate:
   artifactId: "rewrite-hibernate"
-  version: "0.13.2"
+  version: "0.14.0"
   markdownRecipeDescriptors:
     io.moderne.hibernate.MigrateToHibernate66:
       name: "io.moderne.hibernate.MigrateToHibernate66"
@@ -12889,7 +12915,7 @@ rewrite-hibernate:
       artifactId: "rewrite-hibernate"
 rewrite-jackson:
   artifactId: "rewrite-jackson"
-  version: "1.8.0"
+  version: "1.9.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.jackson.CodehausClassesToFasterXML:
       name: "org.openrewrite.java.jackson.CodehausClassesToFasterXML"
@@ -13064,7 +13090,7 @@ rewrite-jackson:
       artifactId: "rewrite-jackson"
 rewrite-java:
   artifactId: "rewrite-java"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.java.AddApache2LicenseHeader:
       name: "org.openrewrite.java.AddApache2LicenseHeader"
@@ -13129,7 +13155,7 @@ rewrite-java:
       artifactId: "rewrite-java"
     org.openrewrite.java.AddLiteralMethodArgument:
       name: "org.openrewrite.java.AddLiteralMethodArgument"
-      description: "Add a literal `String` or `int` argument to method invocations."
+      description: "Add a literal `String` or primitive argument to method invocations."
       docLink: "https://docs.openrewrite.org/recipes/java/addliteralmethodargument"
       options:
       - name: "argumentIndex"
@@ -13761,7 +13787,10 @@ rewrite-java:
       description: "Format Java code using a standard comprehensive set of Java formatting\
         \ recipes."
       docLink: "https://docs.openrewrite.org/recipes/java/format/autoformat"
-      options: []
+      options:
+      - name: "style"
+        type: "String"
+        required: false
       isImperative: true
       artifactId: "rewrite-java"
     org.openrewrite.java.format.BlankLines:
@@ -14294,7 +14323,7 @@ rewrite-java:
       artifactId: "rewrite-java"
 rewrite-java-dependencies:
   artifactId: "rewrite-java-dependencies"
-  version: "1.44.0"
+  version: "1.45.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.dependencies.AddDependency:
       name: "org.openrewrite.java.dependencies.AddDependency"
@@ -14706,7 +14735,7 @@ rewrite-java-dependencies:
       artifactId: "rewrite-java-dependencies"
 rewrite-java-security:
   artifactId: "rewrite-java-security"
-  version: "3.20.0"
+  version: "3.21.0"
   markdownRecipeDescriptors:
     org.openrewrite.csharp.dependencies.DependencyInsight:
       name: "org.openrewrite.csharp.dependencies.DependencyInsight"
@@ -14779,11 +14808,14 @@ rewrite-java-security:
         \ which aggregates vulnerability data from several public databases, including\
         \ the [National Vulnerability Database](https://nvd.nist.gov/) maintained\
         \ by the United States government. Upgrades dependencies versioned according\
-        \ to [Semantic Versioning](https://semver.org/). Last updated: 2025-10-20T1103."
+        \ to [Semantic Versioning](https://semver.org/). Last updated: 2025-10-27T1103."
       docLink: "https://docs.openrewrite.org/recipes/java/dependencies/dependencyvulnerabilitycheck"
       options:
       - name: "maximumUpgradeDelta"
         type: "UpgradeDelta"
+        required: false
+      - name: "minimumSeverity"
+        type: "String"
         required: false
       - name: "overrideTransitive"
         type: "Boolean"
@@ -15350,7 +15382,7 @@ rewrite-java-security:
       artifactId: "rewrite-java-security"
 rewrite-jenkins:
   artifactId: "rewrite-jenkins"
-  version: "0.31.1"
+  version: "0.32.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.testing.htmlunit.UpgradeHtmlUnit_3:
       name: "org.openrewrite.java.testing.htmlunit.UpgradeHtmlUnit_3"
@@ -15533,7 +15565,7 @@ rewrite-jenkins:
       artifactId: "rewrite-jenkins"
 rewrite-joda:
   artifactId: "rewrite-joda"
-  version: "0.2.1"
+  version: "0.3.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.joda.time.JodaTimeRecipe:
       name: "org.openrewrite.java.joda.time.JodaTimeRecipe"
@@ -15557,7 +15589,7 @@ rewrite-joda:
       artifactId: "rewrite-joda"
 rewrite-json:
   artifactId: "rewrite-json"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.json.AddKeyValue:
       name: "org.openrewrite.json.AddKeyValue"
@@ -15668,7 +15700,7 @@ rewrite-json:
       artifactId: "rewrite-json"
 rewrite-kafka:
   artifactId: "rewrite-kafka"
-  version: "0.3.1"
+  version: "0.4.0"
   markdownRecipeDescriptors:
     io.moderne.kafka.MigrateAdminListConsumerGroups:
       name: "io.moderne.kafka.MigrateAdminListConsumerGroups"
@@ -15947,7 +15979,7 @@ rewrite-kafka:
       artifactId: "rewrite-kafka"
 rewrite-kotlin:
   artifactId: "rewrite-kotlin"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.kotlin.FindKotlinSources:
       name: "org.openrewrite.kotlin.FindKotlinSources"
@@ -16055,7 +16087,7 @@ rewrite-kotlin:
       artifactId: "rewrite-kotlin"
 rewrite-kubernetes:
   artifactId: "rewrite-kubernetes"
-  version: "3.12.0"
+  version: "3.13.0"
   markdownRecipeDescriptors:
     org.openrewrite.kubernetes.AddConfiguration:
       name: "org.openrewrite.kubernetes.AddConfiguration"
@@ -16599,7 +16631,7 @@ rewrite-kubernetes:
       artifactId: "rewrite-kubernetes"
 rewrite-liberty:
   artifactId: "rewrite-liberty"
-  version: "1.22.1"
+  version: "1.23.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.liberty.MigrateFromWebSphereToLiberty:
       name: "org.openrewrite.java.liberty.MigrateFromWebSphereToLiberty"
@@ -16707,7 +16739,7 @@ rewrite-liberty:
       artifactId: "rewrite-liberty"
 rewrite-logging-frameworks:
   artifactId: "rewrite-logging-frameworks"
-  version: "3.17.0"
+  version: "3.18.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.logging.ArgumentArrayToVarargs:
       name: "org.openrewrite.java.logging.ArgumentArrayToVarargs"
@@ -17147,14 +17179,6 @@ rewrite-logging-frameworks:
       docLink: "https://docs.openrewrite.org/recipes/java/logging/log4j/convertjulexiting"
       options: []
       isImperative: true
-      artifactId: "rewrite-logging-frameworks"
-    org.openrewrite.java.logging.log4j.InlineMethods:
-      name: "org.openrewrite.java.logging.log4j.InlineMethods"
-      description: "Automatically generated recipes to inline method calls based on\
-        \ `@InlineMe` annotations discovered in the type table."
-      docLink: "https://docs.openrewrite.org/recipes/java/logging/log4j/inlinemethods"
-      options: []
-      isImperative: false
       artifactId: "rewrite-logging-frameworks"
     org.openrewrite.java.logging.log4j.JulToLog4j:
       name: "org.openrewrite.java.logging.log4j.JulToLog4j"
@@ -17816,7 +17840,7 @@ rewrite-logging-frameworks:
       artifactId: "rewrite-logging-frameworks"
 rewrite-maven:
   artifactId: "rewrite-maven"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.maven.AddAnnotationProcessor:
       name: "org.openrewrite.maven.AddAnnotationProcessor"
@@ -19259,7 +19283,7 @@ rewrite-maven:
       artifactId: "rewrite-maven"
 rewrite-micrometer:
   artifactId: "rewrite-micrometer"
-  version: "0.26.1"
+  version: "0.27.0"
   markdownRecipeDescriptors:
     org.openrewrite.micrometer.TimerToObservation:
       name: "org.openrewrite.micrometer.TimerToObservation"
@@ -19318,7 +19342,7 @@ rewrite-micrometer:
       artifactId: "rewrite-micrometer"
 rewrite-micronaut:
   artifactId: "rewrite-micronaut"
-  version: "2.29.1"
+  version: "2.30.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.micronaut.AddAnnotationProcessorPath:
       name: "org.openrewrite.java.micronaut.AddAnnotationProcessorPath"
@@ -19662,7 +19686,7 @@ rewrite-micronaut:
       artifactId: "rewrite-micronaut"
 rewrite-migrate-java:
   artifactId: "rewrite-migrate-java"
-  version: "3.20.0"
+  version: "3.21.1"
   markdownRecipeDescriptors:
     org.openrewrite.java.jspecify.JSpecifyBestPractices:
       name: "org.openrewrite.java.jspecify.JSpecifyBestPractices"
@@ -20317,22 +20341,6 @@ rewrite-migrate-java:
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
-    org.openrewrite.java.migrate.UpdateJakartaAnnotationsIfExistsForJakarta:
-      name: "org.openrewrite.java.migrate.UpdateJakartaAnnotationsIfExistsForJakarta"
-      description: "Counteract the `jakarta.annotation-api` by updating to `jakarta`\
-        \ namespace"
-      docLink: "https://docs.openrewrite.org/recipes/java/migrate/updatejakartaannotationsifexistsforjakarta"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-migrate-java"
-    org.openrewrite.java.migrate.UpdateJakartaAnnotationsIfForJavax:
-      name: "org.openrewrite.java.migrate.UpdateJakartaAnnotationsIfForJavax"
-      description: "Counteract the `jakarta.annotation-api` by updating to `jakarta`\
-        \ namespace"
-      docLink: "https://docs.openrewrite.org/recipes/java/migrate/updatejakartaannotationsifforjavax"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.UpdateSdkMan:
       name: "org.openrewrite.java.migrate.UpdateSdkMan"
       description: "Update the SDKMAN JDK version in the `.sdkmanrc` file. Given a\
@@ -20597,6 +20605,14 @@ rewrite-migrate-java:
       options: []
       isImperative: true
       artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.guava.NoGuavaCollections2Transform:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaCollections2Transform"
+      description: "Prefer `Collection.stream().map(Function)` over `Collections2.transform(Collection,\
+        \ Function)`."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavacollections2transform"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.NoGuavaCreateTempDir:
       name: "org.openrewrite.java.migrate.guava.NoGuavaCreateTempDir"
       description: "Replaces Guava `Files#createTempDir()` with Java `Files#createTempDirectory(..)`.\
@@ -20611,6 +20627,14 @@ rewrite-migrate-java:
         \ just as succinct as `MoreExecutors.directExecutor()` but without the third-party\
         \ library requirement."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavadirectexecutor"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.guava.NoGuavaFunctionsCompose:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaFunctionsCompose"
+      description: "Prefer `Function.compose(Function)` over `Functions.compose(Function,\
+        \ Function)`."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavafunctionscompose"
       options: []
       isImperative: true
       artifactId: "rewrite-migrate-java"
@@ -20638,13 +20662,21 @@ rewrite-migrate-java:
       options: []
       isImperative: true
       artifactId: "rewrite-migrate-java"
-    org.openrewrite.java.migrate.guava.NoGuavaInlineMeMethods:
-      name: "org.openrewrite.java.migrate.guava.NoGuavaInlineMeMethods"
-      description: "Automatically generated recipes to inline method calls based on\
-        \ `@InlineMe` annotations discovered in the type table."
-      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavainlinememethods"
+    org.openrewrite.java.migrate.guava.NoGuavaIterablesAnyFilter:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaIterablesAnyFilter"
+      description: "Prefer `Collection.stream().anyMatch(Predicate)` over `Iterables.any(Collection,\
+        \ Predicate)`."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavaiterablesanyfilter"
       options: []
-      isImperative: false
+      isImperative: true
+      artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.guava.NoGuavaIterablesTransform:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaIterablesTransform"
+      description: "Prefer `Collection.stream().map(Function)` over `Iterables.transform(Collection,\
+        \ Function)`."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavaiterablestransform"
+      options: []
+      isImperative: true
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.NoGuavaJava11:
       name: "org.openrewrite.java.migrate.guava.NoGuavaJava11"
@@ -20714,6 +20746,13 @@ rewrite-migrate-java:
       options: []
       isImperative: true
       artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.guava.NoGuavaOptionalAsSet:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaOptionalAsSet"
+      description: "Prefer `Optional.stream().collect(Collectors.toSet())` over `Optional.asSet()`."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavaoptionalasset"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.NoGuavaOptionalFromJavaUtil:
       name: "org.openrewrite.java.migrate.guava.NoGuavaOptionalFromJavaUtil"
       description: "Replaces `com.google.common.base.Optional#fromJavaUtil(java.util.Optional)`\
@@ -20729,11 +20768,26 @@ rewrite-migrate-java:
       options: []
       isImperative: true
       artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.guava.NoGuavaPredicate:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaPredicate"
+      description: "Change the type only where no methods are used that explicitly\
+        \ require a Guava `Predicate`."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavapredicate"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.NoGuavaPredicatesAndOr:
       name: "org.openrewrite.java.migrate.guava.NoGuavaPredicatesAndOr"
       description: "Prefer `Predicate.and(Predicate)` over `Predicates.and(Predicate,\
         \ Predicate)`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavapredicatesandor"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.guava.NoGuavaPredicatesEqualTo:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaPredicatesEqualTo"
+      description: "Prefer `Predicate.isEqual(Object)` over `Predicates.equalTo(Object)`."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavapredicatesequalto"
       options: []
       isImperative: true
       artifactId: "rewrite-migrate-java"
@@ -20771,6 +20825,14 @@ rewrite-migrate-java:
       name: "org.openrewrite.java.migrate.guava.NoGuavaRefasterRecipes$PreconditionsCheckNotNullWithMessageToObjectsRequireNonNullRecipe"
       description: "Migrate from Guava `Preconditions.checkNotNull` to Java 8 `java.util.Objects.requireNonNull`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavarefasterrecipes$preconditionschecknotnullwithmessagetoobjectsrequirenonnullrecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.guava.NoGuavaSetsFilter:
+      name: "org.openrewrite.java.migrate.guava.NoGuavaSetsFilter"
+      description: "Prefer `Collection.stream().filter(Predicate)` over `Sets.filter(Set,\
+        \ Predicate)`."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/noguavasetsfilter"
       options: []
       isImperative: true
       artifactId: "rewrite-migrate-java"
@@ -21519,6 +21581,14 @@ rewrite-migrate-java:
       description: "Java EE has been rebranded to Jakarta EE, necessitating a package\
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/jakarta/javaxxmlwsmigrationtojakartaxmlws"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.jakarta.JettyUpgradeEE10:
+      name: "org.openrewrite.java.migrate.jakarta.JettyUpgradeEE10"
+      description: "Update Jetty dependencies from EE9 to EE10, changing the groupId\
+        \ and artifactIds as needed."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/jakarta/jettyupgradeee10"
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
@@ -23142,7 +23212,7 @@ rewrite-migrate-java:
       artifactId: "rewrite-migrate-java"
 rewrite-netty:
   artifactId: "rewrite-netty"
-  version: "0.5.1"
+  version: "0.6.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.netty.EventLoopGroupToMultiThreadIoEventLoopGroupRecipes:
       name: "org.openrewrite.java.netty.EventLoopGroupToMultiThreadIoEventLoopGroupRecipes"
@@ -23181,7 +23251,7 @@ rewrite-netty:
       artifactId: "rewrite-netty"
 rewrite-nodejs:
   artifactId: "rewrite-nodejs"
-  version: "0.32.3"
+  version: "0.33.0"
   markdownRecipeDescriptors:
     org.openrewrite.nodejs.DependencyVulnerabilityCheck:
       name: "org.openrewrite.nodejs.DependencyVulnerabilityCheck"
@@ -23330,7 +23400,7 @@ rewrite-nodejs:
       artifactId: "rewrite-nodejs"
 rewrite-okhttp:
   artifactId: "rewrite-okhttp"
-  version: "0.19.1"
+  version: "0.20.0"
   markdownRecipeDescriptors:
     org.openrewrite.okhttp.ReorderRequestBodyCreateArguments:
       name: "org.openrewrite.okhttp.ReorderRequestBodyCreateArguments"
@@ -23387,7 +23457,7 @@ rewrite-okhttp:
       artifactId: "rewrite-okhttp"
 rewrite-openapi:
   artifactId: "rewrite-openapi"
-  version: "0.26.0"
+  version: "0.27.0"
   markdownRecipeDescriptors:
     org.openrewrite.openapi.swagger.ConvertApiResponseCodesToStrings:
       name: "org.openrewrite.openapi.swagger.ConvertApiResponseCodesToStrings"
@@ -23498,7 +23568,7 @@ rewrite-openapi:
       artifactId: "rewrite-openapi"
 rewrite-program-analysis:
   artifactId: "rewrite-program-analysis"
-  version: "0.5.6"
+  version: "0.6.0"
   markdownRecipeDescriptors:
     org.openrewrite.analysis.java.FindNullPointerIssues:
       name: "org.openrewrite.analysis.java.FindNullPointerIssues"
@@ -23630,7 +23700,7 @@ rewrite-program-analysis:
       artifactId: "rewrite-program-analysis"
 rewrite-properties:
   artifactId: "rewrite-properties"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.properties.AddProperty:
       name: "org.openrewrite.properties.AddProperty"
@@ -23760,7 +23830,7 @@ rewrite-properties:
       artifactId: "rewrite-properties"
 rewrite-quarkus:
   artifactId: "rewrite-quarkus"
-  version: "2.27.1"
+  version: "2.28.0"
   markdownRecipeDescriptors:
     org.openrewrite.quarkus.AddQuarkusProperty:
       name: "org.openrewrite.quarkus.AddQuarkusProperty"
@@ -24028,7 +24098,7 @@ rewrite-quarkus:
       artifactId: "rewrite-quarkus"
 rewrite-reactive-streams:
   artifactId: "rewrite-reactive-streams"
-  version: "0.17.1"
+  version: "0.18.0"
   markdownRecipeDescriptors:
     org.openrewrite.reactive.reactor.ReactorBestPractices:
       name: "org.openrewrite.reactive.reactor.ReactorBestPractices"
@@ -24208,7 +24278,7 @@ rewrite-reactive-streams:
       artifactId: "rewrite-reactive-streams"
 rewrite-rewrite:
   artifactId: "rewrite-rewrite"
-  version: "0.14.1"
+  version: "0.15.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.jspecify.MigrateFromOpenRewriteAnnotations:
       name: "org.openrewrite.java.jspecify.MigrateFromOpenRewriteAnnotations"
@@ -24423,7 +24493,7 @@ rewrite-rewrite:
       artifactId: "rewrite-rewrite"
 rewrite-spring:
   artifactId: "rewrite-spring"
-  version: "0.15.0"
+  version: "0.16.0"
   markdownRecipeDescriptors:
     io.moderne.java.spring.boot.FieldToConstructorInjection:
       name: "io.moderne.java.spring.boot.FieldToConstructorInjection"
@@ -24451,7 +24521,7 @@ rewrite-spring:
       artifactId: "rewrite-spring"
     io.moderne.java.spring.boot.MigrateSpringFrameworkDependenciesToSpringBoot:
       name: "io.moderne.java.spring.boot.MigrateSpringFrameworkDependenciesToSpringBoot"
-      description: "Migrate Spring Framework Dependencies to Spring Boot."
+      description: "Migrate Spring Framework dependencies to Spring Boot."
       docLink: "https://docs.openrewrite.org/recipes/java/spring/boot/migratespringframeworkdependenciestospringboot"
       options: []
       isImperative: true
@@ -24692,6 +24762,18 @@ rewrite-spring:
       options: []
       isImperative: false
       artifactId: "rewrite-spring"
+    io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0:
+      name: "io.moderne.java.spring.boot4.UpgradeSpringBoot_4_0"
+      description: "Migrate applications to the latest Spring Boot 4.0 release. This\
+        \ recipe will modify an application's build files, make changes to deprecated/preferred\
+        \ APIs, and migrate configuration settings that have changes between versions.\
+        \ This recipe will also chain additional framework migrations (Spring Framework,\
+        \ Spring Data, etc) that are required as part of the migration to Spring Boot\
+        \ 4.0."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-moderne-edition"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
     io.moderne.java.spring.cloud2020.SpringCloudProperties_2020:
       name: "io.moderne.java.spring.cloud2020.SpringCloudProperties_2020"
       description: "Migrate properties found in `application.properties` and `application.yml`."
@@ -24741,6 +24823,16 @@ rewrite-spring:
       options: []
       isImperative: true
       artifactId: "rewrite-spring"
+    io.moderne.java.spring.framework.NullableSpringWebParameters:
+      name: "io.moderne.java.spring.framework.NullableSpringWebParameters"
+      description: "In Spring Boot 4, JSpecify's `@Nullable` annotation should be\
+        \ used to indicate that a parameter can be null. This recipe adds `@Nullable`\
+        \ to parameters annotated with `@PathVariable(required = false)` or `@RequestParam(required\
+        \ = false)` and removes the now-redundant `required = false` attribute."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/framework/nullablespringwebparameters"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-spring"
     io.moderne.java.spring.framework.beansxml.BeansXmlToConfiguration:
       name: "io.moderne.java.spring.framework.beansxml.BeansXmlToConfiguration"
       description: "Converts Java/Jakarta EE `beans.xml` configuration files to Spring\
@@ -24755,9 +24847,9 @@ rewrite-spring:
         \ This allows for programmatic configuration of the web application context,\
         \ replacing the need for XML-based configuration. This recipe only picks up\
         \ `web.xml` files located in the `src/main/webapp/WEB-INF` directory to avoid\
-        \ inference with tests.It creates a `WebXmlWebAppInitializer` class in `src/main/java`\
-        \ with respect to submodules if they contain java files.**If it finds an existing\
-        \ `WebXmlWebAppInitializer`, it skips the creation**."
+        \ inference with tests. It creates a `WebXmlWebAppInitializer` class in `src/main/java`\
+        \ with respect to submodules if they contain java files. **If it finds an\
+        \ existing `WebXmlWebAppInitializer`, it skips the creation**."
       docLink: "https://docs.openrewrite.org/recipes/java/spring/framework/webxml/webxmltowebapplicationinitializer"
       options:
       - name: "useJakartaEE"
@@ -24773,15 +24865,6 @@ rewrite-spring:
       docLink: "https://docs.openrewrite.org/recipes/java/spring/security6/migrateantpathrequestmatcher"
       options: []
       isImperative: true
-      artifactId: "rewrite-spring"
-    io.moderne.java.spring.security6.UpgradeSpringSecurity_6_4:
-      name: "io.moderne.java.spring.security6.UpgradeSpringSecurity_6_4"
-      description: "Migrate applications to the latest Spring Security 6.4 release.\
-        \ This recipe will modify an application's build files, make changes to deprecated/preferred\
-        \ APIs, and migrate configuration settings that have changes between versions."
-      docLink: "https://docs.openrewrite.org/recipes/java/spring/security6/upgradespringsecurity_6_4"
-      options: []
-      isImperative: false
       artifactId: "rewrite-spring"
     io.moderne.java.spring.security6.UpgradeSpringSecurity_6_5:
       name: "io.moderne.java.spring.security6.UpgradeSpringSecurity_6_5"
@@ -25003,6 +25086,20 @@ rewrite-spring:
       docLink: "https://docs.openrewrite.org/recipes/java/spring/propertiestokebabcase"
       options: []
       isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.PropertiesToKebabCaseProperties:
+      name: "org.openrewrite.java.spring.PropertiesToKebabCaseProperties"
+      description: "Normalize Spring `application*.properties` properties to kebab-case."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/propertiestokebabcaseproperties"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.PropertiesToKebabCaseYaml:
+      name: "org.openrewrite.java.spring.PropertiesToKebabCaseYaml"
+      description: "Normalize Spring `application*.{yml,yaml}` properties to kebab-case."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/propertiestokebabcaseyaml"
+      options: []
+      isImperative: true
       artifactId: "rewrite-spring"
     org.openrewrite.java.spring.RenameBean:
       name: "org.openrewrite.java.spring.RenameBean"
@@ -25305,6 +25402,26 @@ rewrite-spring:
       docLink: "https://docs.openrewrite.org/recipes/java/spring/boot2/migratedatabasecredentials"
       options: []
       isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot2.MigrateDatabaseCredentialsForToolProperties:
+      name: "org.openrewrite.java.spring.boot2.MigrateDatabaseCredentialsForToolProperties"
+      description: "Migrate null credentials."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot2/migratedatabasecredentialsfortoolproperties"
+      options:
+      - name: "tool"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot2.MigrateDatabaseCredentialsForToolYaml:
+      name: "org.openrewrite.java.spring.boot2.MigrateDatabaseCredentialsForToolYaml"
+      description: "Migrate null credentials."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot2/migratedatabasecredentialsfortoolyaml"
+      options:
+      - name: "tool"
+        type: "String"
+        required: true
+      isImperative: true
       artifactId: "rewrite-spring"
     org.openrewrite.java.spring.boot2.MigrateDiskSpaceHealthIndicatorConstructor:
       name: "org.openrewrite.java.spring.boot2.MigrateDiskSpaceHealthIndicatorConstructor"
@@ -26190,6 +26307,22 @@ rewrite-spring:
       options: []
       isImperative: false
       artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.SpringBootProperties_4_0:
+      name: "org.openrewrite.java.spring.boot4.SpringBootProperties_4_0"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/springbootproperties_4_0"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.UpgradeSpringBoot_4_0:
+      name: "org.openrewrite.java.spring.boot4.UpgradeSpringBoot_4_0"
+      description: "Migrate applications to the latest Spring Boot 4.0 release. This\
+        \ recipe will modify an application's build files, make changes to deprecated/preferred\
+        \ APIs."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-community-edition"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
     org.openrewrite.java.spring.cloud2022.AddLoggingPatternLevelForSleuth:
       name: "org.openrewrite.java.spring.cloud2022.AddLoggingPatternLevelForSleuth"
       description: "Add `logging.pattern.level` for traceId and spanId which was previously\
@@ -26688,6 +26821,13 @@ rewrite-spring:
       options: []
       isImperative: false
       artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.framework.UpgradeSpringFramework_7_0:
+      name: "org.openrewrite.java.spring.framework.UpgradeSpringFramework_7_0"
+      description: "Migrate applications to the latest Spring Framework 7.0 release."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/framework/upgradespringframework_7_0"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
     org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty:
       name: "org.openrewrite.java.spring.framework.UseObjectUtilsIsEmpty"
       description: "`StringUtils#isEmpty(Object)` was deprecated in 5.3."
@@ -26782,6 +26922,15 @@ rewrite-spring:
         \ `@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping`, and `@PatchMapping`\
         \ as search results."
       docLink: "https://docs.openrewrite.org/recipes/java/spring/search/findapiendpoints"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.search.FindConfigurationProperties:
+      name: "org.openrewrite.java.spring.search.FindConfigurationProperties"
+      description: "Find all classes annotated with `@ConfigurationProperties` and\
+        \ extract their prefix values. This is useful for discovering all externalized\
+        \ configuration properties in Spring Boot applications."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/search/findconfigurationproperties"
       options: []
       isImperative: true
       artifactId: "rewrite-spring"
@@ -27104,6 +27253,13 @@ rewrite-spring:
       options: []
       isImperative: true
       artifactId: "rewrite-spring"
+    org.openrewrite.java.springdoc.ApiInfoBuilderToInfo:
+      name: "org.openrewrite.java.springdoc.ApiInfoBuilderToInfo"
+      description: "Migrate SpringFox's `ApiInfoBuilder` to Swagger's `Info`."
+      docLink: "https://docs.openrewrite.org/recipes/java/springdoc/apiinfobuildertoinfo"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-spring"
     org.openrewrite.java.springdoc.MigrateSpringdocCommon:
       name: "org.openrewrite.java.springdoc.MigrateSpringdocCommon"
       description: "Migrate from springdoc-openapi-common to springdoc-openapi-starter-common."
@@ -27117,6 +27273,14 @@ rewrite-spring:
       docLink: "https://docs.openrewrite.org/recipes/java/springdoc/replacespringfoxdependencies"
       options: []
       isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.springdoc.SecurityContextToSecurityScheme:
+      name: "org.openrewrite.java.springdoc.SecurityContextToSecurityScheme"
+      description: "Replace `ApiKey`, `AuthorizationScope`, and `SecurityScheme` elements\
+        \ with Swagger's equivalents."
+      docLink: "https://docs.openrewrite.org/recipes/java/springdoc/securitycontexttosecurityscheme"
+      options: []
+      isImperative: true
       artifactId: "rewrite-spring"
     org.openrewrite.java.springdoc.SpringFoxToSpringDoc:
       name: "org.openrewrite.java.springdoc.SpringFoxToSpringDoc"
@@ -27185,7 +27349,7 @@ rewrite-spring:
       artifactId: "rewrite-spring"
 rewrite-spring-to-quarkus:
   artifactId: "rewrite-spring-to-quarkus"
-  version: "0.2.0"
+  version: "0.3.0"
   markdownRecipeDescriptors:
     org.openrewrite.quarkus.spring.AddQuarkusMavenPlugin:
       name: "org.openrewrite.quarkus.spring.AddQuarkusMavenPlugin"
@@ -27541,7 +27705,7 @@ rewrite-spring-to-quarkus:
       artifactId: "rewrite-spring-to-quarkus"
 rewrite-sql:
   artifactId: "rewrite-sql"
-  version: "2.7.1"
+  version: "2.8.0"
   markdownRecipeDescriptors:
     org.openrewrite.sql.ChangeFunctionName:
       name: "org.openrewrite.sql.ChangeFunctionName"
@@ -27657,7 +27821,7 @@ rewrite-sql:
       artifactId: "rewrite-sql"
 rewrite-static-analysis:
   artifactId: "rewrite-static-analysis"
-  version: "2.20.0"
+  version: "2.21.0"
   markdownRecipeDescriptors:
     org.openrewrite.staticanalysis.AbstractClassPublicConstructor:
       name: "org.openrewrite.staticanalysis.AbstractClassPublicConstructor"
@@ -28527,7 +28691,8 @@ rewrite-static-analysis:
     org.openrewrite.staticanalysis.RemoveSystemOutPrintln:
       name: "org.openrewrite.staticanalysis.RemoveSystemOutPrintln"
       description: "Print statements are often left accidentally after debugging an\
-        \ issue."
+        \ issue. This recipe removes all `System.out#println` and `System.err#println`\
+        \ statements from the code."
       docLink: "https://docs.openrewrite.org/recipes/staticanalysis/removesystemoutprintln"
       options: []
       isImperative: true
@@ -28637,6 +28802,14 @@ rewrite-static-analysis:
       options: []
       isImperative: true
       artifactId: "rewrite-static-analysis"
+    org.openrewrite.staticanalysis.ReorderAnnotationAttributes:
+      name: "org.openrewrite.staticanalysis.ReorderAnnotationAttributes"
+      description: "Reorder annotation attributes to be alphabetical. Positional arguments\
+        \ (those without explicit attribute names) are left in their original position."
+      docLink: "https://docs.openrewrite.org/recipes/staticanalysis/reorderannotationattributes"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-static-analysis"
     org.openrewrite.staticanalysis.ReorderAnnotations:
       name: "org.openrewrite.staticanalysis.ReorderAnnotations"
       description: "Consistently order annotations by comparing their simple name."
@@ -28742,6 +28915,15 @@ rewrite-static-analysis:
         \ compiler can optimize simple string concatenation expressions into a single\
         \ String object, which can be more efficient than using StringBuilder."
       docLink: "https://docs.openrewrite.org/recipes/staticanalysis/replacestringbuilderwithstring"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-static-analysis"
+    org.openrewrite.staticanalysis.ReplaceStringConcatenationWithStringValueOf:
+      name: "org.openrewrite.staticanalysis.ReplaceStringConcatenationWithStringValueOf"
+      description: "Replace inefficient string concatenation patterns like `\"\" +\
+        \ ...` with `String.valueOf(...)`. This improves code readability and may\
+        \ have minor performance benefits."
+      docLink: "https://docs.openrewrite.org/recipes/staticanalysis/replacestringconcatenationwithstringvalueof"
       options: []
       isImperative: true
       artifactId: "rewrite-static-analysis"
@@ -29204,7 +29386,7 @@ rewrite-static-analysis:
       artifactId: "rewrite-static-analysis"
 rewrite-struts:
   artifactId: "rewrite-struts"
-  version: "0.22.1"
+  version: "0.23.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.struts.MigrateStrutsDtd:
       name: "org.openrewrite.java.struts.MigrateStrutsDtd"
@@ -29280,7 +29462,7 @@ rewrite-struts:
       artifactId: "rewrite-struts"
 rewrite-terraform:
   artifactId: "rewrite-terraform"
-  version: "3.10.0"
+  version: "3.11.0"
   markdownRecipeDescriptors:
     org.openrewrite.terraform.AddConfiguration:
       name: "org.openrewrite.terraform.AddConfiguration"
@@ -30184,7 +30366,7 @@ rewrite-terraform:
       artifactId: "rewrite-terraform"
 rewrite-testing-frameworks:
   artifactId: "rewrite-testing-frameworks"
-  version: "3.20.0"
+  version: "3.21.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.testing.archunit.ArchUnit0to1Migration:
       name: "org.openrewrite.java.testing.archunit.ArchUnit0to1Migration"
@@ -30747,6 +30929,15 @@ rewrite-testing-frameworks:
       description: "Removes redundant AssertJ assertions when chained methods already\
         \ provide the same or stronger guarantees."
       docLink: "https://docs.openrewrite.org/recipes/java/testing/assertj/simplifyredundantassertjchains"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-testing-frameworks"
+    org.openrewrite.java.testing.assertj.SimplifySequencedCollectionAssertions:
+      name: "org.openrewrite.java.testing.assertj.SimplifySequencedCollectionAssertions"
+      description: "Simplify AssertJ assertions on SequencedCollection by using dedicated\
+        \ assertion methods. For example, `assertThat(sequencedCollection.getLast())`\
+        \ can be simplified to `assertThat(sequencedCollection).last()`."
+      docLink: "https://docs.openrewrite.org/recipes/java/testing/assertj/simplifysequencedcollectionassertions"
       options: []
       isImperative: true
       artifactId: "rewrite-testing-frameworks"
@@ -31890,7 +32081,7 @@ rewrite-testing-frameworks:
       artifactId: "rewrite-testing-frameworks"
 rewrite-third-party:
   artifactId: "rewrite-third-party"
-  version: "0.30.0"
+  version: "0.31.0"
   markdownRecipeDescriptors:
     ai.timefold.solver.migration.ChangeVersion:
       name: "ai.timefold.solver.migration.ChangeVersion"
@@ -31991,6 +32182,14 @@ rewrite-third-party:
       options: []
       isImperative: true
       artifactId: "rewrite-third-party"
+    com.google.guava.InlineGuavaMethods:
+      name: "com.google.guava.InlineGuavaMethods"
+      description: "Automatically generated recipes to inline method calls based on\
+        \ `@InlineMe` annotations discovered in the type table."
+      docLink: "https://docs.openrewrite.org/recipes/com/google/guava/inlineguavamethods"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.ChangeJAXBBindAPIDependencyScope:
       name: "com.oracle.weblogic.rewrite.ChangeJAXBBindAPIDependencyScope"
       description: "This recipe will change the jakarta.xml.bind-api dependency scope\
@@ -31999,7 +32198,7 @@ rewrite-third-party:
         \ WebLogic which can cause class conflicts."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/changejaxbbindapidependencyscope"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.ChangeJakartaInjectAPIDependencyScope:
       name: "com.oracle.weblogic.rewrite.ChangeJakartaInjectAPIDependencyScope"
@@ -32009,7 +32208,7 @@ rewrite-third-party:
         \ WebLogic which can cause class conflicts."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/changejakartainjectapidependencyscope"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.ChangeJakartaWebServiceRSAPIDependencyScope:
       name: "com.oracle.weblogic.rewrite.ChangeJakartaWebServiceRSAPIDependencyScope"
@@ -32019,7 +32218,7 @@ rewrite-third-party:
         \ which can cause class conflicts."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/changejakartawebservicersapidependencyscope"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.CheckAndCommentOutDeprecations1412:
       name: "com.oracle.weblogic.rewrite.CheckAndCommentOutDeprecations1412"
@@ -32027,7 +32226,7 @@ rewrite-third-party:
         \ version 14.1.2."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/checkandcommentoutdeprecations1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.CheckAndCommentOutDeprecations1511:
       name: "com.oracle.weblogic.rewrite.CheckAndCommentOutDeprecations1511"
@@ -32035,7 +32234,7 @@ rewrite-third-party:
         \ version 15.1.1."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/checkandcommentoutdeprecations1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.FacesMigrationToJakartaFaces2x:
       name: "com.oracle.weblogic.rewrite.FacesMigrationToJakartaFaces2x"
@@ -32044,7 +32243,7 @@ rewrite-third-party:
         \ 2.3 on WebLogic 14.1.2 or older."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/facesmigrationtojakartafaces2x"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.JakartaEE9_1:
       name: "com.oracle.weblogic.rewrite.JakartaEE9_1"
@@ -32052,21 +32251,21 @@ rewrite-third-party:
         \ and updating deprecated methods."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakartaee9_1"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.MigrateWebLogicSchemasTo1412:
       name: "com.oracle.weblogic.rewrite.MigrateWebLogicSchemasTo1412"
       description: "This recipe will migrate WebLogic schemas to 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/migrateweblogicschemasto1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.MigrateWebLogicSchemasTo1511:
       name: "com.oracle.weblogic.rewrite.MigrateWebLogicSchemasTo1511"
       description: "This recipe will migrate WebLogic schemas to 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/migrateweblogicschemasto1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.OutputRecipeVersion:
       name: "com.oracle.weblogic.rewrite.OutputRecipeVersion"
@@ -32081,7 +32280,7 @@ rewrite-third-party:
         \ build."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/updatebuildtoweblogic1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.UpdateBuildToWebLogic1511:
       name: "com.oracle.weblogic.rewrite.UpdateBuildToWebLogic1511"
@@ -32089,7 +32288,7 @@ rewrite-third-party:
         \ build."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/updatebuildtoweblogic1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.UpgradeTo1411:
       name: "com.oracle.weblogic.rewrite.UpgradeTo1411"
@@ -32097,7 +32296,7 @@ rewrite-third-party:
         \ 14.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/upgradeto1411"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.UpgradeTo1412:
       name: "com.oracle.weblogic.rewrite.UpgradeTo1412"
@@ -32105,7 +32304,7 @@ rewrite-third-party:
         \ 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/upgradeto1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.UpgradeTo1511:
       name: "com.oracle.weblogic.rewrite.UpgradeTo1511"
@@ -32113,7 +32312,7 @@ rewrite-third-party:
         \ 15.1.1 and Jakarta EE 9.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/upgradeto1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.UpgradeWeblogicMavenPropertyVersion:
       name: "com.oracle.weblogic.rewrite.UpgradeWeblogicMavenPropertyVersion"
@@ -32132,7 +32331,7 @@ rewrite-third-party:
         \ 11 vs WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogic1412javaxmlbindmitigation"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicApplicationClientXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicApplicationClientXmlNamespace1412"
@@ -32140,7 +32339,7 @@ rewrite-third-party:
         \ to WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicapplicationclientxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicApplicationClientXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicApplicationClientXmlNamespace1511"
@@ -32148,7 +32347,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicapplicationclientxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicApplicationXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicApplicationXmlNamespace1412"
@@ -32156,7 +32355,7 @@ rewrite-third-party:
         \ WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicapplicationxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicApplicationXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicApplicationXmlNamespace1511"
@@ -32164,7 +32363,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicapplicationxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicEjbJar32XmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicEjbJar32XmlNamespace1412"
@@ -32172,7 +32371,7 @@ rewrite-third-party:
         \ 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicejbjar32xmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicEjbJar32XmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicEjbJar32XmlNamespace1511"
@@ -32180,7 +32379,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicejbjar32xmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicJdbcXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicJdbcXmlNamespace1412"
@@ -32188,7 +32387,7 @@ rewrite-third-party:
         \ 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicjdbcxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicJdbcXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicJdbcXmlNamespace1511"
@@ -32196,7 +32395,7 @@ rewrite-third-party:
         \ to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicjdbcxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicJmsXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicJmsXmlNamespace1412"
@@ -32204,7 +32403,7 @@ rewrite-third-party:
         \ 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicjmsxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicJmsXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicJmsXmlNamespace1511"
@@ -32212,7 +32411,7 @@ rewrite-third-party:
         \ to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicjmsxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicPersistenceConfigurationXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicPersistenceConfigurationXmlNamespace1412"
@@ -32220,7 +32419,7 @@ rewrite-third-party:
         \ schema files to WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicpersistenceconfigurationxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicPersistenceConfigurationXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicPersistenceConfigurationXmlNamespace1511"
@@ -32228,7 +32427,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicpersistenceconfigurationxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicPlanXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicPlanXmlNamespace1412"
@@ -32236,7 +32435,7 @@ rewrite-third-party:
         \ 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicplanxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicPlanXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicPlanXmlNamespace1511"
@@ -32244,7 +32443,7 @@ rewrite-third-party:
         \ to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicplanxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicPubSubXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicPubSubXmlNamespace1412"
@@ -32252,7 +32451,7 @@ rewrite-third-party:
         \ 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicpubsubxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicPubSubXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicPubSubXmlNamespace1511"
@@ -32260,7 +32459,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicpubsubxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicRaXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicRaXmlNamespace1412"
@@ -32268,7 +32467,7 @@ rewrite-third-party:
         \ to WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicraxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicRaXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicRaXmlNamespace1511"
@@ -32276,7 +32475,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicraxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicRdbmsJarXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicRdbmsJarXmlNamespace1412"
@@ -32284,7 +32483,7 @@ rewrite-third-party:
         \ WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicrdbmsjarxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicRdbmsJarXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicRdbmsJarXmlNamespace1511"
@@ -32292,7 +32491,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicrdbmsjarxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicResourceDeploymentPlanXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicResourceDeploymentPlanXmlNamespace1412"
@@ -32300,7 +32499,7 @@ rewrite-third-party:
         \ files to WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicresourcedeploymentplanxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicResourceDeploymentPlanXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicResourceDeploymentPlanXmlNamespace1511"
@@ -32308,7 +32507,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicresourcedeploymentplanxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicWebServicesXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicWebServicesXmlNamespace1412"
@@ -32316,7 +32515,7 @@ rewrite-third-party:
         \ WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicwebservicesxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicWebServicesXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicWebServicesXmlNamespace1511"
@@ -32324,7 +32523,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicwebservicesxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicWebservicesPolicyRefXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicWebservicesPolicyRefXmlNamespace1412"
@@ -32332,7 +32531,7 @@ rewrite-third-party:
         \ schema files to WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicwebservicespolicyrefxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicWebservicesPolicyRefXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicWebservicesPolicyRefXmlNamespace1511"
@@ -32340,7 +32539,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicwebservicespolicyrefxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicWseeClientHandlerChainXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicWseeClientHandlerChainXmlNamespace1412"
@@ -32348,7 +32547,7 @@ rewrite-third-party:
         \ files to WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicwseeclienthandlerchainxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicWseeClientHandlerChainXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicWseeClientHandlerChainXmlNamespace1511"
@@ -32356,7 +32555,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicwseeclienthandlerchainxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicWseeStandaloneClientXmlNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicWseeStandaloneClientXmlNamespace1412"
@@ -32364,7 +32563,7 @@ rewrite-third-party:
         \ files to WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicwseestandaloneclientxmlnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicWseeStandaloneClientXmlNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicWseeStandaloneClientXmlNamespace1511"
@@ -32372,7 +32571,7 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicwseestandaloneclientxmlnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicXmlCreateIfNotExists1511:
       name: "com.oracle.weblogic.rewrite.WebLogicXmlCreateIfNotExists1511"
@@ -32380,7 +32579,7 @@ rewrite-third-party:
         \ 15.1.1 namespace if it does not already exist."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicxmlcreateifnotexists1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicXmlPreferApplicationPackagesJPA:
       name: "com.oracle.weblogic.rewrite.WebLogicXmlPreferApplicationPackagesJPA"
@@ -32388,7 +32587,7 @@ rewrite-third-party:
         \ Jakarta Persistence in `weblogic.xml` if it does not already exist."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicxmlpreferapplicationpackagesjpa"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicXmlPreferApplicationPackagesSlf4j:
       name: "com.oracle.weblogic.rewrite.WebLogicXmlPreferApplicationPackagesSlf4j"
@@ -32396,14 +32595,14 @@ rewrite-third-party:
         \ SLF4J in `weblogic.xml` if it does not already exist."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicxmlpreferapplicationpackagesslf4j"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicXmlWebAppNamespace1412:
       name: "com.oracle.weblogic.rewrite.WebLogicXmlWebAppNamespace1412"
       description: "Migrate xmlns entries in WebLogic schema files to WebLogic 14.1.2"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicxmlwebappnamespace1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.WebLogicXmlWebAppNamespace1511:
       name: "com.oracle.weblogic.rewrite.WebLogicXmlWebAppNamespace1511"
@@ -32411,28 +32610,28 @@ rewrite-third-party:
         \ files to WebLogic 15.1.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/weblogicxmlwebappnamespace1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.examples.AddImplicitTldFileWithTaglib2_1:
       name: "com.oracle.weblogic.rewrite.examples.AddImplicitTldFileWithTaglib2_1"
       description: "Add `implicit.tld` file with taglib 2.1 to `src/main/webapp/WEB-INF/tags`."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/examples/addimplicittldfilewithtaglib2_1"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.examples.AddImplicitTldFileWithTaglib3_0:
       name: "com.oracle.weblogic.rewrite.examples.AddImplicitTldFileWithTaglib3_0"
       description: "Add `implicit.tld` file with taglib 3.0 to `src/main/webapp/WEB-INF/tags`."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/examples/addimplicittldfilewithtaglib3_0"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.examples.spring.ChangeCacheManagerToSimpleCacheManager:
       name: "com.oracle.weblogic.rewrite.examples.spring.ChangeCacheManagerToSimpleCacheManager"
       description: "Change cacheManager to use the SimpleCacheManager."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/examples/spring/changecachemanagertosimplecachemanager"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.examples.spring.MigratedPetClinicExtrasFor1511:
       name: "com.oracle.weblogic.rewrite.examples.spring.MigratedPetClinicExtrasFor1511"
@@ -32440,35 +32639,35 @@ rewrite-third-party:
         \ run on WebLogic 15.1.1."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/examples/spring/migratedpetclinicextrasfor1511"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.examples.spring.SetupSpringFrameworkPetClinicFor1412:
       name: "com.oracle.weblogic.rewrite.examples.spring.SetupSpringFrameworkPetClinicFor1412"
       description: "Setup Spring Framework 5.3.x PetClinic for WebLogic 14.1.2."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/examples/spring/setupspringframeworkpetclinicfor1412"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.hibernate.AddHibernateOrmCore61:
       name: "com.oracle.weblogic.rewrite.hibernate.AddHibernateOrmCore61"
       description: "This recipe will add Hibernate ORM Core if has dependencies."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/hibernate/addhibernateormcore61"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.hibernate.MigrateHibernateToJakartaEE9:
       name: "com.oracle.weblogic.rewrite.hibernate.MigrateHibernateToJakartaEE9"
       description: "Upgrade hibernate libraries to Jakarta EE9 versions."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/hibernate/migratehibernatetojakartaee9"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.AddJakartaEE9ServletDependencyIfUsingServletContext:
       name: "com.oracle.weblogic.rewrite.jakarta.AddJakartaEE9ServletDependencyIfUsingServletContext"
       description: "Add Jakarta EE 9 Servlet Dependency if using jakarta.servlet.ServletContext"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/addjakartaee9servletdependencyifusingservletcontext"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.ChangeJakartaFacesMethodCalls:
       name: "com.oracle.weblogic.rewrite.jakarta.ChangeJakartaFacesMethodCalls"
@@ -32484,7 +32683,7 @@ rewrite-third-party:
         \ and XML namespaces."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/faces2xmigrationtojakartafaces3x"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.FacesJNDINamesChanged3:
       name: "com.oracle.weblogic.rewrite.jakarta.FacesJNDINamesChanged3"
@@ -32493,7 +32692,7 @@ rewrite-third-party:
         \  The JNDI keys that have been renamed are updated to allow use of the keys.\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/facesjndinameschanged3"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.FacesManagedBeansRemoved3:
       name: "com.oracle.weblogic.rewrite.jakarta.FacesManagedBeansRemoved3"
@@ -32503,7 +32702,7 @@ rewrite-third-party:
         \ the jarkarta.inject.Named annotation.\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/facesmanagedbeansremoved3"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JakartaEeNamespaces9_1:
       name: "com.oracle.weblogic.rewrite.jakarta.JakartaEeNamespaces9_1"
@@ -32511,7 +32710,7 @@ rewrite-third-party:
         \ Namespaces."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/jakartaeenamespaces9_1"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JakartaFaces3Xhtml:
       name: "com.oracle.weblogic.rewrite.jakarta.JakartaFaces3Xhtml"
@@ -32519,7 +32718,7 @@ rewrite-third-party:
         \ Jakarta Faces values in XHTML files."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/jakartafaces3xhtml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxAnnotationMigrationToJakarta9Annotation:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxAnnotationMigrationToJakarta9Annotation"
@@ -32527,7 +32726,7 @@ rewrite-third-party:
         \ relocation.\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxannotationmigrationtojakarta9annotation"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxApplicationClientXmlToJakarta9ApplicationClientXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxApplicationClientXmlToJakarta9ApplicationClientXml"
@@ -32535,7 +32734,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxapplicationclientxmltojakarta9applicationclientxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxApplicationXmlToJakarta9ApplicationXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxApplicationXmlToJakarta9ApplicationXml"
@@ -32543,7 +32742,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxapplicationxmltojakarta9applicationxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxBatchJobsXmlsToJakarta9BatchJobsXmls:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxBatchJobsXmlsToJakarta9BatchJobsXmls"
@@ -32551,7 +32750,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxbatchjobsxmlstojakarta9batchjobsxmls"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxBatchXmlToJakarta9BatchXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxBatchXmlToJakarta9BatchXml"
@@ -32559,7 +32758,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxbatchxmltojakarta9batchxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxBeansXmlToJakarta9BeansXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxBeansXmlToJakarta9BeansXml"
@@ -32567,7 +32766,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxbeansxmltojakarta9beansxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxBindingsSchemaXjbsToJakarta9BindingsSchemaXjbs:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxBindingsSchemaXjbsToJakarta9BindingsSchemaXjbs"
@@ -32575,7 +32774,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxbindingsschemaxjbstojakarta9bindingsschemaxjbs"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxEjbJarXmlToJakarta9EjbJarXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxEjbJarXmlToJakarta9EjbJarXml"
@@ -32583,7 +32782,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxejbjarxmltojakarta9ejbjarxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxFacesConfigXmlToJakartaFaces3ConfigXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxFacesConfigXmlToJakartaFaces3ConfigXml"
@@ -32591,7 +32790,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxfacesconfigxmltojakartafaces3configxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxFacesTagLibraryXmlToJakartaFaces3TagLibraryXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxFacesTagLibraryXmlToJakartaFaces3TagLibraryXml"
@@ -32599,14 +32798,14 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxfacestaglibraryxmltojakartafaces3taglibraryxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxJmsToJakartaJmsOnMdb:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxJmsToJakartaJmsOnMdb"
       description: "Migrate javax.jms to jakarta.jms on MDB"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxjmstojakartajmsonmdb"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxPermissionsXmlToJakarta9PermissionsXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxPermissionsXmlToJakarta9PermissionsXml"
@@ -32614,7 +32813,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxpermissionsxmltojakarta9permissionsxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxRaXmlToJakarta9RaXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxRaXmlToJakarta9RaXml"
@@ -32622,7 +32821,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxraxmltojakarta9raxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxTestWebXmlToJakartaTestWebXml5:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxTestWebXmlToJakartaTestWebXml5"
@@ -32630,7 +32829,7 @@ rewrite-third-party:
         \ namespace relocation for test interfaces like arquillian."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxtestwebxmltojakartatestwebxml5"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxTestXmlsToJakartaTestsXmls:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxTestXmlsToJakartaTestsXmls"
@@ -32638,14 +32837,14 @@ rewrite-third-party:
         \ namespace relocation for test interfaces like arquillian."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxtestxmlstojakartatestsxmls"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxToJakartaCdiExtensions:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxToJakartaCdiExtensions"
       description: "Rename `javax.enterprise.inject.spi.Extension` to `jakarta.enterprise.inject.spi.Extension`."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxtojakartacdiextensions"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxValidationMappingXmlsToJakarta9ValidationMappingXmls:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxValidationMappingXmlsToJakarta9ValidationMappingXmls"
@@ -32653,7 +32852,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxvalidationmappingxmlstojakarta9validationmappingxmls"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxWebFragmentXmlToJakartaWebFragmentXml5:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxWebFragmentXmlToJakartaWebFragmentXml5"
@@ -32661,7 +32860,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxwebfragmentxmltojakartawebfragmentxml5"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxWebHandlerXmlToJakarta9HandlerXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxWebHandlerXmlToJakarta9HandlerXml"
@@ -32669,7 +32868,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxwebhandlerxmltojakarta9handlerxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxWebJspTagLibraryTldsToJakarta9WebJspTagLibraryTlds:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxWebJspTagLibraryTldsToJakarta9WebJspTagLibraryTlds"
@@ -32677,7 +32876,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxwebjsptaglibrarytldstojakarta9webjsptaglibrarytlds"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxWebServicesXmlToJakarta9WebServicesXml:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxWebServicesXmlToJakarta9WebServicesXml"
@@ -32685,7 +32884,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxwebservicesxmltojakarta9webservicesxml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.JavaxWebXmlToJakartaWebXml5:
       name: "com.oracle.weblogic.rewrite.jakarta.JavaxWebXmlToJakartaWebXml5"
@@ -32693,7 +32892,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/javaxwebxmltojakartawebxml5"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.MigrateJavaxMVCToJakartaEE9:
       name: "com.oracle.weblogic.rewrite.jakarta.MigrateJavaxMVCToJakartaEE9"
@@ -32701,7 +32900,7 @@ rewrite-third-party:
         \ EE9) versions."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/migratejavaxmvctojakartaee9"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.MigrateJavaxWebToJakartaWeb9:
       name: "com.oracle.weblogic.rewrite.jakarta.MigrateJavaxWebToJakartaWeb9"
@@ -32709,28 +32908,28 @@ rewrite-third-party:
         \ 9.1"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/migratejavaxwebtojakartaweb9"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.MigrateTagLibsToJakartaEE9:
       name: "com.oracle.weblogic.rewrite.jakarta.MigrateTagLibsToJakartaEE9"
       description: "Upgrade Jakarta Standard Tag libraries to 2.0 (Jakarta EE9) versions."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/migratetaglibstojakartaee9"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.MitigateUnaffectedNonEEJakarta9Packages:
       name: "com.oracle.weblogic.rewrite.jakarta.MitigateUnaffectedNonEEJakarta9Packages"
       description: "Mitigate Unaffected Non-EE Jakarta 9 Packages. Reference: [https://github.com/jakartaee/platform/blob/main/namespace/unaffected-packages.adoc](https://github.com/jakartaee/platform/blob/main/namespace/unaffected-packages.adoc)\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/mitigateunaffectednoneejakarta9packages"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.OrgGlassfishJavaxElToJakartaEl:
       name: "com.oracle.weblogic.rewrite.jakarta.OrgGlassfishJavaxElToJakartaEl"
       description: "Package relocation for rebranded Javax to Jakarta EE."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/orgglassfishjavaxeltojakartael"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.RemovalsServletJakarta9:
       name: "com.oracle.weblogic.rewrite.jakarta.RemovalsServletJakarta9"
@@ -32738,7 +32937,7 @@ rewrite-third-party:
         \ Servlet 5.0\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/removalsservletjakarta9"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.RemovedJakartaFaces3ExpressionLanguageClasses:
       name: "com.oracle.weblogic.rewrite.jakarta.RemovedJakartaFaces3ExpressionLanguageClasses"
@@ -32747,7 +32946,7 @@ rewrite-third-party:
         \ is the CompositeComponentExpressionHolder interface.\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/removedjakartafaces3expressionlanguageclasses"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.RemovedJakartaFaces3ResourceResolver:
       name: "com.oracle.weblogic.rewrite.jakarta.RemovedJakartaFaces3ResourceResolver"
@@ -32756,7 +32955,7 @@ rewrite-third-party:
         \ class.\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/removedjakartafaces3resourceresolver"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.RemovedStateManagerMethods3:
       name: "com.oracle.weblogic.rewrite.jakarta.RemovedStateManagerMethods3"
@@ -32766,7 +32965,7 @@ rewrite-third-party:
         \ based on JakartaEE9 migration in Faces 3.0\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/removedstatemanagermethods3"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.UpdateJakartaFacesMethodCalls:
       name: "com.oracle.weblogic.rewrite.jakarta.UpdateJakartaFacesMethodCalls"
@@ -32775,28 +32974,28 @@ rewrite-third-party:
         \ be run _after_ all the Jakarta Faces related type changes are completed.\n"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/updatejakartafacesmethodcalls"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.UpdateJakartaPersistenceTo31:
       name: "com.oracle.weblogic.rewrite.jakarta.UpdateJakartaPersistenceTo31"
       description: "Update Jakarta Persistence to 3.1."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/updatejakartapersistenceto31"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.UpdateJakartaPersistenceTo32:
       name: "com.oracle.weblogic.rewrite.jakarta.UpdateJakartaPersistenceTo32"
       description: "Update Jakarta Persistence to 3.2."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/updatejakartapersistenceto32"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.UpdateJakartaPlatform9_1:
       name: "com.oracle.weblogic.rewrite.jakarta.UpdateJakartaPlatform9_1"
       description: "Update Jakarta EE Platform Dependencies to 9.1.0"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/updatejakartaplatform9_1"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.UpgradeCommonOpenSourceLibraries:
       name: "com.oracle.weblogic.rewrite.jakarta.UpgradeCommonOpenSourceLibraries"
@@ -32804,7 +33003,7 @@ rewrite-third-party:
         \ versions."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/upgradecommonopensourcelibraries"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.UpgradeFacesOpenSourceLibraries2:
       name: "com.oracle.weblogic.rewrite.jakarta.UpgradeFacesOpenSourceLibraries2"
@@ -32812,7 +33011,7 @@ rewrite-third-party:
         \ EE9 versions."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/upgradefacesopensourcelibraries2"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.UpgradeFacesOpenSourceLibraries3:
       name: "com.oracle.weblogic.rewrite.jakarta.UpgradeFacesOpenSourceLibraries3"
@@ -32820,7 +33019,7 @@ rewrite-third-party:
         \ EE9 versions."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/upgradefacesopensourcelibraries3"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.jakarta.UpgradeMavenPluginArtifactItems:
       name: "com.oracle.weblogic.rewrite.jakarta.UpgradeMavenPluginArtifactItems"
@@ -32851,14 +33050,14 @@ rewrite-third-party:
       description: "Change artifacts for a Maven plugin configuration artifacts."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/jakarta/upgrademavenpluginconfigurationartifacts"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.spring.data.UpgradeSpringDataBom:
       name: "com.oracle.weblogic.rewrite.spring.data.UpgradeSpringDataBom"
       description: "Upgrade Spring Data BOM to 2024.1.x version."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/spring/data/upgradespringdatabom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.spring.data.UpgradeSpringDataJpa:
       name: "com.oracle.weblogic.rewrite.spring.data.UpgradeSpringDataJpa"
@@ -32866,7 +33065,7 @@ rewrite-third-party:
         \ used by spring-data-bom v2024.1.x"
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/spring/data/upgradespringdatajpa"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.spring.framework.DefaultServletHandler:
       name: "com.oracle.weblogic.rewrite.spring.framework.DefaultServletHandler"
@@ -32874,7 +33073,7 @@ rewrite-third-party:
         \ if empty, as noted in the Spring Framework 6.2 [documentation](https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-config/default-servlet-handler.html)."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/spring/framework/defaultservlethandler"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.spring.framework.ReplaceWebLogicJtaTransactionManager:
       name: "com.oracle.weblogic.rewrite.spring.framework.ReplaceWebLogicJtaTransactionManager"
@@ -32882,7 +33081,7 @@ rewrite-third-party:
         \ from Spring Framework 6.2.x."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/spring/framework/replaceweblogicjtatransactionmanager"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.spring.framework.ReplaceWebLogicLoadTimeWeaver:
       name: "com.oracle.weblogic.rewrite.spring.framework.ReplaceWebLogicLoadTimeWeaver"
@@ -32890,7 +33089,7 @@ rewrite-third-party:
         \ Spring Framework 6.2.x."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/spring/framework/replaceweblogicloadtimeweaver"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     com.oracle.weblogic.rewrite.spring.framework.UpgradeToSpringFramework_6_2:
       name: "com.oracle.weblogic.rewrite.spring.framework.UpgradeToSpringFramework_6_2"
@@ -32898,84 +33097,84 @@ rewrite-third-party:
         \ with WebLogic 15.1.1."
       docLink: "https://docs.openrewrite.org/recipes/com/oracle/weblogic/rewrite/spring/framework/upgradetospringframework_6_2"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel40.CamelQuarkusMigrationRecipe"
       description: "Migrate `camel3` quarkus application to `camel4` quarkus."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel40/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel410.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel410.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.9` quarkus application to `camel 4.10`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel410/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel411.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel411.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.10` quarkus application to `camel 4.11`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel411/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel412.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel412.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.11` quarkus application to `camel 4.12`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel412/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel413.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel413.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.12` Quarkus application to `camel 4.13`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel413/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel414.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel414.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.13` Quarkus application to `camel 4.14`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel414/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel415.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel415.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.14` Quarkus application to `camel 4.15`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel415/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel44.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel44.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.0` quarkus application to `camel 4.4`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel44/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel47.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel47.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.4` quarkus application to `camel 4.8`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel47/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel49.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel49.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.8` quarkus application to `camel 4.9`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/camel/camel49/camelquarkusmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.AdditionalChanges:
       name: "io.quarkus.updates.core.quarkus30.AdditionalChanges"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/additionalchanges"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.AdjustApplicationPropertiesWithJakarta:
       name: "io.quarkus.updates.core.quarkus30.AdjustApplicationPropertiesWithJakarta"
@@ -33003,14 +33202,14 @@ rewrite-third-party:
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/applicationproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.ApplicationYml:
       name: "io.quarkus.updates.core.quarkus30.ApplicationYml"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/applicationyml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.ChangeJavaxAnnotationToJakarta:
       name: "io.quarkus.updates.core.quarkus30.ChangeJavaxAnnotationToJakarta"
@@ -33018,7 +33217,7 @@ rewrite-third-party:
         \ relocation. Excludes `javax.annotation.processing`."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/changejavaxannotationtojakarta"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JacksonJavaxToJakarta:
       name: "io.quarkus.updates.core.quarkus30.JacksonJavaxToJakarta"
@@ -33027,7 +33226,7 @@ rewrite-third-party:
         \ with Jakarta EE.\n"
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/jacksonjavaxtojakarta"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxActivationMigrationToJakartaActivation:
       name: "io.quarkus.updates.core.quarkus30.JavaxActivationMigrationToJakartaActivation"
@@ -33035,7 +33234,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxactivationmigrationtojakartaactivation"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxAnnotationMigrationToJakartaAnnotation:
       name: "io.quarkus.updates.core.quarkus30.JavaxAnnotationMigrationToJakartaAnnotation"
@@ -33043,14 +33242,14 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxannotationmigrationtojakartaannotation"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxAnnotationPackageToJakarta:
       name: "io.quarkus.updates.core.quarkus30.JavaxAnnotationPackageToJakarta"
       description: "Change type of classes in the `javax.annotation` package to jakarta."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxannotationpackagetojakarta"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxAnnotationSecurityPackageToJakarta:
       name: "io.quarkus.updates.core.quarkus30.JavaxAnnotationSecurityPackageToJakarta"
@@ -33058,7 +33257,7 @@ rewrite-third-party:
         \ to jakarta."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxannotationsecuritypackagetojakarta"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxAnnotationSqlPackageToJakarta:
       name: "io.quarkus.updates.core.quarkus30.JavaxAnnotationSqlPackageToJakarta"
@@ -33066,7 +33265,7 @@ rewrite-third-party:
         \ jakarta."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxannotationsqlpackagetojakarta"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxAuthenticationMigrationToJakartaAuthentication:
       name: "io.quarkus.updates.core.quarkus30.JavaxAuthenticationMigrationToJakartaAuthentication"
@@ -33074,7 +33273,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxauthenticationmigrationtojakartaauthentication"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxAuthorizationMigrationToJakartaAuthorization:
       name: "io.quarkus.updates.core.quarkus30.JavaxAuthorizationMigrationToJakartaAuthorization"
@@ -33082,7 +33281,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxauthorizationmigrationtojakartaauthorization"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxBatchMigrationToJakartaBatch:
       name: "io.quarkus.updates.core.quarkus30.JavaxBatchMigrationToJakartaBatch"
@@ -33090,14 +33289,14 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxbatchmigrationtojakartabatch"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxConfigurationFiles:
       name: "io.quarkus.updates.core.quarkus30.JavaxConfigurationFiles"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxconfigurationfiles"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxDecoratorToJakartaDecorator:
       name: "io.quarkus.updates.core.quarkus30.JavaxDecoratorToJakartaDecorator"
@@ -33105,7 +33304,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxdecoratortojakartadecorator"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxEjbToJakartaEjb:
       name: "io.quarkus.updates.core.quarkus30.JavaxEjbToJakartaEjb"
@@ -33113,7 +33312,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxejbtojakartaejb"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxElToJakartaEl:
       name: "io.quarkus.updates.core.quarkus30.JavaxElToJakartaEl"
@@ -33121,7 +33320,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxeltojakartael"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxEnterpriseToJakartaEnterprise:
       name: "io.quarkus.updates.core.quarkus30.JavaxEnterpriseToJakartaEnterprise"
@@ -33129,7 +33328,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxenterprisetojakartaenterprise"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxFacesToJakartaFaces:
       name: "io.quarkus.updates.core.quarkus30.JavaxFacesToJakartaFaces"
@@ -33137,7 +33336,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxfacestojakartafaces"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxInjectMigrationToJakartaInject:
       name: "io.quarkus.updates.core.quarkus30.JavaxInjectMigrationToJakartaInject"
@@ -33145,7 +33344,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxinjectmigrationtojakartainject"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxInterceptorToJakartaInterceptor:
       name: "io.quarkus.updates.core.quarkus30.JavaxInterceptorToJakartaInterceptor"
@@ -33153,7 +33352,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxinterceptortojakartainterceptor"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxJmsToJakartaJms:
       name: "io.quarkus.updates.core.quarkus30.JavaxJmsToJakartaJms"
@@ -33161,7 +33360,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxjmstojakartajms"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxJsonToJakartaJson:
       name: "io.quarkus.updates.core.quarkus30.JavaxJsonToJakartaJson"
@@ -33169,7 +33368,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxjsontojakartajson"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxJwsToJakartaJws:
       name: "io.quarkus.updates.core.quarkus30.JavaxJwsToJakartaJws"
@@ -33177,7 +33376,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxjwstojakartajws"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxMailToJakartaMail:
       name: "io.quarkus.updates.core.quarkus30.JavaxMailToJakartaMail"
@@ -33185,7 +33384,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxmailtojakartamail"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxPersistenceToJakartaPersistence:
       name: "io.quarkus.updates.core.quarkus30.JavaxPersistenceToJakartaPersistence"
@@ -33193,7 +33392,7 @@ rewrite-third-party:
         \ relocation"
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxpersistencetojakartapersistence"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxPersistenceXmlToJakartaPersistenceXml:
       name: "io.quarkus.updates.core.quarkus30.JavaxPersistenceXmlToJakartaPersistenceXml"
@@ -33201,7 +33400,7 @@ rewrite-third-party:
         \ namespace relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxpersistencexmltojakartapersistencexml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxResourceToJakartaResource:
       name: "io.quarkus.updates.core.quarkus30.JavaxResourceToJakartaResource"
@@ -33209,7 +33408,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxresourcetojakartaresource"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxSecurityToJakartaSecurity:
       name: "io.quarkus.updates.core.quarkus30.JavaxSecurityToJakartaSecurity"
@@ -33217,7 +33416,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxsecuritytojakartasecurity"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxServletToJakartaServlet:
       name: "io.quarkus.updates.core.quarkus30.JavaxServletToJakartaServlet"
@@ -33225,63 +33424,63 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxservlettojakartaservlet"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxToJakartaAdditionalMigration:
       name: "io.quarkus.updates.core.quarkus30.JavaxToJakartaAdditionalMigration"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtojakartaadditionalmigration"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxToJakartaCodestarts:
       name: "io.quarkus.updates.core.quarkus30.JavaxToJakartaCodestarts"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtojakartacodestarts"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxToJakartaCodestartsTests:
       name: "io.quarkus.updates.core.quarkus30.JavaxToJakartaCodestartsTests"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtojakartacodestartstests"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxToJakartaDocumentationAdoc:
       name: "io.quarkus.updates.core.quarkus30.JavaxToJakartaDocumentationAdoc"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtojakartadocumentationadoc"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxToJakartaDocumentationMd:
       name: "io.quarkus.updates.core.quarkus30.JavaxToJakartaDocumentationMd"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtojakartadocumentationmd"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxToJakartaKotlin:
       name: "io.quarkus.updates.core.quarkus30.JavaxToJakartaKotlin"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtojakartakotlin"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxToJakartaKotlinCodestarts:
       name: "io.quarkus.updates.core.quarkus30.JavaxToJakartaKotlinCodestarts"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtojakartakotlincodestarts"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxToJakartaKotlinCodestartsTests:
       name: "io.quarkus.updates.core.quarkus30.JavaxToJakartaKotlinCodestartsTests"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtojakartakotlincodestartstests"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxTransactionMigrationToJakartaTransaction:
       name: "io.quarkus.updates.core.quarkus30.JavaxTransactionMigrationToJakartaTransaction"
@@ -33289,7 +33488,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxtransactionmigrationtojakartatransaction"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxValidationMigrationToJakartaValidation:
       name: "io.quarkus.updates.core.quarkus30.JavaxValidationMigrationToJakartaValidation"
@@ -33297,7 +33496,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxvalidationmigrationtojakartavalidation"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxWebsocketToJakartaWebsocket:
       name: "io.quarkus.updates.core.quarkus30.JavaxWebsocketToJakartaWebsocket"
@@ -33305,7 +33504,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxwebsockettojakartawebsocket"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxWsToJakartaWs:
       name: "io.quarkus.updates.core.quarkus30.JavaxWsToJakartaWs"
@@ -33313,7 +33512,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxwstojakartaws"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxXmlBindMigrationToJakartaXmlBind:
       name: "io.quarkus.updates.core.quarkus30.JavaxXmlBindMigrationToJakartaXmlBind"
@@ -33321,7 +33520,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxxmlbindmigrationtojakartaxmlbind"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxXmlSoapToJakartaXmlSoap:
       name: "io.quarkus.updates.core.quarkus30.JavaxXmlSoapToJakartaXmlSoap"
@@ -33329,7 +33528,7 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxxmlsoaptojakartaxmlsoap"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.JavaxXmlWsMigrationToJakartaXmlWs:
       name: "io.quarkus.updates.core.quarkus30.JavaxXmlWsMigrationToJakartaXmlWs"
@@ -33337,21 +33536,21 @@ rewrite-third-party:
         \ relocation."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/javaxxmlwsmigrationtojakartaxmlws"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.Kotlin:
       name: "io.quarkus.updates.core.quarkus30.Kotlin"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/kotlin"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.RenameJavaxServiceFiles:
       name: "io.quarkus.updates.core.quarkus30.RenameJavaxServiceFiles"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/renamejavaxservicefiles"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.RestAssuredJavaxToJakarta:
       name: "io.quarkus.updates.core.quarkus30.RestAssuredJavaxToJakarta"
@@ -33360,21 +33559,21 @@ rewrite-third-party:
         \ with Jakarta EE.\n"
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/restassuredjavaxtojakarta"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse:
       name: "io.quarkus.updates.core.quarkus30.UpgradeQuarkiverse"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus30/upgradequarkiverse"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus31.RemoveMockitoInline:
       name: "io.quarkus.updates.core.quarkus31.RemoveMockitoInline"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus31/removemockitoinline"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.AdjustPackageProperty:
       name: "io.quarkus.updates.core.quarkus310.AdjustPackageProperty"
@@ -33388,294 +33587,294 @@ rewrite-third-party:
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/flywaydb2"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.FlywayDerby:
       name: "io.quarkus.updates.core.quarkus310.FlywayDerby"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/flywayderby"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.FlywayPostgreSQL:
       name: "io.quarkus.updates.core.quarkus310.FlywayPostgreSQL"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/flywaypostgresql"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.SyncHibernateJpaModelgenVersionWithBOM:
       name: "io.quarkus.updates.core.quarkus310.SyncHibernateJpaModelgenVersionWithBOM"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/synchibernatejpamodelgenversionwithbom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.UpdateConfigPackagePom:
       name: "io.quarkus.updates.core.quarkus310.UpdateConfigPackagePom"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/updateconfigpackagepom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.UpdateConfigPackageSimpleProperties:
       name: "io.quarkus.updates.core.quarkus310.UpdateConfigPackageSimpleProperties"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/updateconfigpackagesimpleproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeFastJar:
       name: "io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeFastJar"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/updateconfigpackagetypefastjar"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeJar:
       name: "io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeJar"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/updateconfigpackagetypejar"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeMutableJar:
       name: "io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeMutableJar"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/updateconfigpackagetypemutablejar"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeNative:
       name: "io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeNative"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/updateconfigpackagetypenative"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeNativeSources:
       name: "io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeNativeSources"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/updateconfigpackagetypenativesources"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeUberJar:
       name: "io.quarkus.updates.core.quarkus310.UpdateConfigPackageTypeUberJar"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus310/updateconfigpackagetypeuberjar"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus311.SyncHibernateJpaModelgenVersionWithBOM:
       name: "io.quarkus.updates.core.quarkus311.SyncHibernateJpaModelgenVersionWithBOM"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus311/synchibernatejpamodelgenversionwithbom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus312.SyncHibernateJpaModelgenVersionWithBOM:
       name: "io.quarkus.updates.core.quarkus312.SyncHibernateJpaModelgenVersionWithBOM"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus312/synchibernatejpamodelgenversionwithbom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus313.SyncHibernateJpaModelgenVersionWithBOM:
       name: "io.quarkus.updates.core.quarkus313.SyncHibernateJpaModelgenVersionWithBOM"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus313/synchibernatejpamodelgenversionwithbom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus313.UpdateTestOIDCAuthServerUrl:
       name: "io.quarkus.updates.core.quarkus313.UpdateTestOIDCAuthServerUrl"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus313/updatetestoidcauthserverurl"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus318.RemoveFlywayCleanOnValidationError:
       name: "io.quarkus.updates.core.quarkus318.RemoveFlywayCleanOnValidationError"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus318/removeflywaycleanonvalidationerror"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus319.ConfigurationPropertiesChange:
       name: "io.quarkus.updates.core.quarkus319.ConfigurationPropertiesChange"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus319/configurationpropertieschange"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus319.HibernateORMValidationMode:
       name: "io.quarkus.updates.core.quarkus319.HibernateORMValidationMode"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus319/hibernateormvalidationmode"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus319.MoveAccessTokenAnnotationToNewPackage:
       name: "io.quarkus.updates.core.quarkus319.MoveAccessTokenAnnotationToNewPackage"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus319/moveaccesstokenannotationtonewpackage"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus32.ApplicationProperties:
       name: "io.quarkus.updates.core.quarkus32.ApplicationProperties"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus32/applicationproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus32.ApplicationYml:
       name: "io.quarkus.updates.core.quarkus32.ApplicationYml"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus32/applicationyml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus32.InjectMock:
       name: "io.quarkus.updates.core.quarkus32.InjectMock"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus32/injectmock"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus321.TlsRegistrySplitPackagesFix:
       name: "io.quarkus.updates.core.quarkus321.TlsRegistrySplitPackagesFix"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus321/tlsregistrysplitpackagesfix"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus323.HibernateORMSchemaManagementProperties:
       name: "io.quarkus.updates.core.quarkus323.HibernateORMSchemaManagementProperties"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus323/hibernateormschemamanagementproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus324.AddHibernateAnnotationProcessorIfNewJpaModelgenDependency:
       name: "io.quarkus.updates.core.quarkus324.AddHibernateAnnotationProcessorIfNewJpaModelgenDependency"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus324/addhibernateannotationprocessorifnewjpamodelgendependency"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus324.AddHibernateAnnotationProcessorIfOldJpaModelgenDependency:
       name: "io.quarkus.updates.core.quarkus324.AddHibernateAnnotationProcessorIfOldJpaModelgenDependency"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus324/addhibernateannotationprocessorifoldjpamodelgendependency"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus324.LogConsoleAsyncEnable:
       name: "io.quarkus.updates.core.quarkus324.LogConsoleAsyncEnable"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus324/logconsoleasyncenable"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus324.MigrateFromHibernateOrmSessionMethodsRemovedIn7:
       name: "io.quarkus.updates.core.quarkus324.MigrateFromHibernateOrmSessionMethodsRemovedIn7"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus324/migratefromhibernateormsessionmethodsremovedin7"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus324.MigrateFromHibernateOrmVariousRemovedIn7:
       name: "io.quarkus.updates.core.quarkus324.MigrateFromHibernateOrmVariousRemovedIn7"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus324/migratefromhibernateormvariousremovedin7"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus324.RemoveJpaModelgenDependencies:
       name: "io.quarkus.updates.core.quarkus324.RemoveJpaModelgenDependencies"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus324/removejpamodelgendependencies"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus324.ReplaceNewJpaModelgenAnnotationProcessor:
       name: "io.quarkus.updates.core.quarkus324.ReplaceNewJpaModelgenAnnotationProcessor"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus324/replacenewjpamodelgenannotationprocessor"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus324.ReplaceOldJpaModelgenAnnotationProcessor:
       name: "io.quarkus.updates.core.quarkus324.ReplaceOldJpaModelgenAnnotationProcessor"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus324/replaceoldjpamodelgenannotationprocessor"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus326.EnableEnabledConfigChanges:
       name: "io.quarkus.updates.core.quarkus326.EnableEnabledConfigChanges"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus326/enableenabledconfigchanges"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus33.ApplicationProperties:
       name: "io.quarkus.updates.core.quarkus33.ApplicationProperties"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus33/applicationproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus33.ApplicationYml:
       name: "io.quarkus.updates.core.quarkus33.ApplicationYml"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus33/applicationyml"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus33.GraalVMSubstitutionsArtifact:
       name: "io.quarkus.updates.core.quarkus33.GraalVMSubstitutionsArtifact"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus33/graalvmsubstitutionsartifact"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus35.MutinyUniAndGroupCombinedWith:
       name: "io.quarkus.updates.core.quarkus35.MutinyUniAndGroupCombinedWith"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus35/mutinyuniandgroupcombinedwith"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus35.MutinyUniMemoizeAtLeast:
       name: "io.quarkus.updates.core.quarkus35.MutinyUniMemoizeAtLeast"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus35/mutinyunimemoizeatleast"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus36.JaegerSmallRyeOpenTracing:
       name: "io.quarkus.updates.core.quarkus36.JaegerSmallRyeOpenTracing"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus36/jaegersmallryeopentracing"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.AddJpaModelgenAnnotationProcessor:
       name: "io.quarkus.updates.core.quarkus37.AddJpaModelgenAnnotationProcessor"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/addjpamodelgenannotationprocessor"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.AddJpaModelgenAnnotationProcessorIfOldArtifact:
       name: "io.quarkus.updates.core.quarkus37.AddJpaModelgenAnnotationProcessorIfOldArtifact"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/addjpamodelgenannotationprocessorifoldartifact"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.AddMavenCompilerAnnotationProcessor:
       name: "io.quarkus.updates.core.quarkus37.AddMavenCompilerAnnotationProcessor"
@@ -33736,21 +33935,21 @@ rewrite-third-party:
       description: "The `javax.security.cert` package has been deprecated for removal."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/deprecatedjavaxsecuritycert"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.DeprecatedLogRecordThreadID:
       name: "io.quarkus.updates.core.quarkus37.DeprecatedLogRecordThreadID"
       description: "Avoid using the deprecated methods in `java.util.logging.LogRecord`"
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/deprecatedlogrecordthreadid"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.HibernateSearchOutboxPolling:
       name: "io.quarkus.updates.core.quarkus37.HibernateSearchOutboxPolling"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/hibernatesearchoutboxpolling"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.JavaVersion17:
       name: "io.quarkus.updates.core.quarkus37.JavaVersion17"
@@ -33758,28 +33957,28 @@ rewrite-third-party:
         \ to 17."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/javaversion17"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.Jre17AgentMainPreMainPublic:
       name: "io.quarkus.updates.core.quarkus37.Jre17AgentMainPreMainPublic"
       description: "Check for a behavior change in Java agents."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/jre17agentmainpremainpublic"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.MavenPlugins:
       name: "io.quarkus.updates.core.quarkus37.MavenPlugins"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/mavenplugins"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.RemoveJpaModelgenDependencies:
       name: "io.quarkus.updates.core.quarkus37.RemoveJpaModelgenDependencies"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/removejpamodelgendependencies"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.RemovedLegacySunJSSEProviderName:
       name: "io.quarkus.updates.core.quarkus37.RemovedLegacySunJSSEProviderName"
@@ -33787,21 +33986,21 @@ rewrite-third-party:
         \ removed."
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/removedlegacysunjsseprovidername"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.ReplaceJpaModelgenAnnotationProcessor:
       name: "io.quarkus.updates.core.quarkus37.ReplaceJpaModelgenAnnotationProcessor"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/replacejpamodelgenannotationprocessor"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.ResteasyClientRenaming:
       name: "io.quarkus.updates.core.quarkus37.ResteasyClientRenaming"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/resteasyclientrenaming"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.SetupJavaUpgradeJavaVersion:
       name: "io.quarkus.updates.core.quarkus37.SetupJavaUpgradeJavaVersion"
@@ -33819,7 +34018,7 @@ rewrite-third-party:
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/synchibernatejpamodelgenversionwithbom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus37.SyncMavenCompilerAnnotationProcessorVersion:
       name: "io.quarkus.updates.core.quarkus37.SyncMavenCompilerAnnotationProcessorVersion"
@@ -33860,35 +34059,35 @@ rewrite-third-party:
         \ be also be upgraded to versions that are compatible with Java 17.\n"
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus37/upgradetojava17"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus38.SyncHibernateJpaModelgenVersionWithBOM:
       name: "io.quarkus.updates.core.quarkus38.SyncHibernateJpaModelgenVersionWithBOM"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus38/synchibernatejpamodelgenversionwithbom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus383.GraalSDK:
       name: "io.quarkus.updates.core.quarkus383.GraalSDK"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus383/graalsdk"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus39.GraalSDK:
       name: "io.quarkus.updates.core.quarkus39.GraalSDK"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus39/graalsdk"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus39.Relocations:
       name: "io.quarkus.updates.core.quarkus39.Relocations"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus39/relocations"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus39.RemoveMavenCompilerAnnotationProcessor:
       name: "io.quarkus.updates.core.quarkus39.RemoveMavenCompilerAnnotationProcessor"
@@ -33912,35 +34111,35 @@ rewrite-third-party:
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus39/removepanacheannotationprocessor"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus39.SyncHibernateJpaModelgenVersionWithBOM:
       name: "io.quarkus.updates.core.quarkus39.SyncHibernateJpaModelgenVersionWithBOM"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus39/synchibernatejpamodelgenversionwithbom"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus39.UpdateConfigRoots:
       name: "io.quarkus.updates.core.quarkus39.UpdateConfigRoots"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/core/quarkus39/updateconfigroots"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.minio.minio38.UpdateAll:
       name: "io.quarkus.updates.minio.minio38.UpdateAll"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/minio/minio38/updateall"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.minio.minio38.UpdateProperties:
       name: "io.quarkus.updates.minio.minio38.UpdateProperties"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/io/quarkus/updates/minio/minio38/updateproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     io.quarkus.updates.quarkiverse.minio.minio38.AdjustURLPropertyValue:
       name: "io.quarkus.updates.quarkiverse.minio.minio38.AdjustURLPropertyValue"
@@ -33954,14 +34153,14 @@ rewrite-third-party:
       description: "Migrates Apache Camel application to 4.10.6."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel410ltsmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.CamelMigrationRecipe"
       description: "Migrates Apache Camel application to 4.14.0."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.JavaVersion17:
       name: "org.apache.camel.upgrade.JavaVersion17"
@@ -33969,7 +34168,7 @@ rewrite-third-party:
         \ to 17."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/javaversion17"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.SetupJavaUpgradeJavaVersion:
       name: "org.apache.camel.upgrade.SetupJavaUpgradeJavaVersion"
@@ -33987,7 +34186,7 @@ rewrite-third-party:
       description: "Update properties and yaml configurations file."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/updatepropertiesandyamlkeys"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.UpgradeJavaVersion:
       name: "org.apache.camel.upgrade.UpgradeJavaVersion"
@@ -34014,42 +34213,42 @@ rewrite-third-party:
         \ be also be upgraded to versions that are compatible with Java 17.\n"
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/upgradetojava17"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel40.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel40.CamelMigrationRecipe"
       description: "Migrate `camel3` application to `camel4`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel40/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel40.ChangeManagedChoiceMBeanMethodName:
       name: "org.apache.camel.upgrade.camel40.ChangeManagedChoiceMBeanMethodName"
       description: "MBeans now use a consistent method name of `extendedInformation`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel40/changemanagedchoicembeanmethodname"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel40.ChangeManagedFailoverLoadBalancerMBeanMethodName:
       name: "org.apache.camel.upgrade.camel40.ChangeManagedFailoverLoadBalancerMBeanMethodName"
       description: "MBeans now use a consistent method name of `extendedInformation`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel40/changemanagedfailoverloadbalancermbeanmethodname"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel40.ChangeTypes:
       name: "org.apache.camel.upgrade.camel40.ChangeTypes"
       description: "Change type of classes related to change of API."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel40/changetypes"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel40.UsePluginHelperForContextGetters:
       name: "org.apache.camel.upgrade.camel40.UsePluginHelperForContextGetters"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel40/usepluginhelperforcontextgetters"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel40.java.CamelAPIsRecipe:
       name: "org.apache.camel.upgrade.camel40.java.CamelAPIsRecipe"
@@ -34087,7 +34286,7 @@ rewrite-third-party:
         \ Removal of deprecated APIs, which could be part of the application.properties."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel40/properties/rejectedpolicy"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel40.xml.CircuitBreakerXmlDslRecipe:
       name: "org.apache.camel.upgrade.camel40.xml.CircuitBreakerXmlDslRecipe"
@@ -34134,7 +34333,7 @@ rewrite-third-party:
         \ Instead, use constants from the TagConstants."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel41/tracingtag"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel41.XmlDslRecipe:
       name: "org.apache.camel.upgrade.camel41.XmlDslRecipe"
@@ -34156,7 +34355,7 @@ rewrite-third-party:
       description: "Migrates `camel 4.9` application to `camel 4.10`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel410/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel410.XmlDsl410Recipe:
       name: "org.apache.camel.upgrade.camel410.XmlDsl410Recipe"
@@ -34170,28 +34369,28 @@ rewrite-third-party:
       description: "Renamed constants in camel-azure-files."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel410/camelazurefiles"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel410.camelSmb:
       name: "org.apache.camel.upgrade.camel410.camelSmb"
       description: "Renamed constants in camel-smb."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel410/camelsmb"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel410_4.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel410_4.CamelMigrationRecipe"
       description: "Migrates `camel 4.10.3` application to `camel 4.10.4`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel410_4/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel411.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel411.CamelMigrationRecipe"
       description: "Migrates `camel 4.10` application to `camel 4.11`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel411/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel411.platformHttpFilterStrategy:
       name: "org.apache.camel.upgrade.camel411.platformHttpFilterStrategy"
@@ -34199,28 +34398,28 @@ rewrite-third-party:
         \ instead."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel411/platformhttpfilterstrategy"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel411.removedDependencies:
       name: "org.apache.camel.upgrade.camel411.removedDependencies"
       description: "Removed deprecated components (camel-etcd3)."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel411/removeddependencies"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel411.removedLightweight:
       name: "org.apache.camel.upgrade.camel411.removedLightweight"
       description: "Removed deprecated configuration properties (camel.main.lightweight)."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel411/removedlightweight"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel412.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel412.CamelMigrationRecipe"
       description: "Migrates `camel 4.11` application to `camel 4.12`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel412/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel412.Java412Recipes:
       name: "org.apache.camel.upgrade.camel412.Java412Recipes"
@@ -34235,7 +34434,7 @@ rewrite-third-party:
         \ JAR and moved to a new package - java."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel412/scanclassesmoved"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel412.scanClassesMovedMaven:
       name: "org.apache.camel.upgrade.camel412.scanClassesMovedMaven"
@@ -34243,7 +34442,7 @@ rewrite-third-party:
         \ JAR and moved to a new package - maven."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel412/scanclassesmovedmaven"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel412.xmlDslBearer:
       name: "org.apache.camel.upgrade.camel412.xmlDslBearer"
@@ -34252,7 +34451,7 @@ rewrite-third-party:
         \ DSL."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel412/xmldslbearer"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel412.yamlDslBearer:
       name: "org.apache.camel.upgrade.camel412.yamlDslBearer"
@@ -34261,14 +34460,14 @@ rewrite-third-party:
         \ DSL."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel412/yamldslbearer"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel413.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel413.CamelMigrationRecipe"
       description: "Migrates `camel 4.12` application to `camel 4.13`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel413/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel413.YamlDsl413Recipe:
       name: "org.apache.camel.upgrade.camel413.YamlDsl413Recipe"
@@ -34282,35 +34481,35 @@ rewrite-third-party:
       description: "BasicAuthenticationHttpClientConfigurer is renamed to DefaultAuthenticationHttpClientConfigurer."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel413/authenticationhttpclientconfigurer"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel413.furyDependency:
       name: "org.apache.camel.upgrade.camel413.furyDependency"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel413/furydependency"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel413.furyDsl:
       name: "org.apache.camel.upgrade.camel413.furyDsl"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel413/furydsl"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel413.furyJava:
       name: "org.apache.camel.upgrade.camel413.furyJava"
       description: "BasicAuthenticationHttpClientConfigurer is renamed to DefaultAuthenticationHttpClientConfigurer."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel413/furyjava"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel414.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel414.CamelMigrationRecipe"
       description: "Migrates `camel 4.13` application to `camel 4.14`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel414/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel414.httpBusinessVsManagementServicesSeparationProperties:
       name: "org.apache.camel.upgrade.camel414.httpBusinessVsManagementServicesSeparationProperties"
@@ -34319,28 +34518,28 @@ rewrite-third-party:
         \ in application.properties should be changed from camel.server.xxx to camel.management.xxx."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel414/httpbusinessvsmanagementservicesseparationproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel415.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel415.CamelMigrationRecipe"
       description: "Migrates `camel 4.14` application to `camel 4.15`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel415/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel415.aiNestedHeadersClasses:
       name: "org.apache.camel.upgrade.camel415.aiNestedHeadersClasses"
       description: "Changed types of camel AI nested headers classes."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel415/ainestedheadersclasses"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel415.dataFormats:
       name: "org.apache.camel.upgrade.camel415.dataFormats"
       description: "Refactored dataFormats."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel415/dataformats"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel415.nettyAndNettyHttp:
       name: "org.apache.camel.upgrade.camel415.nettyAndNettyHttp"
@@ -34348,28 +34547,28 @@ rewrite-third-party:
         \ value."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel415/nettyandnettyhttp"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel415.xmlDataFormats:
       name: "org.apache.camel.upgrade.camel415.xmlDataFormats"
       description: "Refactored dataFormats (XML DSL)."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel415/xmldataformats"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel415.yamDataFormats:
       name: "org.apache.camel.upgrade.camel415.yamDataFormats"
       description: "Refactored dataFormats (YAML DSL)."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel415/yamdataformats"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel42.CamelMainDebugger:
       name: "org.apache.camel.upgrade.camel42.CamelMainDebugger"
       description: "The option camel.main.debugger has been renamed to camel.debug.enabled."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel42/camelmaindebugger"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel42.CamelSagaRecipe:
       name: "org.apache.camel.upgrade.camel42.CamelSagaRecipe"
@@ -34399,7 +34598,7 @@ rewrite-third-party:
         \ method for metadata changed."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel43/kafkametadata"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel43.StateRepository:
       name: "org.apache.camel.upgrade.camel43.StateRepository"
@@ -34407,7 +34606,7 @@ rewrite-third-party:
         \ camel-base-engine to  camel-support."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel43/staterepository"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel44.CamelCoreRecipe:
       name: "org.apache.camel.upgrade.camel44.CamelCoreRecipe"
@@ -34421,56 +34620,56 @@ rewrite-third-party:
       description: "Migrates `camel 4.0` application to `camel 4.4`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel44/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel44.DefaultJsonSchemaLoader:
       name: "org.apache.camel.upgrade.camel44.DefaultJsonSchemaLoader"
       description: "Replaces deprecated class with its successor."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel44/defaultjsonschemaloader"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel44.RouteControllerProperties:
       name: "org.apache.camel.upgrade.camel44.RouteControllerProperties"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel44/routecontrollerproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel45.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel45.CamelMigrationRecipe"
       description: "Migrates `camel 4.4` application to `camel 4.5`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel45/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel45.TraceProperties:
       name: "org.apache.camel.upgrade.camel45.TraceProperties"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel45/traceproperties"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel45.UseExtendedCamelContextGetters:
       name: "org.apache.camel.upgrade.camel45.UseExtendedCamelContextGetters"
       description: ""
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel45/useextendedcamelcontextgetters"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel45.renamedClasses:
       name: "org.apache.camel.upgrade.camel45.renamedClasses"
       description: "Renamed classes for elasticsearch,opensearch and spring regis."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel45/renamedclasses"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel46.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel46.CamelMigrationRecipe"
       description: "Migrates `camel 4.5` application to `camel 4.6`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel46/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel46.XmlDsl46Recipe:
       name: "org.apache.camel.upgrade.camel46.XmlDsl46Recipe"
@@ -34492,28 +34691,28 @@ rewrite-third-party:
       description: "Renamed classes for elasticsearch,opensearch and spring regis."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel46/renamedclasses"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel46.renamedDependencies:
       name: "org.apache.camel.upgrade.camel46.renamedDependencies"
       description: "Renamed dependencies."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel46/renameddependencies"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel46.yamStreamCaching:
       name: "org.apache.camel.upgrade.camel46.yamStreamCaching"
       description: "Renamed streamCaching to streamCache on the route."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel46/yamstreamcaching"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel47.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel47.CamelMigrationRecipe"
       description: "Migrates `camel 4.6` application to `camel 4.7`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel47/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel47.Java47Recipes:
       name: "org.apache.camel.upgrade.camel47.Java47Recipes"
@@ -34543,14 +34742,14 @@ rewrite-third-party:
         \ camel-cloudevents."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel47/removeddependencies"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel47.renamedClasses:
       name: "org.apache.camel.upgrade.camel47.renamedClasses"
       description: "Renamed classes for API."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel47/renamedclasses"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel49.AwsSecretRecipe:
       name: "org.apache.camel.upgrade.camel49.AwsSecretRecipe"
@@ -34558,7 +34757,7 @@ rewrite-third-party:
         \ changed.."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel49/awssecretrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel49.AzureSecretRecipe:
       name: "org.apache.camel.upgrade.camel49.AzureSecretRecipe"
@@ -34566,14 +34765,14 @@ rewrite-third-party:
         \ changed.."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel49/azuresecretrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel49.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel49.CamelMigrationRecipe"
       description: "Migrates `camel 4.8` application to `camel 4.9`."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel49/camelmigrationrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel49.DebeziumChangeTypes:
       name: "org.apache.camel.upgrade.camel49.DebeziumChangeTypes"
@@ -34583,7 +34782,7 @@ rewrite-third-party:
         \ instead of having everything under the root package org.apache.camel.component.debezium."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel49/debeziumchangetypes"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel49.GcpSecretRecipe:
       name: "org.apache.camel.upgrade.camel49.GcpSecretRecipe"
@@ -34591,7 +34790,7 @@ rewrite-third-party:
         \ changed.."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel49/gcpsecretrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel49.HashicorpSecretRecipe:
       name: "org.apache.camel.upgrade.camel49.HashicorpSecretRecipe"
@@ -34599,7 +34798,7 @@ rewrite-third-party:
         \ changed.."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel49/hashicorpsecretrecipe"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel49.removedDependencies:
       name: "org.apache.camel.upgrade.camel49.removedDependencies"
@@ -34607,14 +34806,14 @@ rewrite-third-party:
         \ camel-jsh-dsl, camel-kotlin-api, camel-kotlin-dsl)."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel49/removeddependencies"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel49.renamedAPIs:
       name: "org.apache.camel.upgrade.camel49.renamedAPIs"
       description: "Renamed classes for API."
       docLink: "https://docs.openrewrite.org/recipes/org/apache/camel/upgrade/camel49/renamedapis"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.customRecipes.ChangePropertyKeyWithCaseChange:
       name: "org.apache.camel.upgrade.customRecipes.ChangePropertyKeyWithCaseChange"
@@ -34749,6 +34948,14 @@ rewrite-third-party:
         required: true
       isImperative: true
       artifactId: "rewrite-third-party"
+    org.apache.logging.log4j.InlineLog4jApiMethods:
+      name: "org.apache.logging.log4j.InlineLog4jApiMethods"
+      description: "Automatically generated recipes to inline method calls based on\
+        \ `@InlineMe` annotations discovered in the type table."
+      docLink: "https://docs.openrewrite.org/recipes/org/apache/logging/log4j/inlinelog4japimethods"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
     org.apache.wicket.BestPractices:
       name: "org.apache.wicket.BestPractices"
       description: "Applies Wicket best practices such as minimizing anonymous inner\
@@ -34786,7 +34993,7 @@ rewrite-third-party:
         \ part of Camel 3.x."
       docLink: "https://docs.openrewrite.org/recipes/java/camel/migrate/removedextensions"
       options: []
-      isImperative: true
+      isImperative: false
       artifactId: "rewrite-third-party"
     org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0:
       name: "org.openrewrite.quarkus.MigrateToQuarkus_v3_0_0"
@@ -40513,11 +40720,12 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatBooleanArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatBooleanArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(boolean[] actual, Supplier<String>\
-        \ message, boolean[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(boolean[] actual, Supplier<String>\
-        \ message, boolean[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(boolean[] actual, Supplier<@Nullable String> message, boolean[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(boolean[] actual, Supplier<@Nullable String> message, boolean[]\
+        \ expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatbooleanarraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -40553,11 +40761,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatByteArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatByteArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(byte[] actual, Supplier<String>\
-        \ message, byte[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(byte[] actual, Supplier<String> message,\
-        \ byte[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(byte[] actual, Supplier<@Nullable String> message, byte[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(byte[] actual, Supplier<@Nullable String> message, byte[]\
+        \ expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatbytearraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -40593,11 +40802,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatCharArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatCharArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(char[] actual, Supplier<String>\
-        \ message, char[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(char[] actual, Supplier<String> message,\
-        \ char[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(char[] actual, Supplier<@Nullable String> message, char[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(char[] actual, Supplier<@Nullable String> message, char[]\
+        \ expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatchararraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -40637,13 +40847,15 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatCodeWithFailMessageSupplierDoesNotThrowAnyExceptionRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException\
-        \ {\n    \n    @BeforeTemplate\n    void before(Executable throwingCallable,\
-        \ Supplier<String> supplier) {\n        assertDoesNotThrow(throwingCallable,\
-        \ supplier);\n    }\n    \n    @BeforeTemplate\n    void before(ThrowingSupplier<?>\
-        \ throwingCallable, Supplier<String> supplier) {\n        assertDoesNotThrow(throwingCallable,\
-        \ supplier);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
-        \ = STATIC_IMPORT_ALWAYS)\n    void after(ThrowingCallable throwingCallable,\
-        \ Supplier<String> supplier) {\n        assertThatCode(throwingCallable).withFailMessage(supplier).doesNotThrowAnyException();\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(Executable throwingCallable, Supplier<@Nullable String>\
+        \ supplier) {\n        assertDoesNotThrow(throwingCallable, supplier);\n \
+        \   }\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(ThrowingSupplier<?> throwingCallable, Supplier<@Nullable\
+        \ String> supplier) {\n        assertDoesNotThrow(throwingCallable, supplier);\n\
+        \    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(ThrowingCallable throwingCallable, Supplier<@Nullable String>\
+        \ supplier) {\n        assertThatCode(throwingCallable).withFailMessage(supplier).doesNotThrowAnyException();\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatcodewithfailmessagesupplierdoesnotthrowanyexceptionrecipe"
       options: []
@@ -40708,11 +40920,12 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatDoubleArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatDoubleArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(double[] actual, Supplier<String>\
-        \ message, double[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(double[] actual, Supplier<String>\
-        \ message, double[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(double[] actual, Supplier<@Nullable String> message, double[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(double[] actual, Supplier<@Nullable String> message, double[]\
+        \ expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatdoublearraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -40722,11 +40935,12 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatDoubleArrayWithFailMessageSupplierContainsExactlyWithOffsetRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatDoubleArrayWithFailMessageSupplierContainsExactlyWithOffset\
-        \ {\n    \n    @BeforeTemplate\n    void before(double[] actual, Supplier<String>\
-        \ messageSupplier, double[] expected, double delta) {\n        assertArrayEquals(expected,\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(double[] actual, Supplier<@Nullable String> messageSupplier,\
+        \ double[] expected, double delta) {\n        assertArrayEquals(expected,\
         \ actual, delta, messageSupplier);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
-        \ = STATIC_IMPORT_ALWAYS)\n    void after(double[] actual, Supplier<String>\
-        \ messageSupplier, double[] expected, double delta) {\n        assertThat(actual).withFailMessage(messageSupplier).containsExactly(expected,\
+        \ = STATIC_IMPORT_ALWAYS)\n    void after(double[] actual, Supplier<@Nullable\
+        \ String> messageSupplier, double[] expected, double delta) {\n        assertThat(actual).withFailMessage(messageSupplier).containsExactly(expected,\
         \ offset(delta));\n    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatdoublearraywithfailmessagesuppliercontainsexactlywithoffsetrecipe"
       options: []
@@ -40791,11 +41005,12 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatFloatArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatFloatArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(float[] actual, Supplier<String>\
-        \ message, float[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(float[] actual, Supplier<String> message,\
-        \ float[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(float[] actual, Supplier<@Nullable String> message, float[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(float[] actual, Supplier<@Nullable String> message, float[]\
+        \ expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatfloatarraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -40805,11 +41020,12 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatFloatArrayWithFailMessageSupplierContainsExactlyWithOffsetRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatFloatArrayWithFailMessageSupplierContainsExactlyWithOffset\
-        \ {\n    \n    @BeforeTemplate\n    void before(float[] actual, Supplier<String>\
-        \ message, float[] expected, float delta) {\n        assertArrayEquals(expected,\
-        \ actual, delta, message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
-        \ = STATIC_IMPORT_ALWAYS)\n    void after(float[] actual, Supplier<String>\
-        \ message, float[] expected, float delta) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected,\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(float[] actual, Supplier<@Nullable String> message, float[]\
+        \ expected, float delta) {\n        assertArrayEquals(expected, actual, delta,\
+        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
+        \ STATIC_IMPORT_ALWAYS)\n    void after(float[] actual, Supplier<@Nullable\
+        \ String> message, float[] expected, float delta) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected,\
         \ offset(delta));\n    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatfloatarraywithfailmessagesuppliercontainsexactlywithoffsetrecipe"
       options: []
@@ -40844,11 +41060,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatIntArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatIntArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(int[] actual, Supplier<String>\
-        \ message, int[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(int[] actual, Supplier<String> message,\
-        \ int[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(int[] actual, Supplier<@Nullable String> message, int[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(int[] actual, Supplier<@Nullable String> message, int[] expected)\
+        \ {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatintarraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -40967,11 +41184,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatLongArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatLongArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(long[] actual, Supplier<String>\
-        \ message, long[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(long[] actual, Supplier<String> message,\
-        \ long[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(long[] actual, Supplier<@Nullable String> message, long[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(long[] actual, Supplier<@Nullable String> message, long[]\
+        \ expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatlongarraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -41008,11 +41226,12 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatObjectArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatObjectArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(Object[] actual, Supplier<String>\
-        \ message, Object[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(Object[] actual, Supplier<String>\
-        \ message, Object[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(Object[] actual, Supplier<@Nullable String> message, Object[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(Object[] actual, Supplier<@Nullable String> message, Object[]\
+        \ expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatobjectarraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -41049,11 +41268,12 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatShortArrayWithFailMessageSupplierContainsExactlyRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatShortArrayWithFailMessageSupplierContainsExactly\
-        \ {\n    \n    @BeforeTemplate\n    void before(short[] actual, Supplier<String>\
-        \ message, short[] expected) {\n        assertArrayEquals(expected, actual,\
-        \ message);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value =\
-        \ STATIC_IMPORT_ALWAYS)\n    void after(short[] actual, Supplier<String> message,\
-        \ short[] expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
+        \ {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\"\
+        )\n    void before(short[] actual, Supplier<@Nullable String> message, short[]\
+        \ expected) {\n        assertArrayEquals(expected, actual, message);\n   \
+        \ }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(short[] actual, Supplier<@Nullable String> message, short[]\
+        \ expected) {\n        assertThat(actual).withFailMessage(message).containsExactly(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatshortarraywithfailmessagesuppliercontainsexactlyrecipe"
       options: []
@@ -41119,12 +41339,12 @@ rewrite-third-party:
     : name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOfRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf<T\
-        \ extends Throwable> {\n    \n    @BeforeTemplate\n    void before(Executable\
-        \ throwingCallable, Supplier<String> supplier, Class<T> clazz) {\n       \
-        \ assertThrowsExactly(clazz, throwingCallable, supplier);\n    }\n    \n \
-        \   @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n \
-        \   void after(ThrowingCallable throwingCallable, Supplier<String> supplier,\
-        \ Class<T> clazz) {\n        assertThatThrownBy(throwingCallable).withFailMessage(supplier).isExactlyInstanceOf(clazz);\n\
+        \ extends Throwable> {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value\
+        \ = \"java:S4449\")\n    void before(Executable throwingCallable, Supplier<@Nullable\
+        \ String> supplier, Class<T> clazz) {\n        assertThrowsExactly(clazz,\
+        \ throwingCallable, supplier);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
+        \ = STATIC_IMPORT_ALWAYS)\n    void after(ThrowingCallable throwingCallable,\
+        \ Supplier<@Nullable String> supplier, Class<T> clazz) {\n        assertThatThrownBy(throwingCallable).withFailMessage(supplier).isExactlyInstanceOf(clazz);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatthrownbywithfailmessagesupplierisexactlyinstanceofrecipe"
       options: []
@@ -41134,12 +41354,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatThrownByWithFailMessageSupplierIsInstanceOfRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatThrownByWithFailMessageSupplierIsInstanceOf<T\
-        \ extends Throwable> {\n    \n    @BeforeTemplate\n    void before(Executable\
-        \ throwingCallable, Supplier<String> supplier, Class<T> clazz) {\n       \
-        \ assertThrows(clazz, throwingCallable, supplier);\n    }\n    \n    @AfterTemplate\n\
-        \    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n    void after(ThrowingCallable\
-        \ throwingCallable, Supplier<String> supplier, Class<T> clazz) {\n       \
-        \ assertThatThrownBy(throwingCallable).withFailMessage(supplier).isInstanceOf(clazz);\n\
+        \ extends Throwable> {\n    \n    @BeforeTemplate\n    @SuppressWarnings(value\
+        \ = \"java:S4449\")\n    void before(Executable throwingCallable, Supplier<@Nullable\
+        \ String> supplier, Class<T> clazz) {\n        assertThrows(clazz, throwingCallable,\
+        \ supplier);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
+        \ = STATIC_IMPORT_ALWAYS)\n    void after(ThrowingCallable throwingCallable,\
+        \ Supplier<@Nullable String> supplier, Class<T> clazz) {\n        assertThatThrownBy(throwingCallable).withFailMessage(supplier).isInstanceOf(clazz);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatthrownbywithfailmessagesupplierisinstanceofrecipe"
       options: []
@@ -41242,11 +41462,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatWithFailMessageSupplierIsFalseRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatWithFailMessageSupplierIsFalse {\n    \n    @BeforeTemplate\n\
-        \    void before(boolean actual, Supplier<String> supplier) {\n        assertFalse(actual,\
-        \ supplier);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
-        \ = STATIC_IMPORT_ALWAYS)\n    void after(boolean actual, Supplier<String>\
-        \ supplier) {\n        assertThat(actual).withFailMessage(supplier).isFalse();\n\
-        \    }\n}\n```\n."
+        \    @SuppressWarnings(value = \"java:S4449\")\n    void before(boolean actual,\
+        \ Supplier<@Nullable String> supplier) {\n        assertFalse(actual, supplier);\n\
+        \    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(boolean actual, Supplier<@Nullable String> supplier) {\n \
+        \       assertThat(actual).withFailMessage(supplier).isFalse();\n    }\n}\n\
+        ```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatwithfailmessagesupplierisfalserecipe"
       options: []
       isImperative: true
@@ -41255,11 +41476,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatWithFailMessageSupplierIsInstanceOfRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatWithFailMessageSupplierIsInstanceOf<T> {\n  \
-        \  \n    @BeforeTemplate\n    void before(Object actual, Supplier<String>\
-        \ supplier, Class<T> clazz) {\n        assertInstanceOf(clazz, actual, supplier);\n\
-        \    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
-        \    void after(Object actual, Supplier<String> supplier, Class<T> clazz)\
-        \ {\n        assertThat(actual).withFailMessage(supplier).isInstanceOf(clazz);\n\
+        \  \n    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\")\n\
+        \    void before(Object actual, Supplier<@Nullable String> supplier, Class<T>\
+        \ clazz) {\n        assertInstanceOf(clazz, actual, supplier);\n    }\n  \
+        \  \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(Object actual, Supplier<@Nullable String> supplier, Class<T>\
+        \ clazz) {\n        assertThat(actual).withFailMessage(supplier).isInstanceOf(clazz);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatwithfailmessagesupplierisinstanceofrecipe"
       options: []
@@ -41269,10 +41491,11 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatWithFailMessageSupplierIsNotNullRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatWithFailMessageSupplierIsNotNull {\n    \n  \
-        \  @BeforeTemplate\n    void before(Object actual, Supplier<String> supplier)\
-        \ {\n        assertNotNull(actual, supplier);\n    }\n    \n    @AfterTemplate\n\
-        \    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n    void after(Object\
-        \ actual, Supplier<String> supplier) {\n        assertThat(actual).withFailMessage(supplier).isNotNull();\n\
+        \  @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\")\n    void\
+        \ before(Object actual, Supplier<@Nullable String> supplier) {\n        assertNotNull(actual,\
+        \ supplier);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
+        \ = STATIC_IMPORT_ALWAYS)\n    void after(Object actual, Supplier<@Nullable\
+        \ String> supplier) {\n        assertThat(actual).withFailMessage(supplier).isNotNull();\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatwithfailmessagesupplierisnotnullrecipe"
       options: []
@@ -41282,10 +41505,11 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatWithFailMessageSupplierIsNotSameAsRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatWithFailMessageSupplierIsNotSameAs {\n    \n\
-        \    @BeforeTemplate\n    void before(Object actual, Supplier<String> supplier,\
-        \ Object expected) {\n        assertNotSame(expected, actual, supplier);\n\
-        \    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
-        \    void after(Object actual, Supplier<String> supplier, Object expected)\
+        \    @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\")\n    void\
+        \ before(Object actual, Supplier<@Nullable String> supplier, Object expected)\
+        \ {\n        assertNotSame(expected, actual, supplier);\n    }\n    \n   \
+        \ @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n   \
+        \ void after(Object actual, Supplier<@Nullable String> supplier, Object expected)\
         \ {\n        assertThat(actual).withFailMessage(supplier).isNotSameAs(expected);\n\
         \    }\n}\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatwithfailmessagesupplierisnotsameasrecipe"
@@ -41296,11 +41520,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatWithFailMessageSupplierIsNullRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatWithFailMessageSupplierIsNull {\n    \n    @BeforeTemplate\n\
-        \    void before(Object actual, Supplier<String> supplier) {\n        assertNull(actual,\
-        \ supplier);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
-        \ = STATIC_IMPORT_ALWAYS)\n    void after(Object actual, Supplier<String>\
-        \ supplier) {\n        assertThat(actual).withFailMessage(supplier).isNull();\n\
-        \    }\n}\n```\n."
+        \    @SuppressWarnings(value = \"java:S4449\")\n    void before(Object actual,\
+        \ Supplier<@Nullable String> supplier) {\n        assertNull(actual, supplier);\n\
+        \    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(Object actual, Supplier<@Nullable String> supplier) {\n  \
+        \      assertThat(actual).withFailMessage(supplier).isNull();\n    }\n}\n\
+        ```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatwithfailmessagesupplierisnullrecipe"
       options: []
       isImperative: true
@@ -41309,12 +41534,13 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatWithFailMessageSupplierIsSameAsRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatWithFailMessageSupplierIsSameAs {\n    \n   \
-        \ @BeforeTemplate\n    void before(Object actual, Supplier<String> supplier,\
-        \ Object expected) {\n        assertSame(expected, actual, supplier);\n  \
-        \  }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
-        \    void after(Object actual, Supplier<String> supplier, Object expected)\
-        \ {\n        assertThat(actual).withFailMessage(supplier).isSameAs(expected);\n\
-        \    }\n}\n```\n."
+        \ @BeforeTemplate\n    @SuppressWarnings(value = \"java:S4449\")\n    void\
+        \ before(Object actual, Supplier<@Nullable String> supplier, Object expected)\
+        \ {\n        assertSame(expected, actual, supplier);\n    }\n    \n    @AfterTemplate\n\
+        \    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n    void after(Object\
+        \ actual, Supplier<@Nullable String> supplier, Object expected) {\n      \
+        \  assertThat(actual).withFailMessage(supplier).isSameAs(expected);\n    }\n\
+        }\n```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatwithfailmessagesupplierissameasrecipe"
       options: []
       isImperative: true
@@ -41323,11 +41549,12 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.JUnitToAssertJRulesRecipes$AssertThatWithFailMessageSupplierIsTrueRecipe"
       description: "Recipe created for the following Refaster template:\n```java\n\
         static final class AssertThatWithFailMessageSupplierIsTrue {\n    \n    @BeforeTemplate\n\
-        \    void before(boolean actual, Supplier<String> supplier) {\n        assertTrue(actual,\
-        \ supplier);\n    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value\
-        \ = STATIC_IMPORT_ALWAYS)\n    void after(boolean actual, Supplier<String>\
-        \ supplier) {\n        assertThat(actual).withFailMessage(supplier).isTrue();\n\
-        \    }\n}\n```\n."
+        \    @SuppressWarnings(value = \"java:S4449\")\n    void before(boolean actual,\
+        \ Supplier<@Nullable String> supplier) {\n        assertTrue(actual, supplier);\n\
+        \    }\n    \n    @AfterTemplate\n    @UseImportPolicy(value = STATIC_IMPORT_ALWAYS)\n\
+        \    void after(boolean actual, Supplier<@Nullable String> supplier) {\n \
+        \       assertThat(actual).withFailMessage(supplier).isTrue();\n    }\n}\n\
+        ```\n."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/junittoassertjrulesrecipes$assertthatwithfailmessagesupplieristruerecipe"
       options: []
       isImperative: true
@@ -42528,6 +42755,14 @@ rewrite-third-party:
       options: []
       isImperative: true
       artifactId: "rewrite-third-party"
+    tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$FluxTimeoutFluxEmptyRecipe:
+      name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$FluxTimeoutFluxEmptyRecipe"
+      description: "Prefer `Flux#timeout(Duration, Publisher)` over more contrived\
+        \ or less performant alternatives."
+      docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$fluxtimeoutfluxemptyrecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
     tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$FluxTransformMaxRecipe:
       name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$FluxTransformMaxRecipe"
       description: "Prefer `MathFlux#max(Publisher)` over less efficient alternatives."
@@ -42863,6 +43098,54 @@ rewrite-third-party:
       name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoThenReturnRecipe"
       description: "Prefer `Mono#thenReturn(Object)` over more verbose alternatives."
       docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monothenreturnrecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationMonoEmptyRecipe:
+      name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationMonoEmptyRecipe"
+      description: "Prefer `Mono#timeout(Duration, Mono)` over more contrived or less\
+        \ performant alternatives."
+      docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutdurationmonoemptyrecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationMonoJustRecipe:
+      name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationMonoJustRecipe"
+      description: "Prefer `Mono#timeout(Duration, Mono)` over more contrived or less\
+        \ performant alternatives."
+      docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutdurationmonojustrecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationRecipe:
+      name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutDurationRecipe"
+      description: "Prefer `Mono#timeout(Duration, Mono)` over more contrived or less\
+        \ performant alternatives."
+      docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutdurationrecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherMonoEmptyRecipe:
+      name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherMonoEmptyRecipe"
+      description: "Prefer `Mono#timeout(Publisher, Mono)` over more contrived or\
+        \ less performant alternatives."
+      docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutpublishermonoemptyrecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherMonoJustRecipe:
+      name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherMonoJustRecipe"
+      description: "Prefer `Mono#timeout(Publisher, Mono)` over more contrived or\
+        \ less performant alternatives."
+      docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutpublishermonojustrecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherRecipe:
+      name: "tech.picnic.errorprone.refasterrules.ReactorRulesRecipes$MonoTimeoutPublisherRecipe"
+      description: "Prefer `Mono#timeout(Publisher, Mono)` over more contrived or\
+        \ less performant alternatives."
+      docLink: "https://docs.openrewrite.org/recipes/tech/picnic/errorprone/refasterrules/reactorrulesrecipes$monotimeoutpublisherrecipe"
       options: []
       isImperative: true
       artifactId: "rewrite-third-party"
@@ -45383,7 +45666,7 @@ rewrite-third-party:
       artifactId: "rewrite-third-party"
 rewrite-toml:
   artifactId: "rewrite-toml"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.toml.ChangeKey:
       name: "org.openrewrite.toml.ChangeKey"
@@ -45576,7 +45859,7 @@ rewrite-vulncheck:
       artifactId: "rewrite-vulncheck"
 rewrite-xml:
   artifactId: "rewrite-xml"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.xml.AddCommentToXmlTag:
       name: "org.openrewrite.xml.AddCommentToXmlTag"
@@ -45923,7 +46206,7 @@ rewrite-xml:
       artifactId: "rewrite-xml"
 rewrite-yaml:
   artifactId: "rewrite-yaml"
-  version: "8.64.0"
+  version: "8.66.1"
   markdownRecipeDescriptors:
     org.openrewrite.yaml.AppendToSequence:
       name: "org.openrewrite.yaml.AppendToSequence"

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -81,7 +81,7 @@ class RecipeMarkdownGeneratorTest {
                 mutableListOf(),
                 mutableListOf(),
                 mutableListOf(),
-                java.net.URI.create("test://test")
+                null
             )
         )
     }


### PR DESCRIPTION
So that the markdown generator can run again.
Also generates changelog for the latest openrewrite.

- Fixes: https://github.com/openrewrite/rewrite-recipe-markdown-generator/issues/235

The core issue was that `source` was removed from a `RecipeDescriptor`.

This also fixes issues with `com.google` recipes and fixes a bug where some recipes weren't being correctly marked as imperative or declarative.