### PR TITLE
Use two-level heading hierarchy in data tables and Moderne recipe lists

### DIFF
--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -44,7 +44,11 @@ class ListsOfRecipesWriter(
             .toSortedMap()
     }
 
-    fun createModerneRecipes(moderneProprietaryRecipesMap: TreeMap<String, MutableList<RecipeDescriptor>>) {
+    fun createModerneRecipes(
+        moderneProprietaryRecipes: List<RecipeDescriptor>,
+        recipeOrigins: Map<URI, RecipeOrigin>,
+        recipeToSource: Map<String, URI>
+    ) {
         val moderneRecipesPath = outputPath.resolve("moderne-recipes.md")
 
         Files.newBufferedWriter(moderneRecipesPath, StandardOpenOption.CREATE).useAndApply {
@@ -64,32 +68,36 @@ class ListsOfRecipesWriter(
                         "[contact us](https://www.moderne.ai/contact-us).\n"
             )
 
-            for (entry in moderneProprietaryRecipesMap) {
-                // Artifact ID
-                writeln("\n## ${entry.key}\n")
+            for ((groupId, artifactMap) in groupByOrigin(moderneProprietaryRecipes, { it.name }, recipeOrigins, recipeToSource)) {
+                writeln("\n## ${groupId}\n")
 
-                for (recipe in entry.value.sortedBy { it.name }) {
-                    val recipePath = RecipeMarkdownGenerator.getRecipePath(recipe)
-                    // Link to Moderne docs since these recipes are exclusive to Moderne
-                    writeln("* [${recipe.name}](https://docs.moderne.io/user-documentation/recipes/recipe-catalog/${recipePath})")
-                    writeln("  * **${recipe.displayNameEscapedMdx()}**")
-                    writeln("  * ${recipe.descriptionEscaped()}")
+                for ((artifactId, recipes) in artifactMap) {
+                    writeln("\n### ${artifactId}\n")
+
+                    for (recipe in recipes.sortedBy { it.name }) {
+                        val recipePath = RecipeMarkdownGenerator.getRecipePath(recipe)
+                        // Link to Moderne docs since these recipes are exclusive to Moderne
+                        writeln("* [${recipe.name}](https://docs.moderne.io/user-documentation/recipes/recipe-catalog/${recipePath})")
+                        writeln("  * **${recipe.displayNameEscapedMdx()}**")
+                        writeln("  * ${recipe.descriptionEscaped()}")
+                    }
                 }
-
-                writeln("")
             }
         }
     }
 
     // These are common in every recipe - so let's not use them when generating the list of recipes with data tables.
-    private val dataTablesToIgnore = listOf(
+    private val dataTablesToIgnore = setOf(
         "org.openrewrite.table.SearchResults",
         "org.openrewrite.table.SourcesFileResults",
         "org.openrewrite.table.SourcesFileErrors",
         "org.openrewrite.table.RecipeRunStats"
     )
 
-    fun createRecipesWithDataTables() {
+    fun createRecipesWithDataTables(
+        recipeOrigins: Map<URI, RecipeOrigin>,
+        recipeToSource: Map<String, URI>
+    ) {
         val recipesWithDataTables = allRecipeDescriptors.filter {
             it.dataTables != null && it.dataTables.any { dataTable -> dataTable.name !in dataTablesToIgnore }
         }
@@ -112,23 +120,31 @@ class ListsOfRecipesWriter(
                         "it won't be included in this list._\n"
             )
 
-            for (recipe in recipesWithDataTables) {
-                val recipePath = RecipeMarkdownGenerator.getRecipePath(recipe)
-                writeln("### [${recipe.name}](${recipeLinkBasePath}/${recipePath}.md)")
-                writeln("  * **${recipe.displayNameEscapedMdx()}**")
-                writeln("  * ${recipe.descriptionEscaped()}")
+            for ((groupId, artifactMap) in groupByOrigin(recipesWithDataTables, { it.name }, recipeOrigins, recipeToSource)) {
+                writeln("\n## ${groupId}\n")
 
-                writeln("\n#### Data tables:\n")
+                for ((artifactId, recipes) in artifactMap) {
+                    writeln("\n### ${artifactId}\n")
 
-                val filteredDataTables = recipe.dataTables.filter { dataTable ->
-                    dataTable.name !in dataTablesToIgnore
+                    for (recipe in recipes.sortedBy { it.name }) {
+                        val recipePath = RecipeMarkdownGenerator.getRecipePath(recipe)
+                        writeln("#### [${recipe.name}](${recipeLinkBasePath}/${recipePath}.md)")
+                        writeln("  * **${recipe.displayNameEscapedMdx()}**")
+                        writeln("  * ${recipe.descriptionEscaped()}")
+
+                        writeln("\n##### Data tables:\n")
+
+                        val filteredDataTables = recipe.dataTables.filter { dataTable ->
+                            dataTable.name !in dataTablesToIgnore
+                        }
+
+                        for (dataTable in filteredDataTables) {
+                            writeln("  * **${dataTable.name}**: *${escapeMdx(dataTable.description).replace("\n", " ")}*")
+                        }
+
+                        writeln("\n")
+                    }
                 }
-
-                for (dataTable in filteredDataTables) {
-                    writeln("  * **${dataTable.name}**: *${escapeMdx(dataTable.description).replace("\n", " ")}*")
-                }
-
-                writeln("\n")
             }
         }
     }

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -314,8 +314,8 @@ class RecipeMarkdownGenerator : Runnable {
         // Write lists of recipes into various files
         // OpenRewrite docs: open-source recipes only (links use /recipes path)
         val listWriter = ListsOfRecipesWriter(openSourceRecipeDescriptors, outputPath, "/recipes")
-        listWriter.createModerneRecipes(moderneOnlyRecipes)
-        listWriter.createRecipesWithDataTables()
+        listWriter.createModerneRecipes(moderneOnlyRecipes.values.flatten(), recipeOrigins, recipeToSource)
+        listWriter.createRecipesWithDataTables(recipeOrigins, recipeToSource)
         listWriter.createRecipesByTag()
         listWriter.createScanningRecipes(
             allRecipes.filter { recipe ->
@@ -331,7 +331,7 @@ class RecipeMarkdownGenerator : Runnable {
         // Moderne docs: ALL recipes (links use /user-documentation/recipes/recipe-catalog path)
         if (moderneListsPath != null) {
             val moderneListWriter = ListsOfRecipesWriter(allRecipeDescriptors, moderneListsPath, "/user-documentation/recipes/recipe-catalog")
-            moderneListWriter.createRecipesWithDataTables()
+            moderneListWriter.createRecipesWithDataTables(recipeOrigins, recipeToSource)
             moderneListWriter.createRecipesByTag()
             moderneListWriter.createScanningRecipes(
                 allRecipes.filter { recipe ->


### PR DESCRIPTION
## Summary
- Updates "Recipes with Data Tables" and "Moderne Recipes" pages to use the same two-level heading hierarchy (`## groupId` / `### artifactId`) introduced in #293 for other recipe list pages
- Both methods now use the existing `groupByOrigin()` helper for consistent grouping across all recipe list pages

## Test plan
- [x] Project compiles successfully
- [x] All tests pass (except pre-existing `latestVersions` failure on main)
- [ ] Verify generated markdown shows groupId/artifactId hierarchy in recipes-with-data-tables.md and moderne-recipes.md