### PR TITLE
Use Maven --define long form instead of -D in CLI examples

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -573,7 +573,7 @@ import TabItem from '@theme/TabItem';
             if (recipeDescriptor.dataTables == null || recipeDescriptor.dataTables.isEmpty()) "" else "<exportDatatables>true</exportDatatables>"
 
         val dataTableCommandLineSnippet =
-            if (recipeDescriptor.dataTables == null || recipeDescriptor.dataTables.isEmpty()) "" else "-Drewrite.exportDatatables=true"
+            if (recipeDescriptor.dataTables == null || recipeDescriptor.dataTables.isEmpty()) "" else "--define rewrite.exportDatatables=true"
 
         if (requiresConfiguration) {
             val exampleRecipeName =
@@ -1172,7 +1172,7 @@ $cliSnippet
             You will need to have [Maven](https://maven.apache.org/download.cgi) installed on your machine before you can run the following command.
 
             ```shell title="shell"
-            mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.activeRecipes=${recipeDescriptor.name} $dataTableCommandLineSnippet
+            mvn -U org.openrewrite.maven:rewrite-maven-plugin:run --define rewrite.activeRecipes=${recipeDescriptor.name} $dataTableCommandLineSnippet
             ```
 
             </TabItem>
@@ -1314,7 +1314,7 @@ $cliSnippet
             You will need to have [Maven](https://maven.apache.org/download.cgi) installed on your machine before you can run the following command.
 
             ```shell title="shell"
-            mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=${origin.groupId}:${origin.artifactId}:RELEASE -Drewrite.activeRecipes=${recipeDescriptor.name} $dataTableCommandLineSnippet
+            mvn -U org.openrewrite.maven:rewrite-maven-plugin:run --define rewrite.recipeArtifactCoordinates=${origin.groupId}:${origin.artifactId}:RELEASE --define rewrite.activeRecipes=${recipeDescriptor.name} $dataTableCommandLineSnippet
             ```
             </TabItem>
             """.trimIndent()


### PR DESCRIPTION
## Summary
- Replaces `-Drewrite.*` with `--define rewrite.*` in generated Maven Command Line tab snippets
- PowerShell interprets `-D` as a parameter prefix, causing these commands to fail for Windows/PowerShell users
- The `--define` long form is functionally equivalent and works across all shells (bash, zsh, PowerShell, cmd)

## Alternatives considered

If `--define` proves problematic, other PowerShell-compatible approaches include:

| Approach | Example | Pros | Cons |
|---|---|---|---|
| Quote each `-D` arg | `"-Drewrite.activeRecipes=..."` | Simple, familiar | Easy to forget a quote |
| Backtick escape | `` `-Drewrite.activeRecipes=...`` | PS-native | Unfamiliar to non-PS users |
| Stop-parsing `--% ` | `mvn --% -U ... -Drewrite...` | One change, rest unchanged | Only works in PS 3+; not widely known |
| Separate PowerShell tab | Add a second tab with PS-specific syntax | No change to existing tab | Maintenance burden; tab clutter |

## Test plan
- [x] Verified `mvn --define` works correctly on macOS
- [ ] Verify generated markdown renders correctly on the docs site