### PR TITLE
Fix Python recipe discovery

### DIFF
--- a/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
@@ -101,24 +101,41 @@ class PythonRecipeLoader(
             val effectivePipPath = pipPackagesPath ?: Files.createTempDirectory("rewrite-python-packages")
             builder.pipPackagesPath(effectivePipPath)
 
-            // Pre-install recipe pip packages to the target directory. bootstrapOpenrewrite() only
-            // installs the core 'openrewrite' package; additional recipe packages must be installed
-            // separately so the RPC server can discover their entry points.
+            // Pre-install recipe pip packages so the RPC server can discover their entry points.
+            // bootstrapOpenrewrite() only installs the core 'openrewrite' package; additional recipe
+            // packages must be installed separately.
+            // We install both to the target directory (--target) AND to the system Python so that
+            // entry points are properly registered via importlib.metadata.
             for (pkg in packagesToLoad) {
                 if (pkg.pipPackageName == "openrewrite") continue
                 val targetDir = effectivePipPath.toAbsolutePath().normalize().toString()
                 val versionSpec = if (pkg.version != null) "${pkg.pipPackageName}==${pkg.version}" else pkg.pipPackageName
                 println("Pre-installing pip package: $versionSpec")
-                val proc = ProcessBuilder("python3", "-m", "pip", "install", "--target=$targetDir", versionSpec)
+
+                // Install to the target directory for the RPC server's package path
+                val targetProc = ProcessBuilder("python3", "-m", "pip", "install", "--target=$targetDir", versionSpec)
                     .redirectErrorStream(true)
                     .start()
-                val output = proc.inputStream.bufferedReader().readText()
-                if (!proc.waitFor(2, TimeUnit.MINUTES)) {
-                    proc.destroyForcibly()
-                    System.err.println("Warning: Timed out installing $versionSpec")
-                } else if (proc.exitValue() != 0) {
-                    System.err.println("Warning: Failed to pip install $versionSpec (exit code ${proc.exitValue()})")
-                    System.err.println(output)
+                val targetOutput = targetProc.inputStream.bufferedReader().readText()
+                if (!targetProc.waitFor(2, TimeUnit.MINUTES)) {
+                    targetProc.destroyForcibly()
+                    System.err.println("Warning: Timed out installing $versionSpec to target dir")
+                } else if (targetProc.exitValue() != 0) {
+                    System.err.println("Warning: Failed to pip install $versionSpec to target dir (exit code ${targetProc.exitValue()})")
+                    System.err.println(targetOutput)
+                }
+
+                // Also install normally so entry points are registered for importlib.metadata discovery
+                val globalProc = ProcessBuilder("python3", "-m", "pip", "install", versionSpec)
+                    .redirectErrorStream(true)
+                    .start()
+                val globalOutput = globalProc.inputStream.bufferedReader().readText()
+                if (!globalProc.waitFor(2, TimeUnit.MINUTES)) {
+                    globalProc.destroyForcibly()
+                    System.err.println("Warning: Timed out installing $versionSpec globally")
+                } else if (globalProc.exitValue() != 0) {
+                    System.err.println("Warning: Failed to pip install $versionSpec globally (exit code ${globalProc.exitValue()})")
+                    System.err.println(globalOutput)
                 }
             }
 
@@ -185,9 +202,9 @@ class PythonRecipeLoader(
             return PythonRecipeResult(allDescriptors, recipeToSource, syntheticOrigins)
 
         } catch (e: Exception) {
-            System.err.println("Error loading Python recipes: ${e.message}")
-            e.printStackTrace()
-            return PythonRecipeResult(emptyList(), emptyMap())
+            throw RuntimeException(
+                "Failed to load Python recipes. Ensure Python 3.10+ and pip are installed and available on PATH.", e
+            )
         } finally {
             // Cleanup: shutdown the RPC process
             rpc?.shutdown()

--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -110,11 +110,17 @@ class RecipeLoader {
         println("\nChecking for TypeScript/JavaScript recipes...")
         val typeScriptLoader = TypeScriptRecipeLoader(recipeOrigins)
         val typeScriptResult = typeScriptLoader.loadTypeScriptRecipes()
+        if (typeScriptResult.descriptors.isEmpty() && TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES.isNotEmpty()) {
+            System.err.println("WARNING: 0 TypeScript recipes loaded despite ${TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES.size} module(s) configured. Check that Node.js is installed.")
+        }
 
         // Load Python recipes via RPC
         println("\nChecking for Python recipes...")
         val pythonLoader = PythonRecipeLoader(recipeOrigins)
         val pythonResult = pythonLoader.loadPythonRecipes()
+        if (pythonResult.descriptors.isEmpty() && PythonRecipeLoader.PYTHON_RECIPE_MODULES.isNotEmpty()) {
+            System.err.println("WARNING: 0 Python recipes loaded despite ${PythonRecipeLoader.PYTHON_RECIPE_MODULES.size} module(s) configured. Check that Python 3.10+ and pip are installed.")
+        }
 
         // Merge TypeScript and Python results with Java/YAML results
         val allDescriptors = environmentData.flatMap { it.recipeDescriptors }.toMutableList()

--- a/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
@@ -154,9 +154,9 @@ class TypeScriptRecipeLoader(
             return TypeScriptRecipeResult(allDescriptors, recipeToSource)
 
         } catch (e: Exception) {
-            System.err.println("Error loading TypeScript recipes: ${e.message}")
-            e.printStackTrace()
-            return TypeScriptRecipeResult(emptyList(), emptyMap())
+            throw RuntimeException(
+                "Failed to load TypeScript recipes. Ensure Node.js is installed and available on PATH.", e
+            )
         } finally {
             // Cleanup: shutdown the RPC process
             rpc?.shutdown()


### PR DESCRIPTION
Python recipes from rewrite-migrate-python were missing from the generated docs. The recipes loaded fine locally - but not in the CI because the pre-install step used `pip install --target=<dir>` (which puts package files in the directory but doesn't register entry points with `importlib.metadata`). Since the RPC server discovers recipe packages via entry points, `openrewrite-migrate-python` was invisible to it.

This fixes the issue by also installing packages normally (without `--target`) so entry points are properly registered. Both RPC loaders also now throw on failure instead of silently returning empty results, so this kind of issue will be caught more quickly going forward.
