### PR TITLE
Escape `|` in recipe options table

### DIFF
--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -42,12 +42,8 @@ class ListsOfRecipesWriter(
                 for (recipe in entry.value.sortedBy { it.displayName }) {
                     writeln(
                         "* [${recipe.displayNameEscaped()}](/recipes/${
-                            RecipeMarkdownGenerator.Companion.getRecipePath(
-                                recipe
-                            )
-                        }.md) - _${
-                            recipe.descriptionEscaped()
-                        }_"
+                            RecipeMarkdownGenerator.getRecipePath(recipe)
+                        }.md) - _${recipe.descriptionEscaped()}_"
                     )
                 }
 

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -198,19 +198,17 @@ import TabItem from '@theme/TabItem';
                 var description = if (option.description == null) {
                     ""
                 } else {
-                    option.description.replace("\n", "<br />")
-
-                    // Ensure that anything that matches ${variable} is wrapped in ``
-                    // Otherwise Docusaurus tries to parse it as a variable.
-                    val regex = Regex("(?<!`)\\$\\{[^}]+}(?!`)")
-                    option.description.replace(regex) { matchResult ->
-                        "`${matchResult.value}`"
-                    }
+                    option.description
+                        .replace("\n", "<br />")
+                        .replace("|", "\\|")
+                        // Ensure that anything that matches ${variable} is wrapped in ``
+                        // Otherwise Docusaurus tries to parse it as a variable.
+                        .replace(Regex("(?<!`)\\$\\{[^}]+}(?!`)")) { matchResult ->
+                            "`${matchResult.value}`"
+                        }
                 }
-                description = if (option.isRequired) {
-                    description
-                } else {
-                    "*Optional*. $description"
+                if (!option.isRequired) {
+                    description = "*Optional*. $description"
                 }
 
                 // Add valid options to description


### PR DESCRIPTION
After seeing misaligned values in: https://docs.openrewrite.org/recipes/java/dependencies/dependencyvulnerabilitycheck