### PR TITLE
Show preconditions in generated recipe docs

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeDescriptorExtensions.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeDescriptorExtensions.kt
@@ -81,6 +81,20 @@ description: |
             s.appendLine(option.asYaml())
         }
     }
+    if (preconditions.isNotEmpty()) {
+        s.appendLine("preconditions:")
+        for (precondition in preconditions) {
+            s.append("  - ${precondition.name}")
+            if (precondition.options.isEmpty() || precondition.options.all { it.value == null }) {
+                s.appendLine()
+            } else {
+                s.appendLine(":")
+            }
+            for (option in precondition.options) {
+                s.append(option.asYaml(3))
+            }
+        }
+    }
     if (recipeList.isNotEmpty()) {
         s.appendLine("recipeList:")
         for (subRecipe in recipeList) {

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -764,6 +764,34 @@ ${props.toString().trimEnd()}
             }
             val pathToRecipes = pathToRecipesBuilder.toString()
 
+            if (recipeDescriptor.preconditions.isNotEmpty()) {
+                writeln("**Preconditions**")
+                newLine()
+                for (precondition in recipeDescriptor.preconditions) {
+                    if (recipeToSource.containsKey(precondition.name)) {
+                        val recipeLink = getRecipeLink(precondition, pathToRecipes)
+                        writeln("* [${precondition.displayNameEscapedMdx()}]($recipeLink)")
+                    } else {
+                        writeln("* ${precondition.displayNameEscapedMdx()}")
+                    }
+
+                    if (precondition.options.isNotEmpty()) {
+                        for (option in precondition.options) {
+                            if (option.value != null) {
+                                val formattedOptionString = printValue(option.value!!)
+                                    .replace("<p>", "< p >")
+                                    .replace("\n", " ")
+
+                                writeln("  * " + option.name + ": `" + formattedOptionString + "`")
+                            }
+                        }
+                    }
+                }
+                newLine()
+                writeln("**Recipes**")
+                newLine()
+            }
+
             for (recipe in recipeDescriptor.recipeList) {
                 // https://github.com/openrewrite/rewrite-docs/issues/250
                 if (recipe.displayName == "Precondition bellwether") {

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.config.OptionDescriptor
 import org.openrewrite.config.RecipeDescriptor
 import picocli.CommandLine
 import java.io.PrintWriter
@@ -193,6 +194,85 @@ class RecipeMarkdownGeneratorTest {
 
     private fun getRecipePath(recipeName: String): String {
         return RecipeMarkdownGenerator.getRecipePath(createDescriptor(recipeName))
+    }
+
+    @Test
+    fun asYamlIncludesPreconditions() {
+        initializeConflictDetection(emptyList())
+
+        val precondition = RecipeDescriptor(
+            "org.openrewrite.java.search.HasJavaVersion",
+            "Has Java version",
+            "",
+            "Check Java version",
+            mutableSetOf(),
+            java.time.Duration.ZERO,
+            mutableListOf(OptionDescriptor("version", "String", "Version", "The version", null, null, false, "21.X")),
+            mutableListOf(),  // preconditions
+            mutableListOf(),  // recipeList
+            mutableListOf(),
+            mutableListOf(),
+            mutableListOf(),
+            mutableListOf(),
+            URI.create("https://example.com/recipe")
+        )
+
+        val subRecipe = RecipeDescriptor(
+            "org.openrewrite.java.spring.AddSpringProperty",
+            "Add Spring property",
+            "",
+            "Add a property",
+            mutableSetOf(),
+            java.time.Duration.ZERO,
+            mutableListOf(
+                OptionDescriptor("property", "String", "Property", "The property", null, null, true, "spring.threads.virtual.enabled"),
+                OptionDescriptor("value", "String", "Value", "The value", null, null, true, "true")
+            ),
+            mutableListOf(),
+            mutableListOf(),
+            mutableListOf(),
+            mutableListOf(),
+            mutableListOf(),
+            mutableListOf(),
+            URI.create("https://example.com/recipe")
+        )
+
+        val descriptor = RecipeDescriptor(
+            "org.openrewrite.java.spring.boot3.EnableVirtualThreads",
+            "Enable Virtual Threads on Java 21",
+            "",
+            "Set spring.threads.virtual.enabled to true.",
+            mutableSetOf(),
+            java.time.Duration.ZERO,
+            mutableListOf(),
+            mutableListOf(precondition),  // preconditions
+            mutableListOf(subRecipe),     // recipeList
+            mutableListOf(),
+            mutableListOf(),
+            mutableListOf(),
+            mutableListOf(),
+            URI.create("https://example.com/recipe")
+        )
+
+        val yaml = descriptor.asYaml()
+        assertThat(yaml).contains("preconditions:")
+        assertThat(yaml).contains("  - org.openrewrite.java.search.HasJavaVersion:")
+        assertThat(yaml).contains("      version: 21.X")
+        assertThat(yaml).contains("recipeList:")
+        assertThat(yaml).contains("  - org.openrewrite.java.spring.AddSpringProperty:")
+        assertThat(yaml).contains("      property: spring.threads.virtual.enabled")
+
+        // preconditions should appear before recipeList
+        assertThat(yaml.indexOf("preconditions:")).isLessThan(yaml.indexOf("recipeList:"))
+    }
+
+    @Test
+    fun asYamlOmitsPreconditionsWhenEmpty() {
+        initializeConflictDetection(emptyList())
+
+        val descriptor = createDescriptor("org.openrewrite.test.SomeRecipe")
+        val yaml = descriptor.asYaml()
+        assertThat(yaml).doesNotContain("preconditions:")
     }
 
     private fun createDescriptor(recipeName: String): RecipeDescriptor {


### PR DESCRIPTION
## Summary

- Fixes https://github.com/openrewrite/rewrite-docs/issues/250

- Renders a `preconditions:` section in the generated YAML tab using `RecipeDescriptor.getPreconditions()` (available since rewrite-core 8.79.0), with configured options shown inline
- Adds a **Preconditions** / **Recipes** labeled split in the human-readable Recipe List tab, with links and option values
- Keeps existing bellwether filtering as a safety net
- 656 recipes across the codebase now correctly show their preconditions (e.g., `EnableVirtualThreads` shows `HasJavaVersion` with `version: 21.X`)

## Test plan

- [x] Unit tests for `asYaml()` with and without preconditions
- [x] Full generator run verified `EnableVirtualThreads` output matches the ideal from the issue
- [x] `./gradlew build` passes