### PR TITLE
Recipe location refactor

### DIFF
--- a/src/main/kotlin/org/openrewrite/CategoryWriter.kt
+++ b/src/main/kotlin/org/openrewrite/CategoryWriter.kt
@@ -245,6 +245,7 @@ data class Category(
         }
 
         val outputPath = outputRoot.resolve("$path/README.md")
+        Files.createDirectories(outputPath.parent)
         Files.newBufferedWriter(outputPath, StandardOpenOption.CREATE).useAndApply {
             writeln(categoryIndex())
         }

--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -30,7 +30,7 @@ class ListsOfRecipesWriter(
 
             writeln(
                 "This doc includes every recipe that is exclusive to users of Moderne. " +
-                        "For a full list of all recipes, check out our [recipe catalog](https://docs.openrewrite.org/recipes). " +
+                        "For a full list of all recipes, check out our [recipe catalog](https://docs.moderne.io/user-documentation/recipes/recipe-catalog). " +
                         "For more information about how to use Moderne for automating code refactoring and analysis at scale, " +
                         "[contact us](https://www.moderne.ai/contact-us).\n"
             )
@@ -41,7 +41,8 @@ class ListsOfRecipesWriter(
 
                 for (recipe in entry.value.sortedBy { it.name }) {
                     val recipePath = RecipeMarkdownGenerator.getRecipePath(recipe)
-                    writeln("* [${recipe.name}](/recipes/${recipePath}.md)")
+                    // Link to Moderne docs since these recipes are exclusive to Moderne
+                    writeln("* [${recipe.name}](https://docs.moderne.io/user-documentation/recipes/recipe-catalog/${recipePath})")
                     writeln("  * **${recipe.displayNameEscaped()}**")
                     writeln("  * ${recipe.descriptionEscaped()}")
                 }
@@ -95,7 +96,7 @@ class ListsOfRecipesWriter(
                 } ?: emptyList()
 
                 for (dataTable in filteredDataTables) {
-                    writeln("  * **${dataTable.name}**: *${dataTable.description.replace("\n", " ")}*")
+                    writeln("  * **${dataTable.name}**: *${escapeMdx(dataTable.description).replace("\n", " ")}*")
                 }
 
                 writeln("\n")

--- a/src/main/kotlin/org/openrewrite/RedirectWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RedirectWriter.kt
@@ -1,0 +1,88 @@
+package org.openrewrite
+
+import org.openrewrite.RecipeMarkdownGenerator.Companion.getRecipePath
+import org.openrewrite.config.RecipeDescriptor
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+/**
+ * Generates HTML redirect pages for proprietary recipes.
+ *
+ * Since Docusaurus's redirect plugin only supports internal redirects, we generate
+ * actual HTML files that perform client-side redirects to Moderne docs.
+ * These files should be placed in the `static/` directory of the docs site.
+ */
+object RedirectWriter {
+
+    /**
+     * Writes HTML redirect pages for proprietary recipes.
+     *
+     * Each redirect page uses both meta refresh and JavaScript redirect for maximum compatibility.
+     * The generated files should be copied to `static/recipes/` in the docs site.
+     *
+     * @param outputPath Base output directory where redirect HTML files will be written
+     * @param proprietaryRecipes List of proprietary recipe descriptors that need redirects
+     * @param moderneBaseUrl Base URL for Moderne docs (e.g., "https://docs.moderne.io")
+     * @param moderneLinkBasePath Base path for recipe links on Moderne (e.g., "/user-documentation/recipes/recipe-catalog")
+     */
+    fun writeRedirectConfig(
+        outputPath: Path,
+        proprietaryRecipes: List<RecipeDescriptor>,
+        moderneBaseUrl: String,
+        moderneLinkBasePath: String
+    ) {
+        if (proprietaryRecipes.isEmpty()) {
+            return
+        }
+
+        // Create the static/recipes directory for redirect HTML files
+        val staticRecipesPath = outputPath.resolve("static/recipes")
+        Files.createDirectories(staticRecipesPath)
+
+        var successCount = 0
+        for (recipe in proprietaryRecipes) {
+            try {
+                val recipePath = getRecipePath(recipe)
+                val targetUrl = "$moderneBaseUrl$moderneLinkBasePath/$recipePath"
+
+                // Create the directory structure for this recipe
+                // Use index.html in a directory for clean URLs (e.g., /recipes/ai/findagentsinuse/ -> index.html)
+                val redirectFilePath = staticRecipesPath.resolve("$recipePath/index.html")
+                Files.createDirectories(redirectFilePath.parent)
+
+                // Generate HTML redirect page
+                val htmlContent = generateRedirectHtml(recipe.displayName, targetUrl)
+                Files.writeString(redirectFilePath, htmlContent, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+                successCount++
+            } catch (e: Exception) {
+                System.err.println("Warning: Could not generate redirect for recipe ${recipe.name}: ${e.message}")
+            }
+        }
+
+        println("Wrote $successCount redirect page(s) to $staticRecipesPath")
+    }
+
+    /**
+     * Generates an HTML page that redirects to the target URL.
+     * Uses both meta refresh (for browsers without JS) and JavaScript redirect.
+     */
+    private fun generateRedirectHtml(recipeDisplayName: String, targetUrl: String): String {
+        return """
+            |<!DOCTYPE html>
+            |<html lang="en">
+            |<head>
+            |    <meta charset="UTF-8">
+            |    <meta http-equiv="refresh" content="0; url=$targetUrl">
+            |    <link rel="canonical" href="$targetUrl">
+            |    <title>Redirecting to $recipeDisplayName</title>
+            |    <script>window.location.replace("$targetUrl");</script>
+            |</head>
+            |<body>
+            |    <p>This recipe has moved to Moderne docs.</p>
+            |    <p>If you are not redirected automatically, <a href="$targetUrl">click here</a>.</p>
+            |</body>
+            |</html>
+        """.trimMargin()
+    }
+}


### PR DESCRIPTION
This separates out open-source and proprietary recipes so that the OR docs only get open-source - and the Moderne docs get all of the recipes. The OR docs should have static HTML redirects to the Moderne recipes for all proprietary recipes. Open source recipes should remain unchanged (but any cross-references to proprietary sub-recipes now link to the Moderne docs).

There also was some escape logic added to prevent issues with some of the new recipes.
