### PR TITLE
Register Java marketplace with CSharpRewriteRpc for delegatesTo resolution

### DIFF
--- a/src/main/kotlin/org/openrewrite/CSharpRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/CSharpRecipeLoader.kt
@@ -5,6 +5,10 @@ package org.openrewrite
 import org.openrewrite.config.RecipeDescriptor
 import org.openrewrite.csharp.rpc.CSharpRewriteRpc
 import org.openrewrite.marketplace.RecipeBundle
+import org.openrewrite.marketplace.RecipeBundleReader
+import org.openrewrite.marketplace.RecipeBundleResolver
+import org.openrewrite.marketplace.RecipeListing
+import org.openrewrite.marketplace.RecipeMarketplace
 import java.net.URI
 
 /**
@@ -13,7 +17,9 @@ import java.net.URI
  * needing to parse C# source files directly.
  */
 class CSharpRecipeLoader(
-    private val recipeOrigins: Map<URI, RecipeOrigin>
+    private val recipeOrigins: Map<URI, RecipeOrigin>,
+    private val javaDescriptors: Collection<RecipeDescriptor> = emptyList(),
+    private val classloader: ClassLoader = CSharpRecipeLoader::class.java.classLoader
 ) {
 
     companion object {
@@ -43,6 +49,21 @@ class CSharpRecipeLoader(
             "recipes-migrate-dotnet" to "https://github.com/moderneinc/recipes-csharp/blob/main/",
             "recipes-tunit" to "https://github.com/moderneinc/recipes-csharp/blob/main/"
         )
+
+        private val CLASSPATH_BUNDLE = RecipeBundle("classpath", "java-recipes", null, null, null)
+
+        /**
+         * Build a [RecipeMarketplace] populated with Java recipe descriptors so that
+         * C# recipes that delegate to Java recipes can be resolved during [CSharpRewriteRpc.prepareRecipe].
+         */
+        @JvmStatic
+        fun buildMarketplace(descriptors: Collection<RecipeDescriptor>): RecipeMarketplace {
+            val marketplace = RecipeMarketplace()
+            for (descriptor in descriptors) {
+                marketplace.install(RecipeListing.fromDescriptor(descriptor, CLASSPATH_BUNDLE), emptyList())
+            }
+            return marketplace
+        }
     }
 
     data class CSharpRecipeResult(
@@ -70,6 +91,27 @@ class CSharpRecipeLoader(
     }
 
     /**
+     * Creates a [RecipeBundleResolver] that can prepare Java recipes from the classpath.
+     * Used when C# recipes delegate to Java recipes via [org.openrewrite.rpc.request.PrepareRecipeResponse.DelegatesTo].
+     */
+    private fun classpathResolver(): RecipeBundleResolver {
+        return object : RecipeBundleResolver {
+            override fun getEcosystem() = CLASSPATH_BUNDLE.packageEcosystem
+
+            override fun resolve(bundle: RecipeBundle): RecipeBundleReader {
+                val loader = org.openrewrite.internal.RecipeLoader(classloader)
+                return object : RecipeBundleReader {
+                    override fun getBundle() = bundle
+                    override fun read() = RecipeMarketplace()
+                    override fun describe(listing: RecipeListing) = loader.load(listing.name, emptyMap()).descriptor
+                    override fun prepare(listing: RecipeListing, options: MutableMap<String, Any>) =
+                        loader.load(listing.name, options)
+                }
+            }
+        }
+    }
+
+    /**
      * Loads C# recipes from NuGet packages via RPC.
      */
     fun loadCSharpRecipes(): CSharpRecipeResult {
@@ -87,14 +129,21 @@ class CSharpRecipeLoader(
 
         println("Found ${packagesToLoad.size} C# recipe module(s): ${packagesToLoad.joinToString { it.artifactId }}")
 
+        val marketplace = buildMarketplace(javaDescriptors)
+        if (javaDescriptors.isNotEmpty()) {
+            println("Registered ${javaDescriptors.size} Java recipe(s) in marketplace for delegatesTo resolution")
+        }
+
         var rpc: CSharpRewriteRpc? = null
         try {
-            rpc = CSharpRewriteRpc.builder().get()
+            rpc = CSharpRewriteRpc.builder()
+                .marketplace(marketplace)
+                .resolvers(listOf(classpathResolver()))
+                .get()
             println("Started .NET RPC process for C# recipe loading")
 
-            val allDescriptors = mutableListOf<RecipeDescriptor>()
-            val recipeToSource = mutableMapOf<String, URI>()
-
+            // Phase 1: Install all NuGet packages before preparing any recipes.
+            // This ensures cross-package delegatesTo (e.g. TUnit → org.openrewrite.csharp.*) can resolve.
             for (pkg in packagesToLoad) {
                 try {
                     val versionLabel = pkg.version ?: "latest"
@@ -106,7 +155,18 @@ class CSharpRecipeLoader(
                         rpc.installRecipes(pkg.nugetPackageName)
                     }
                     println("  Installed ${response.recipesInstalled} recipe(s) from ${pkg.nugetPackageName}")
+                } catch (e: Exception) {
+                    System.err.println("Warning: Failed to install recipes from ${pkg.artifactId}: ${e.message}")
+                    e.printStackTrace()
+                }
+            }
 
+            // Phase 2: Now prepare recipes from each package.
+            val allDescriptors = mutableListOf<RecipeDescriptor>()
+            val recipeToSource = mutableMapOf<String, URI>()
+
+            for (pkg in packagesToLoad) {
+                try {
                     val descriptors = rpc.getMarketplace(RecipeBundle("nuget", pkg.nugetPackageName, null, null, null))
                         .allRecipes
                         .mapNotNull { r ->
@@ -129,7 +189,7 @@ class CSharpRecipeLoader(
                     allDescriptors.addAll(newDescriptors)
 
                 } catch (e: Exception) {
-                    System.err.println("Warning: Failed to install recipes from ${pkg.artifactId}: ${e.message}")
+                    System.err.println("Warning: Failed to load recipes from ${pkg.artifactId}: ${e.message}")
                     e.printStackTrace()
                 }
             }

--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -122,9 +122,10 @@ class RecipeLoader {
             System.err.println("WARNING: 0 Python recipes loaded despite ${PythonRecipeLoader.PYTHON_RECIPE_MODULES.size} module(s) configured. Check that Python 3.10+ and pip are installed.")
         }
 
-        // Load C# recipes via RPC
+        // Load C# recipes via RPC, passing Java descriptors so delegatesTo can resolve
         println("\nChecking for C# recipes...")
-        val csharpLoader = CSharpRecipeLoader(recipeOrigins)
+        val javaDescriptors = environmentData.flatMap { it.recipeDescriptors }
+        val csharpLoader = CSharpRecipeLoader(recipeOrigins, javaDescriptors, classloader)
         val csharpResult = csharpLoader.loadCSharpRecipes()
         if (csharpResult.descriptors.isEmpty() && CSharpRecipeLoader.CSHARP_RECIPE_MODULES.isNotEmpty()) {
             System.err.println("WARNING: 0 C# recipes loaded despite ${CSharpRecipeLoader.CSHARP_RECIPE_MODULES.size} module(s) configured. Check that .NET SDK is installed.")

--- a/src/test/kotlin/org/openrewrite/CSharpRecipeLoaderTest.kt
+++ b/src/test/kotlin/org/openrewrite/CSharpRecipeLoaderTest.kt
@@ -2,6 +2,9 @@ package org.openrewrite
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.openrewrite.config.OptionDescriptor
+import org.openrewrite.config.RecipeDescriptor
+import java.net.URI
 
 class CSharpRecipeLoaderTest {
 
@@ -18,5 +21,54 @@ class CSharpRecipeLoaderTest {
             .isEqualTo("OpenRewrite.MigrateDotNet")
         assertThat(CSharpRecipeLoader.CSHARP_RECIPE_MODULES["recipes-tunit"])
             .isEqualTo("OpenRewrite.TUnit")
+    }
+
+    private fun descriptor(name: String, displayName: String, description: String,
+                           options: List<OptionDescriptor> = emptyList()): RecipeDescriptor {
+        return RecipeDescriptor(
+            name, displayName, displayName, description,
+            emptySet(), null, options, emptyList(), emptyList(),
+            emptyList(), emptyList(), emptyList(), emptyList(),
+            URI.create("file:///test")
+        )
+    }
+
+    @Test
+    fun buildMarketplacePopulatesFromJavaDescriptors() {
+        val descriptors = listOf(
+            descriptor("org.openrewrite.java.ChangeMethodName", "Change method name", "Rename a method"),
+            descriptor("org.openrewrite.java.ChangeType", "Change type", "Change a type reference")
+        )
+
+        val marketplace = CSharpRecipeLoader.buildMarketplace(descriptors)
+
+        assertThat(marketplace.findRecipe("org.openrewrite.java.ChangeMethodName")).isNotNull
+        assertThat(marketplace.findRecipe("org.openrewrite.java.ChangeType")).isNotNull
+        assertThat(marketplace.findRecipe("org.openrewrite.java.NonExistent")).isNull()
+    }
+
+    @Test
+    fun buildMarketplaceHandlesEmptyDescriptors() {
+        val marketplace = CSharpRecipeLoader.buildMarketplace(emptyList())
+
+        assertThat(marketplace.allRecipes).isEmpty()
+    }
+
+    @Test
+    fun buildMarketplacePreservesRecipeOptions() {
+        val options = listOf(
+            OptionDescriptor("methodPattern", "String", "Method pattern", "A method pattern", null, null, true, null),
+            OptionDescriptor("newName", "String", "New name", "The new name", null, null, true, null)
+        )
+        val descriptors = listOf(
+            descriptor("org.openrewrite.java.ChangeMethodName", "Change method name", "Rename a method", options)
+        )
+
+        val marketplace = CSharpRecipeLoader.buildMarketplace(descriptors)
+        val listing = marketplace.findRecipe("org.openrewrite.java.ChangeMethodName")
+
+        assertThat(listing).isNotNull
+        assertThat(listing!!.options).hasSize(2)
+        assertThat(listing.options.map { it.name }).containsExactly("methodPattern", "newName")
     }
 }


### PR DESCRIPTION
## Motivation

C# recipes that delegate to Java recipes (e.g. `OpenRewrite.Recipes.ChangeMethodName` → `org.openrewrite.java.ChangeMethodName`) fail during `prepareRecipe` with:

```
Remote declared delegatesTo org.openrewrite.java.ChangeMethodName but no recipe found in marketplace.
```

This happens because `CSharpRewriteRpc` is constructed with an empty `RecipeMarketplace`, so when `prepareRecipe` gets a `delegatesTo` response from the C# process, the Java host can't resolve the delegate. Additionally, cross-C#-package delegation (e.g. TUnit recipes → `org.openrewrite.csharp.*` from CodeQuality) fails because packages are installed and prepared one at a time.

- Fixes openrewrite/rewrite#7142

## Summary

- Populate a `RecipeMarketplace` with all Java recipe descriptors and pass it to `CSharpRewriteRpc.builder().marketplace()`
- Create a classpath-backed `RecipeBundleResolver` so `delegatesTo` can instantiate Java recipes
- Restructure the NuGet install loop into two phases: install-all-then-prepare-all, so cross-C#-package delegation resolves within the C# process
- Pass Java descriptors and classloader from `RecipeLoader` to `CSharpRecipeLoader`

## Test plan

- [ ] Unit tests for `buildMarketplace` (populates from descriptors, handles empty input, preserves options)
- [ ] Full generator run to verify C# recipes that previously failed with `delegatesTo` errors now produce markdown pages
- [ ] Verify no regression in Java/TypeScript/Python recipe loading