### PR TITLE
Fix TypeScript recipe origin assignment

### DIFF
--- a/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
@@ -97,7 +97,7 @@ class TypeScriptRecipeLoader(
             val allDescriptors = mutableListOf<RecipeDescriptor>()
             val recipeToSource = mutableMapOf<String, URI>()
 
-            // Install recipes from each npm package
+            // Install recipes from each npm package, tracking which origin each recipe came from
             for (origin in typeScriptOrigins) {
                 try {
                     val packageName = getNpmPackageName(origin)
@@ -106,21 +106,41 @@ class TypeScriptRecipeLoader(
                     val count = rpc.installRecipes(packageName, origin.version)
                     println("  Installed $count recipe(s) from $packageName")
 
-                    allDescriptors.addAll(
-                        rpc.getMarketplace(RecipeBundle("npm", packageName, null, null, null))
-                            .allRecipes
-                            .mapNotNull { r ->
-                                try {
-                                    val requiredOptions = r.options
-                                        .filter { it.isRequired }
-                                        .associate { it.name to "PlaceholderValueToFoolValidation" }
-                                    rpc.prepareRecipe(r.name, requiredOptions).descriptor
-                                } catch (e: Exception) {
-                                    System.err.println("Warning: Failed to prepare recipe ${r.name}: ${e.message}")
-                                    null
-                                }
+                    val descriptors = rpc.getMarketplace(RecipeBundle("npm", packageName, null, null, null))
+                        .allRecipes
+                        .mapNotNull { r ->
+                            try {
+                                val requiredOptions = r.options
+                                    .filter { it.isRequired }
+                                    .associate { it.name to "PlaceholderValueToFoolValidation" }
+                                rpc.prepareRecipe(r.name, requiredOptions).descriptor
+                            } catch (e: Exception) {
+                                System.err.println("Warning: Failed to prepare recipe ${r.name}: ${e.message}")
+                                null
                             }
-                    )
+                        }
+
+                    // getMarketplace is accumulative, so only take recipes not already seen
+                    val newDescriptors = descriptors.filter { it.name !in recipeToSource }
+                    for (descriptor in newDescriptors) {
+                        // Debug: Print option types for recipes with options
+                        // Remove this once the type checking is fixed: https://github.com/openrewrite/rewrite/issues/6293
+                        if (descriptor.options != null && descriptor.options.isNotEmpty()) {
+                            println("  Recipe: ${descriptor.name}")
+                            for (option in descriptor.options) {
+                                println("    Option name: ${option.name}")
+                                println("      type: ${option.type}")
+                                println("      description: ${option.description}")
+                                println("      example: ${option.example}")
+                                println("      required: ${option.isRequired}")
+                            }
+                        }
+
+                        val sourceUri = mapRecipeToSourceUri(descriptor.name, origin)
+                        recipeToSource[descriptor.name] = sourceUri
+                    }
+
+                    allDescriptors.addAll(newDescriptors)
 
                 } catch (e: Exception) {
                     System.err.println("Warning: Failed to install recipes from ${origin.artifactId}: ${e.message}")
@@ -130,30 +150,6 @@ class TypeScriptRecipeLoader(
 
             // Get all recipe descriptors from the RPC process
             println("Retrieved ${allDescriptors.size} TypeScript recipe descriptor(s) via RPC")
-
-            // Map each recipe to its source file location
-            for (descriptor in allDescriptors) {
-                // Debug: Print option types for recipes with options
-                // Remove this once the type checking is fixed: https://github.com/openrewrite/rewrite/issues/6293
-                if (descriptor.options != null && descriptor.options.isNotEmpty()) {
-                    println("  Recipe: ${descriptor.name}")
-                    for (option in descriptor.options) {
-                        println("    Option name: ${option.name}")
-                        println("      type: ${option.type}")
-                        println("      description: ${option.description}")
-                        println("      example: ${option.example}")
-                        println("      required: ${option.isRequired}")
-                    }
-                }
-
-                // Find the origin this recipe belongs to
-                val origin = typeScriptOrigins.firstOrNull { origin ->
-                    descriptor.name.startsWith("org.openrewrite.${origin.artifactId.removePrefix("rewrite-")}")
-                } ?: typeScriptOrigins.first()
-
-                val sourceUri = mapRecipeToSourceUri(descriptor.name, origin)
-                recipeToSource[descriptor.name] = sourceUri
-            }
 
             return TypeScriptRecipeResult(allDescriptors, recipeToSource)
 


### PR DESCRIPTION
TypeScript recipes were assigned to the wrong origin (and therefore, the wrong npm package / GitHub repo) in the generated docs. For example, `rewrite-nodejs` recipes like `upgrade-node-22` showed `@openrewrite/rewrite` instead of `@openrewrite/recipes-nodejs` because the name-matching heuristic (`org.openrewrite.node` vs `org.openrewrite.nodejs`) failed and fell back to the first origin alphabetically (`rewrite-javascript`).

We can fix this by tracking each recipe's origin during installation (where we already know it) instead of guessing afterward with a name prefix heuristic.

- Fixes: https://github.com/moderneinc/customer-requests/issues/1812

**Note:** This will result in the node JS recipes disappearing from the OR docs (with a redirect to the Moderne Docs). It also changes many of these recipes to show that the license is Moderne Proprietary instead of Moderne Source Available - which I think is more accurate?