### PR TITLE
Upgrade Java toolchain from 17 to 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,13 +161,13 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 
 tasks.named<JavaCompile>("compileJava") {
-    sourceCompatibility = JavaVersion.VERSION_17.toString()
-    targetCompatibility = JavaVersion.VERSION_17.toString()
+    sourceCompatibility = JavaVersion.VERSION_21.toString()
+    targetCompatibility = JavaVersion.VERSION_21.toString()
 }
 
 tasks.withType<Test> {


### PR DESCRIPTION
**What**:
Bumping Java used from 17 to 21.

**Why**:
In a hope it helps with https://github.com/moderneinc/moderne-docs failure:
```
Caused by: java.lang.UnsupportedClassVersionError: ai/timefold/solver/migration/AbstractRecipe has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
```