### PR TITLE
Fix Python recipe tag links by removing dots from anchors

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -165,6 +165,7 @@ import TabItem from '@theme/TabItem';
                         .substringBefore('-')
                         .substringBefore('_')
                         .replace(' ', '-')
+                        .replace(".", "")
                     val tagBasePath = if (forModerneDocs) "/user-documentation/recipes/lists/recipes-by-tag" else "/reference/recipes-by-tag"
                     writeln("* [$tag](${tagBasePath}#${tagAnchor})")
                 }


### PR DESCRIPTION
## Summary

- Fixes #275: Python recipes generate broken tag links because Docusaurus's github-slugger removes dots from heading anchors. A tag like "3.13" now produces the correct anchor #313 instead of #3.13.

## Changes

Added `.replace(".", "")` to the tag anchor generation logic to strip dots, matching what Docusaurus produces from headings.

## Verification

This fixes ~100 broken anchor warnings in the build logs related to Python recipe tags (versions like 3.13, 3.8, 1.0, 0.2, etc.).