### PR TITLE
Fix List-type options rendered as scalars in YAML examples

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeDescriptorExtensions.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeDescriptorExtensions.kt
@@ -113,10 +113,12 @@ fun OptionDescriptor.asYaml(indentation: Int = 0): String {
     }
 
     val prefix = prefixBuilder.toString()
-    val formattedValue = if (value is Array<*>) {
+    if (value is Array<*>) {
         val asArray = value as Array<*>
-        "[${asArray.joinToString(", ")}]"
-    } else if (value == "*") {
+        val itemPrefix = prefix + "  "
+        return "$prefix$name:\n" + asArray.joinToString("") { "${itemPrefix}- $it\n" }
+    }
+    val formattedValue = if (value == "*") {
         "\"*\""
     } else {
         value

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -626,6 +626,7 @@ import TabItem from '@theme/TabItem';
                     continue
                 }
                 val optionExample = option.example
+                val isList = option.type == "List" || option.type.startsWith("List<")
                 val ex = if (optionExample != null && option.type == "String" &&
                     (optionExample.matches("^[{}\\[\\],`|=%@*!?-].*".toRegex()) ||
                             optionExample.matches(".*:\\s.*".toRegex()))
@@ -639,7 +640,12 @@ import TabItem from '@theme/TabItem';
                     option.example
                 }
                 cliOptions += " --recipe-option \"${option.name}=$ex\""
-                writeln("      ${option.name}: $ex")
+                if (isList) {
+                    writeln("      ${option.name}:")
+                    writeln("        - ${ex ?: "TODO"}")
+                } else {
+                    writeln("      ${option.name}: $ex")
+                }
             }
             writeln("```")
             newLine()


### PR DESCRIPTION
## Summary
- Fixes issue #288: Recipe options with List type now render as proper YAML block lists instead of inline scalars in documentation.

Examples like `UnfoldProperties` (where `exclusions` and `applyTo` are required List options) now show correct YAML syntax:
```yaml
applyTo:
  - $..[org.springframework.security]
```
instead of the incorrect scalar form.

## Changes
- `RecipeDescriptorExtensions.kt`: Array values render as block list items with proper indentation
- `RecipeMarkdownWriter.kt`: Usage section renders List-type options as YAML lists with placeholder values when needed