### PR TITLE
Mark rewrite-cobol as proprietary despite missing metadata

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -237,7 +237,7 @@ class RecipeLoader {
                 origin.license = license
             } else if (origin.artifactId == "rewrite-cobol") {
                 origin.license = Licenses.Proprietary
-            }else {
+            } else {
                 println("Unable to determine License for ${origin}")
             }
             origin.repositoryUrl = mfInfos[uri]?.second ?: ""


### PR DESCRIPTION
We've not done a release there in a while, so there's not been any update to the metadata there.