### PR TITLE
Add rewrite-angular to TypeScript recipe modules

### DIFF
--- a/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
@@ -29,7 +29,8 @@ class TypeScriptRecipeLoader(
          */
         val TYPESCRIPT_RECIPE_MODULES = mapOf(
             "rewrite-javascript" to "@openrewrite/rewrite",
-            "rewrite-nodejs" to "@openrewrite/recipes-nodejs"
+            "rewrite-nodejs" to "@openrewrite/recipes-nodejs",
+            "rewrite-angular" to "@openrewrite/recipes-angular"
             // "rewrite-react" to "@openrewrite/recipes-react"  // Not yet published - uncomment when available
         )
     }


### PR DESCRIPTION
## Summary

- Register `rewrite-angular` → `@openrewrite/recipes-angular` in `TYPESCRIPT_RECIPE_MODULES` so the markdown generator discovers and documents Angular TypeScript recipes
- The JAR dependency was already in `build.gradle.kts` (line 146), but the TS recipe loader didn't know about the npm package, so Angular TS recipes were missing from docs.moderne.io

## Context

`rewrite-nodejs` TS recipes appear on docs.moderne.io because it's registered in `TYPESCRIPT_RECIPE_MODULES`. `rewrite-angular` has the same npm publishing setup (`@openrewrite/recipes-angular` is published to npm) but was missing from the registry, so its TS recipes were never loaded via RPC.