### PR TITLE
Fix issue with C# doc generation + broken tests

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -261,10 +261,21 @@ class RecipeLoader {
      */
     private fun buildCategoryPath(cat1: String, cat2: String, recipeFileName: String): String {
         val parts = mutableListOf<String>()
-        if (cat2.isNotBlank()) parts.add(cat2.lowercase())
-        if (cat1.isNotBlank()) parts.add(cat1.lowercase())
+        if (cat2.isNotBlank()) parts.add(sanitizePathSegment(cat2))
+        if (cat1.isNotBlank()) parts.add(sanitizePathSegment(cat1))
         parts.add(recipeFileName)
         return parts.joinToString("/")
+    }
+
+    companion object {
+        /**
+         * Sanitize a category name for use as a URL-safe directory path segment.
+         * Replaces special characters that are invalid in URLs/directory names.
+         * E.g., "C#" → "csharp", "F#" → "fsharp"
+         */
+        fun sanitizePathSegment(segment: String): String {
+            return segment.lowercase().replace("#", "sharp")
+        }
     }
 
     /**

--- a/src/test/kotlin/org/openrewrite/RecipeLoaderTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeLoaderTest.kt
@@ -1,0 +1,27 @@
+package org.openrewrite
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class RecipeLoaderTest {
+
+    @Test
+    fun sanitizePathSegmentRemovesHash() {
+        assertThat(RecipeLoader.sanitizePathSegment("C#")).isEqualTo("csharp")
+    }
+
+    @Test
+    fun sanitizePathSegmentHandlesFSharp() {
+        assertThat(RecipeLoader.sanitizePathSegment("F#")).isEqualTo("fsharp")
+    }
+
+    @Test
+    fun sanitizePathSegmentLowercases() {
+        assertThat(RecipeLoader.sanitizePathSegment("Python")).isEqualTo("python")
+    }
+
+    @Test
+    fun sanitizePathSegmentLeavesPlainSegmentsUnchanged() {
+        assertThat(RecipeLoader.sanitizePathSegment("java")).isEqualTo("java")
+    }
+}

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -122,38 +122,6 @@ class RecipeMarkdownGeneratorTest {
     }
 
     @Test
-    fun editionLabelReturnsCorrectLabelsForConflictingRecipes() {
-        val recipes = listOf(
-            "io.moderne.java.spring.boot3.UpgradeSpringBoot_3_4",
-            "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_4",
-            "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_3"
-        )
-        initializeConflictDetection(recipes)
-
-        assertThat(RecipeMarkdownGenerator.editionLabel("io.moderne.java.spring.boot3.UpgradeSpringBoot_3_4"))
-            .isEqualTo(" (Moderne Edition)")
-        assertThat(RecipeMarkdownGenerator.editionLabel("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_4"))
-            .isEqualTo(" (Community Edition)")
-        assertThat(RecipeMarkdownGenerator.editionLabel("org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_3"))
-            .isEqualTo("")
-    }
-
-    @Test
-    fun editionLabelDynamicallyDetectsNewConflictingPairs() {
-        // A pair that was NOT in the old hardcoded list — dynamic detection should still catch it
-        val recipes = listOf(
-            "io.moderne.java.spring.security6.UpgradeSpringSecurity_6_5",
-            "org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_5"
-        )
-        initializeConflictDetection(recipes)
-
-        assertThat(RecipeMarkdownGenerator.editionLabel("io.moderne.java.spring.security6.UpgradeSpringSecurity_6_5"))
-            .isEqualTo(" (Moderne Edition)")
-        assertThat(RecipeMarkdownGenerator.editionLabel("org.openrewrite.java.spring.security6.UpgradeSpringSecurity_6_5"))
-            .isEqualTo(" (Community Edition)")
-    }
-
-    @Test
     fun thirdPartyRecipesUnaffected() {
         // Third-party recipes should never get edition suffixes
         val recipes = listOf(


### PR DESCRIPTION
- Fixes: https://github.com/openrewrite/rewrite-recipe-markdown-generator/issues/283

- @timtebeek FYI the tests you added in: https://github.com/openrewrite/rewrite-recipe-markdown-generator/pull/281 don't compile and don't work. I think they must've been a remnant from one of the steps in the middle. I've gone ahead and removed them since I don't think they make sense given the current state of editions but feel free to let me know if you disagree.