### PR TITLE
Always pass artifact coordinates to RunRecipe component

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -671,10 +671,11 @@ import RunRecipe from '@site/src/components/RunRecipe';
         props.appendLine("  recipeName=\"${recipeDescriptor.name}\"")
         props.appendLine("  displayName=\"${recipeDescriptor.displayNameEscapedMdx()}\"")
 
-        if (requiresDependency) {
-            props.appendLine("  groupId=\"${origin.groupId}\"")
-            props.appendLine("  artifactId=\"${origin.artifactId}\"")
-            props.appendLine("  versionKey=\"${origin.versionPlaceholderKey()}\"")
+        props.appendLine("  groupId=\"${origin.groupId}\"")
+        props.appendLine("  artifactId=\"${origin.artifactId}\"")
+        props.appendLine("  versionKey=\"${origin.versionPlaceholderKey()}\"")
+        if (!requiresDependency) {
+            props.appendLine("  isCoreLibrary")
         }
 
         if (requiresConfiguration) {


### PR DESCRIPTION
## Summary

Core library recipes (e.g. `rewrite-properties`'s `AddProperty`) were missing CLI installation commands because `groupId`, `artifactId`, and `versionKey` were only passed to `<RunRecipe>` when `requiresDependency` was true. Since core libraries have `requiresDependency=false`, the component had no artifact info to render the CLI install command.

Now always passes artifact coordinates to `<RunRecipe>` and adds an `isCoreLibrary` flag so the component can still skip Maven/Gradle dependency snippets for core libraries.

## Test plan
- [x] `./gradlew test` passes
- [ ] Verify generated markdown for a core library recipe (e.g. AddProperty) includes `groupId`, `artifactId`, `versionKey`, and `isCoreLibrary`
- [ ] Verify generated markdown for a non-core library recipe does NOT include `isCoreLibrary`