### PR TITLE
Bootstrap Python pip packages for RPC server

### DIFF
--- a/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
@@ -6,6 +6,7 @@ import org.openrewrite.config.RecipeDescriptor
 import org.openrewrite.marketplace.RecipeBundle
 import org.openrewrite.python.rpc.PythonRewriteRpc
 import java.net.URI
+import java.nio.file.Files
 import java.nio.file.Path
 
 /**
@@ -96,9 +97,8 @@ class PythonRecipeLoader(
         try {
             // Build and start the RPC client
             val builder = PythonRewriteRpc.builder()
-            if (pipPackagesPath != null) {
-                builder.pipPackagesPath(pipPackagesPath)
-            }
+            val effectivePipPath = pipPackagesPath ?: Files.createTempDirectory("rewrite-python-packages")
+            builder.pipPackagesPath(effectivePipPath)
 
             rpc = builder.get()
             println("Started Python RPC process for Python recipe loading")


### PR DESCRIPTION
## Summary

- Always set `pipPackagesPath` on the `PythonRewriteRpc` builder, using a temp directory as the default. This triggers `bootstrapOpenrewrite()`, which pip-installs the `openrewrite` package (containing the `rewrite.rpc.server` module) before starting the RPC server.
- Without this, the Python RPC server fails to start in CI environments that lack a `.venv` or the `rewrite` monorepo source tree, since the `rewrite.rpc` module is not discoverable.

## Context

The `PythonRewriteRpc.Builder` has three ways to find `rewrite.rpc.server`:
1. A `.venv/bin/python` with the package pre-installed (local dev)
2. The `rewrite-python/rewrite/src` source tree on PYTHONPATH (monorepo dev)
3. `bootstrapOpenrewrite()` which pip-installs `openrewrite` to a `pipPackagesPath` and adds it to PYTHONPATH

Option 3 is the only one that works in CI (e.g. the moderne-docs GitHub Action), but it was only triggered when `pipPackagesPath` was explicitly provided — which the `PythonRecipeLoader` never did by default.

## Test plan

- [x] Verified `./gradlew compileKotlin` succeeds
- [x] Confirmed the Python RPC server error (`No module named 'rewrite'`) matches the CI failure from the moderne-docs GitHub Action

🤖 Generated with [Claude Code](https://claude.com/claude-code)