### PR TITLE
Show full tags in recipes-by-tag page

### DIFF
--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -107,17 +107,23 @@ class ListsOfRecipesWriter(
 
     fun createRecipesByTag() {
         val tagToRecipes = TreeMap<String, TreeSet<RecipeDescriptor>>(String.CASE_INSENSITIVE_ORDER)
+        val recipeToFullTags = HashMap<String, TreeMap<String, TreeSet<String>>>() // prefix -> (recipeName -> fullTags)
 
         // Collect all tags and their associated recipes
         for (recipeDescriptor in allRecipeDescriptors) {
             if (recipeDescriptor.tags != null) {
                 for (tag in recipeDescriptor.tags) {
-                    tagToRecipes.computeIfAbsent(
-                        tag
-                            .substringBefore('-')
-                            .substringBefore('_')
-                    ) { TreeSet(compareBy { it.name }) }
+                    val prefix = tag
+                        .substringBefore('-')
+                        .substringBefore('_')
+                    tagToRecipes.computeIfAbsent(prefix) { TreeSet(compareBy { it.name }) }
                         .add(recipeDescriptor)
+                    if (prefix != tag) {
+                        recipeToFullTags
+                            .computeIfAbsent(prefix) { TreeMap(String.CASE_INSENSITIVE_ORDER) }
+                            .computeIfAbsent(recipeDescriptor.name) { TreeSet(String.CASE_INSENSITIVE_ORDER) }
+                            .add(tag)
+                    }
                 }
             }
         }
@@ -160,6 +166,10 @@ class ListsOfRecipesWriter(
                         writeln("* [${recipe.name}](${recipeLinkBasePath}/${recipePath}.md)")
                         writeln("  * **${recipe.displayNameEscapedMdx()}**")
                         writeln("  * ${recipe.descriptionEscaped()}")
+                        val fullTags = recipeToFullTags[tag]?.get(recipe.name)
+                        if (fullTags != null) {
+                            writeln("  * Tags: ${fullTags.joinToString(", ")}")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- The recipes-by-tag page groups tags by their prefix (before the first `-` or `_`), but previously discarded the full tag identifier
- Now shows a "Tags:" sub-bullet under each recipe listing the full tag(s) when they differ from the section header prefix
- Makes specific tags (e.g., `RSPEC-1234`) searchable on the page while keeping the grouped layout

## Test plan
- [ ] Verify output of `recipes-by-tag.md` includes full tags as sub-bullets
- [ ] Confirm tags that match their prefix exactly (no dash/underscore) do not get a redundant "Tags:" line
- [ ] Check that multiple full tags per recipe within a prefix group are comma-separated