### PR TITLE
Fix latestVersions test and add CI test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - "*"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v5
+      - name: Run tests
+        run: ./gradlew test

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -30,6 +30,7 @@ class RecipeMarkdownGeneratorTest {
             "1.x", // Moderne Recipe BOM
             "6.x", // Gradle plugin
             "5.x", // Maven plugin
+            "--latest-versions-only",
         )
         assertThat(exitCode).isEqualTo(0)
 


### PR DESCRIPTION
## Summary
- Fix the `latestVersions` test which failed because it ran the full generator flow (including Python recipe loading via pip) when it only needs to verify the latest-versions markdown file. Added `--latest-versions-only` flag to match the test's intent.
- Add a new GitHub Actions workflow (`test.yml`) to run `./gradlew test` on pushes to main and PRs, since the existing CI workflow only runs the generator and never runs tests.

## Test plan
- [x] `./gradlew test` passes locally (11/11 tests)