### PR TITLE
Fix 1729 recipes listed under other/unknown in recipe list pages

### DIFF
--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -29,7 +29,8 @@ class ListsOfRecipesWriter(
         data class WithOrigin(val item: T, val groupId: String, val artifactId: String)
 
         val enriched = items.map { item ->
-            val origin = recipeOrigins[recipeToSource[nameOf(item)]]
+            val name = nameOf(item)
+            val origin = RecipeMarkdownGenerator.findOrigin(recipeToSource[name], name, recipeOrigins)
             WithOrigin(item, origin?.groupId ?: "other", origin?.artifactId ?: "unknown")
         }
 


### PR DESCRIPTION
## Summary

- `groupByOrigin()` in `ListsOfRecipesWriter` did a direct URI map lookup to resolve recipe origins, but YAML (declarative) recipes have `jar:file:...!META-INF/rewrite/foo.yml` URIs that don't match the plain `file:` URIs used as keys in `recipeOrigins`
- This caused ~1729 recipes to fall through to the `"other"/"unknown"` fallback on https://docs.openrewrite.org/reference/all-recipes#other
- Fixed by reusing the existing `RecipeMarkdownGenerator.findOrigin()` helper, which correctly strips the `jar:` prefix and `!...` suffix before lookup, and also handles TypeScript/Python URI schemes

## Test plan

- [x] Existing tests pass (the one failing test `latestVersions` is pre-existing on main)
- [ ] Run the full generator and verify the "other" section in `all-recipes.md` is empty or near-empty
- [ ] Verify `standalone-recipes.md` and `scanning-recipes.md` also have correct groupings