### PR TITLE
Add support for JavaScript docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,30 +39,38 @@ val recipeConf = configurations.create("recipe")
 val rewriteVersion = "latest.release"
 
 dependencies {
-    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
+    // Platform dependencies (BOMs)
     implementation(platform("io.moderne.recipe:moderne-recipe-bom:$rewriteVersion"))
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
-    implementation("info.picocli:picocli:latest.release")
-    implementation("org.openrewrite:rewrite-core")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
+    // Core implementation dependencies
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("info.picocli:picocli:latest.release")
     implementation("io.github.java-diff-utils:java-diff-utils:4.11")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.openrewrite:rewrite-core")
+    implementation("org.openrewrite:rewrite-javascript")
+
+    // Runtime dependencies
     runtimeOnly("org.slf4j:slf4j-simple:1.7.30")
 
+    // Test dependencies
     testImplementation("org.junit.jupiter:junit-jupiter:5.+")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    // Do not use BOM to show the latest patch versions of individual modules
-//    "recipe"(platform("io.moderne.recipe:moderne-recipe-bom:$rewriteVersion"))
+    // Recipe configuration dependencies
+    // Note: Not using BOM to show the latest patch versions of individual modules
 
+    // Core rewrite modules (org.openrewrite)
     "recipe"("org.openrewrite:rewrite-core:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-csharp:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-gradle:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-groovy:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-hcl:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-java:$rewriteVersion")
+    "recipe"("org.openrewrite:rewrite-javascript:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-json:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-kotlin:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-maven:$rewriteVersion")
@@ -72,16 +80,16 @@ dependencies {
     "recipe"("org.openrewrite:rewrite-xml:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-yaml:$rewriteVersion")
 
-    // Only show the versions of these modules below
+    // Additional core modules (versions only, recipes not yet included)
 //    "recipe"("org.openrewrite:rewrite-cobol:$rewriteVersion")
-//    "recipe"("org.openrewrite:rewrite-javascript:$rewriteVersion")
 //    "recipe"("org.openrewrite:rewrite-polyglot:$rewriteVersion")
 //    "recipe"("org.openrewrite:rewrite-python:$rewriteVersion")
 //    "recipe"("org.openrewrite:rewrite-templating:$rewriteVersion")
 
-    "recipe"("org.openrewrite.recipe:rewrite-all:$rewriteVersion")
+    // Recipe modules (org.openrewrite.recipe)
     "recipe"("org.openrewrite.meta:rewrite-analysis:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-ai-search:$rewriteVersion")
+    "recipe"("org.openrewrite.recipe:rewrite-all:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-android:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-apache:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-azul:$rewriteVersion")
@@ -92,7 +100,6 @@ dependencies {
     "recipe"("org.openrewrite.recipe:rewrite-comprehension:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-concourse:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-cucumber-jvm:$rewriteVersion")
-    // Not released yet; when uncommented it pulls in snapshot versions of dependencies into the generated docs
 //    "recipe"("org.openrewrite.recipe:rewrite-diffblue:latest.integration") {
 //        exclude(group = "org.openrewrite")
 //        exclude(group = "org.openrewrite.recipe")
@@ -131,6 +138,7 @@ dependencies {
     "recipe"("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
 
+    // Moderne recipe modules (io.moderne.recipe)
     "recipe"("io.moderne.recipe:rewrite-cryptography:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-devcenter:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-elastic:$rewriteVersion")

--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -1,3 +1,5 @@
+@file:Suppress("SENSELESS_COMPARISON")
+
 package org.openrewrite
 
 import org.openrewrite.RecipeMarkdownGenerator.Companion.useAndApply
@@ -63,7 +65,7 @@ class ListsOfRecipesWriter(
 
     fun createRecipesWithDataTables() {
         val recipesWithDataTables = allRecipeDescriptors.filter {
-            it.dataTables.any { dataTable -> dataTable.name !in dataTablesToIgnore }
+            it.dataTables != null && it.dataTables.any { dataTable -> dataTable.name !in dataTablesToIgnore }
         }
 
         val recipesWithDataTablesPath = outputPath.resolve("recipes-with-data-tables.md")
@@ -96,9 +98,9 @@ class ListsOfRecipesWriter(
                 writeln("${recipe.descriptionEscaped()}\n")
                 writeln("#### Data tables:\n")
 
-                val filteredDataTables = recipe.dataTables.filter { dataTable ->
+                val filteredDataTables = recipe.dataTables?.filter { dataTable ->
                     dataTable.name !in dataTablesToIgnore
-                }
+                } ?: emptyList()
 
                 for (dataTable in filteredDataTables) {
                     writeln("  * **${dataTable.name}**: *${dataTable.description.replace("\n", " ")}*")
@@ -114,13 +116,15 @@ class ListsOfRecipesWriter(
 
         // Collect all tags and their associated recipes
         for (recipeDescriptor in allRecipeDescriptors) {
-            for (tag in recipeDescriptor.tags) {
-                tagToRecipes.computeIfAbsent(
-                    tag
-                        .substringBefore('-')
-                        .substringBefore('_')
-                ) { TreeSet(compareBy { it.name }) }
-                    .add(recipeDescriptor)
+            if (recipeDescriptor.tags != null) {
+                for (tag in recipeDescriptor.tags) {
+                    tagToRecipes.computeIfAbsent(
+                        tag
+                            .substringBefore('-')
+                            .substringBefore('_')
+                    ) { TreeSet(compareBy { it.name }) }
+                        .add(recipeDescriptor)
+                }
             }
         }
 

--- a/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
@@ -1,0 +1,156 @@
+@file:Suppress("SENSELESS_COMPARISON")
+
+package org.openrewrite
+
+import org.openrewrite.config.RecipeDescriptor
+import org.openrewrite.javascript.rpc.JavaScriptRewriteRpc
+import java.net.URI
+import java.nio.file.Path
+
+/**
+ * Loads TypeScript/JavaScript recipes via RPC by communicating with a Node.js process.
+ * This allows the markdown generator to discover recipes written in TypeScript without
+ * needing to parse TypeScript source files directly.
+ */
+class TypeScriptRecipeLoader(
+    private val recipeOrigins: Map<URI, RecipeOrigin>,
+    private val recipeInstallDir: Path? = null
+) {
+
+    companion object {
+        /**
+         * Registry mapping artifact IDs to their corresponding npm package names.
+         * Add new TypeScript recipe modules here with a single line:
+         * "artifact-id" to "npm-package-name"
+         *
+         * This is the single source of truth for TypeScript recipe module mappings.
+         * Both recipe loading and documentation generation use this registry.
+         */
+        val TYPESCRIPT_RECIPE_MODULES = mapOf(
+            "rewrite-javascript" to "@openrewrite/rewrite",
+            "rewrite-nodejs" to "@openrewrite/recipes-nodejs"
+            // "rewrite-react" to "@openrewrite/recipes-react"  // Not yet published - uncomment when available
+        )
+    }
+
+    data class TypeScriptRecipeResult(
+        val descriptors: List<RecipeDescriptor>,
+        val recipeToSource: Map<String, URI>
+    )
+
+    /**
+     * Detects which recipe modules contain TypeScript recipes by checking if they're
+     * registered in the TYPESCRIPT_RECIPE_MODULES map.
+     */
+    private fun hasTypeScriptRecipes(origin: RecipeOrigin): Boolean {
+        return origin.artifactId in TYPESCRIPT_RECIPE_MODULES
+    }
+
+    /**
+     * Gets the npm package name for a given recipe origin.
+     */
+    private fun getNpmPackageName(origin: RecipeOrigin): String {
+        return TYPESCRIPT_RECIPE_MODULES[origin.artifactId]
+            ?: throw IllegalArgumentException("No npm package configured for artifact: ${origin.artifactId}")
+    }
+
+    /**
+     * Attempts to map a recipe name to its TypeScript source file location.
+     * This is used to generate GitHub links to the recipe source.
+     *
+     * Note: The exact file path mapping is complex because recipe names don't directly
+     * correspond to file names. For now, we link to the GitHub search for the recipe name.
+     */
+    private fun mapRecipeToSourceUri(recipeName: String, origin: RecipeOrigin): URI {
+        // For now, use a search-based URI that will be converted to a GitHub code search link
+        // This ensures users can find the recipe even if our file path mapping is imperfect
+        return URI.create("typescript-search://${origin.artifactId}/$recipeName")
+    }
+
+    /**
+     * Loads TypeScript recipes from npm packages via RPC.
+     *
+     * @return A result containing the recipe descriptors and a mapping of recipe names to source URIs
+     */
+    fun loadTypeScriptRecipes(): TypeScriptRecipeResult {
+        val typeScriptOrigins = recipeOrigins.values.filter { hasTypeScriptRecipes(it) }
+
+        if (typeScriptOrigins.isEmpty()) {
+            println("No TypeScript recipe modules detected.")
+            return TypeScriptRecipeResult(emptyList(), emptyMap())
+        }
+
+        println("Found ${typeScriptOrigins.size} module(s) with TypeScript recipes: ${typeScriptOrigins.joinToString { it.artifactId }}")
+
+        var rpc: JavaScriptRewriteRpc? = null
+        try {
+            // Build and start the RPC client
+            val builder = JavaScriptRewriteRpc.builder()
+            if (recipeInstallDir != null) {
+                builder.recipeInstallDir(recipeInstallDir)
+            }
+
+            rpc = builder.get()
+            println("Started Node.js RPC process for TypeScript recipe loading")
+
+            val allDescriptors = mutableListOf<RecipeDescriptor>()
+            val recipeToSource = mutableMapOf<String, URI>()
+
+            // Install recipes from each npm package
+            for (origin in typeScriptOrigins) {
+                try {
+                    val packageName = getNpmPackageName(origin)
+                    println("Installing TypeScript recipes from npm package: $packageName@${origin.version}")
+
+                    val count = rpc.installRecipes(packageName, origin.version)
+                    println("  Installed $count recipe(s) from $packageName")
+
+                } catch (e: Exception) {
+                    System.err.println("Warning: Failed to install recipes from ${origin.artifactId}: ${e.message}")
+                    e.printStackTrace()
+                }
+            }
+
+            // Get all recipe descriptors from the RPC process
+            val descriptors = rpc.recipes
+            println("Retrieved ${descriptors.size} TypeScript recipe descriptor(s) via RPC")
+
+            // Map each recipe to its source file location
+            for (descriptor in descriptors) {
+                allDescriptors.add(descriptor)
+
+                // Debug: Print option types for recipes with options
+                // Remove this once the type checking is fixed: https://github.com/openrewrite/rewrite/issues/6293
+                if (descriptor.options != null && descriptor.options.isNotEmpty()) {
+                    println("  Recipe: ${descriptor.name}")
+                    for (option in descriptor.options) {
+                        println("    Option name: ${option.name}")
+                        println("      type: ${option.type}")
+                        println("      description: ${option.description}")
+                        println("      example: ${option.example}")
+                        println("      required: ${option.isRequired}")
+                    }
+                }
+
+                // Find the origin this recipe belongs to
+                val origin = typeScriptOrigins.firstOrNull { origin ->
+                    descriptor.name.startsWith("org.openrewrite.${origin.artifactId.removePrefix("rewrite-")}")
+                } ?: typeScriptOrigins.first()
+
+                val sourceUri = mapRecipeToSourceUri(descriptor.name, origin)
+                recipeToSource[descriptor.name] = sourceUri
+            }
+
+            return TypeScriptRecipeResult(allDescriptors, recipeToSource)
+
+        } catch (e: Exception) {
+            System.err.println("Error loading TypeScript recipes: ${e.message}")
+            e.printStackTrace()
+            return TypeScriptRecipeResult(emptyList(), emptyMap())
+        } finally {
+            // Cleanup: shutdown the RPC process
+            rpc?.shutdown()
+            println("Shut down Node.js RPC process")
+        }
+    }
+}


### PR DESCRIPTION
There are some caveats here - type functionality doesn't work as the RPC doesn't support that (a known bug). Also, some JS recipes haven't been published - such as the react ones, so we can't include them in the docs.

This is a first draft to just have some details for JS recipes but more work/changes will need to be done in the future as we implement things like running JS recipes in app.moderne or whatnot.
