### PR TITLE
Produce proper Markdown when more complex syntax is used

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -88,7 +88,7 @@ import TabItem from '@theme/TabItem';
             return formattedRecipeDescription
         }
 
-        // Check for markdown formatting indicators (headers, bullet lists, numbered lists)
+        // Check for Markdown formatting indicators (headers, bullet lists, numbered lists)
         // These suggest the description is already formatted as Markdown and should preserve newlines
         val markdownIndicatorRegex = Pattern.compile("(^|\\n)#{1,6}\\s|\\n\\s*[-*+]\\s|\\n\\s*\\d+\\.\\s")
         if (markdownIndicatorRegex.matcher(formattedRecipeDescription).find()) {


### PR DESCRIPTION
## What's changed?

The way we identify Markdown in a recipe description.

## What's your motivation?

The logic for properly rendering Markdown with more complex notation doesn't work properly, as observed [here](https://github.com/openrewrite/rewrite-docs/blob/d51cb3d498dd91060d5ce4d3b0221a2fa6d44ebf/docs/recipes/java/dependencies/dependencyvulnerabilitycheck.md?plain=1#L12). The recipe description should not be rendered. Markdown notation should be preserved.

The regex matches:
  - (^|\n)#{1,6}\s - Markdown headers (h1-h6)
  - \n\s*[-*+]\s - Bullet lists using -, *, or +
  - \n\s*\d+\.\s - Numbered lists

## Anything in particular you'd like reviewers to focus on?

No

## Any additional context

I produced the Markdown file with `./gradlew run`. The recipe descriptor is now rendered as follows:

```
# Find and fix vulnerable dependencies

**org.openrewrite.java.dependencies.DependencyVulnerabilityCheck**

This software composition analysis (SCA) tool detects and upgrades dependencies with publicly disclosed vulnerabilities. This recipe both generates a report of vulnerable dependencies and upgrades to newer versions with fixes. This recipe by default only upgrades to the latest **patch** version.  If a minor or major upgrade is required to reach the fixed version, this can be controlled using the `maximumUpgradeDelta` option. Vulnerability information comes from the [GitHub Security Advisory Database](https://docs.github.com/en/code-security/security-advisories/global-security-advisories/about-the-github-advisory-database), which aggregates vulnerability data from several public databases, including the [National Vulnerability Database](https://nvd.nist.gov/) maintained by the United States government. Upgrades dependencies versioned according to [Semantic Versioning](https://semver.org/). 

## Customizing Vulnerability Data

This recipe can be customized by extending `DependencyVulnerabilityCheckBase` and overriding the vulnerability data sources:

 - **`baselineVulnerabilities(ExecutionContext ctx)`**: Provides the default set of known vulnerabilities.
The base implementation loads vulnerability data from the GitHub Security Advisory Database CSV file using `ResourceUtils.parseResourceAsCsv()`. Override this method to replace the entire vulnerability dataset with your own curated list.

 - **`supplementalVulnerabilities(ExecutionContext ctx)`**: Allows adding custom vulnerability data beyond the baseline.
The base implementation returns an empty list. Override this method to add organization-specific vulnerabilities, internal security advisories, or vulnerabilities from additional sources while retaining the baseline GitHub Advisory Database.

Both methods return `List<Vulnerability>` objects. Vulnerability data can be loaded from CSV files using `ResourceUtils.parseResourceAsCsv(path, Vulnerability.class, consumer)` or constructed programmatically. To customize, extend `DependencyVulnerabilityCheckBase` and override one or both methods depending on your needs. For example, override `supplementalVulnerabilities()` to add custom CVEs while keeping the standard vulnerability database, or override `baselineVulnerabilities()` to use an entirely different vulnerability data source.
```

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
