### PR TITLE
Escape cliOptions values for valid JSX string literals

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -682,8 +682,10 @@ import RunRecipe from '@site/src/components/RunRecipe';
         }
 
         if (cliOptions.isNotEmpty()) {
-            // Use single quotes for JSX to avoid issues with double quotes in option values
-            props.appendLine("  cliOptions={'$cliOptions'}")
+            // Use single quotes for JSX to avoid issues with double quotes in option values.
+            // Escape backslashes, single quotes, and newlines so the JS string literal is valid.
+            val escaped = cliOptions.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n")
+            props.appendLine("  cliOptions={'$escaped'}")
         }
 
         if (suppressGradle) {


### PR DESCRIPTION
## Summary

- Fixes the docs deployment failure ([run](https://github.com/openrewrite/rewrite-docs/actions/runs/23382227531)) caused by 43 recipe markdown files with invalid MDX
- The `cliOptions` prop can contain single quotes (from option examples like `'$.subjects.*'`) and newlines (from YAML block scalar syntax) which break the JS string literal `{' ... '}` in the generated JSX
- Escapes `\`, `'`, and `\n` in the cliOptions value before embedding it in the JSX attribute

## Test plan

- [x] `./gradlew compileKotlin` passes
- [x] `./gradlew test` passes
- [ ] Re-run the docs update workflow after merging to verify the build succeeds