### PR TITLE
Route rewrite-devcenter recipes to moderne-docs only

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -177,7 +177,7 @@ class RecipeMarkdownGenerator : Runnable {
         initializeConflictDetection(allRecipeDescriptors)
 
         val markdownArtifacts = TreeMap<String, MarkdownRecipeArtifact>()
-        val moderneProprietaryRecipes = TreeMap<String, MutableList<RecipeDescriptor>>()
+        val moderneOnlyRecipes = TreeMap<String, MutableList<RecipeDescriptor>>()
 
         // Build mapping from recipe name to Recipe instance (for checking if declarative)
         val recipesByName = allRecipes.associateBy { it.name }
@@ -231,7 +231,7 @@ class RecipeMarkdownGenerator : Runnable {
 
             // Track moderne-docs-only recipes separately (for moderne-recipes.md list and redirects)
             if (isModerneDocsOnly(origin)) {
-                moderneProprietaryRecipes.computeIfAbsent(origin.artifactId) { mutableListOf() }.add(recipeDescriptor)
+                moderneOnlyRecipes.computeIfAbsent(origin.artifactId) { mutableListOf() }.add(recipeDescriptor)
                 // Skip writing moderne-docs-only recipes to rewrite-docs
                 continue
             }
@@ -314,7 +314,7 @@ class RecipeMarkdownGenerator : Runnable {
         // Write lists of recipes into various files
         // OpenRewrite docs: open-source recipes only (links use /recipes path)
         val listWriter = ListsOfRecipesWriter(openSourceRecipeDescriptors, outputPath, "/recipes")
-        listWriter.createModerneRecipes(moderneProprietaryRecipes)
+        listWriter.createModerneRecipes(moderneOnlyRecipes)
         listWriter.createRecipesWithDataTables()
         listWriter.createRecipesByTag()
         listWriter.createScanningRecipes(
@@ -345,11 +345,11 @@ class RecipeMarkdownGenerator : Runnable {
         }
 
         // Generate redirects for proprietary recipes (from old OpenRewrite URLs to Moderne docs)
-        val allProprietaryRecipes = moderneProprietaryRecipes.values.flatten()
-        if (allProprietaryRecipes.isNotEmpty()) {
+        val allModerneOnlyRecipes = moderneOnlyRecipes.values.flatten()
+        if (allModerneOnlyRecipes.isNotEmpty()) {
             RedirectWriter.writeRedirectConfig(
                 outputPath,
-                allProprietaryRecipes,
+                allModerneOnlyRecipes,
                 "https://docs.moderne.io",
                 "/user-documentation/recipes/recipe-catalog"
             )
@@ -370,7 +370,7 @@ class RecipeMarkdownGenerator : Runnable {
         /** Modules whose docs should only appear in Moderne docs, regardless of license. */
         private val MODERNE_DOCS_ONLY_MODULES = setOf("rewrite-devcenter")
 
-        fun isModerneDocsOnly(origin: RecipeOrigin): Boolean =
+        private fun isModerneDocsOnly(origin: RecipeOrigin): Boolean =
             origin.license == Licenses.Proprietary || origin.artifactId in MODERNE_DOCS_ONLY_MODULES
 
         // Set of base paths that have both io.moderne and org.openrewrite recipes (conflicts)


### PR DESCRIPTION
Adds a MODERNE_DOCS_ONLY_MODULES set to route specific artifact IDs (like rewrite-devcenter) to the Moderne docs output only, without overwriting their actual license. This allows both org.openrewrite and io.moderne variants of rewrite-devcenter to be routed correctly while preserving their real license for content formatting.

The solution uses a new helper predicate `isModerneDocsOnly()` that checks either the license (for backwards compatibility with proprietary recipes) or the artifact ID against the new constant set. This decouples routing concerns from license, keeping the license metadata intact for content formatting decisions.