### PR TITLE
Generate CLI install commands for pip, npm, and nuget ecosystems

### DIFF
--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -59,13 +59,39 @@ class VersionWriter {
                 | [**io.moderne.recipe:moderne-recipe-bom**](https://github.com/moderneinc/moderne-recipe-bom)                          | **${moderneBomLink}** | ${Licenses.Proprietary.markdown()} |
                 """.trimIndent()
             )
-            var cliInstallGavs = ""
-            var cliInstallGavsLatest = ""
+            var cliInstallJarPinned = ""
+            var cliInstallJarLatest = ""
+            var cliInstallPipPinned = ""
+            var cliInstallPipLatest = ""
+            var cliInstallNpmPinned = ""
+            var cliInstallNpmLatest = ""
+            var cliInstallNugetPinned = ""
+            var cliInstallNugetLatest = ""
             var loadRecipesAsync = ""
             for (origin in recipeOrigins) {
 
-                cliInstallGavs += "${origin.groupId}:${origin.artifactId}:{{${origin.versionPlaceholderKey()}}} "
-                cliInstallGavsLatest += "${origin.groupId}:${origin.artifactId}:LATEST "
+                val versionPlaceholder = "{{${origin.versionPlaceholderKey()}}}"
+                when (origin.artifactId) {
+                    in PythonRecipeLoader.PYTHON_RECIPE_MODULES -> {
+                        val pipPackage = PythonRecipeLoader.PYTHON_RECIPE_MODULES.getValue(origin.artifactId)
+                        cliInstallPipPinned += "$pipPackage==$versionPlaceholder "
+                        cliInstallPipLatest += "$pipPackage "
+                    }
+                    in TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES -> {
+                        val npmPackage = TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES.getValue(origin.artifactId)
+                        cliInstallNpmPinned += "$npmPackage@$versionPlaceholder "
+                        cliInstallNpmLatest += "$npmPackage "
+                    }
+                    in CSharpRecipeLoader.CSHARP_RECIPE_MODULES -> {
+                        val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES.getValue(origin.artifactId)
+                        cliInstallNugetPinned += "$nugetPackage@$versionPlaceholder "
+                        cliInstallNugetLatest += "$nugetPackage "
+                    }
+                    else -> {
+                        cliInstallJarPinned += "${origin.groupId}:${origin.artifactId}:$versionPlaceholder "
+                        cliInstallJarLatest += "${origin.groupId}:${origin.artifactId}:LATEST "
+                    }
+                }
 
                 val loadCommand = "load_" + (origin.groupId + '_' + origin.artifactId)
                     .replace('-', '_')
@@ -84,10 +110,24 @@ class VersionWriter {
                 val releaseLink = "[${origin.version}](${origin.releaseUrl(origin.version)})"
                 writeln("| ${repoLink.padEnd(117)} | ${releaseLink.padEnd(90)} | ${origin.license.markdown()} |")
             }
+
+            val pinnedInstalls = listOf(
+                "jar" to cliInstallJarPinned,
+                "pip" to cliInstallPipPinned,
+                "npm" to cliInstallNpmPinned,
+                "nuget" to cliInstallNugetPinned,
+            )
+            val latestInstalls = listOf(
+                "jar" to cliInstallJarLatest,
+                "pip" to cliInstallPipLatest,
+                "npm" to cliInstallNpmLatest,
+                "nuget" to cliInstallNugetLatest,
+            )
+
             //language=markdown
             writeln(
                 """
-                
+
                 ## CLI Installation
 
                 Install the latest versions of all the OpenRewrite recipe modules into the Moderne CLI:
@@ -96,16 +136,29 @@ class VersionWriter {
                 <TabItem value="pinned" label="Pinned versions">
 
                 ```bash
-                mod config recipes jar install ${cliInstallGavs}
+                """.trimIndent()
+            )
+            for ((type, packages) in pinnedInstalls) {
+                if (packages.isNotBlank()) writeln("mod config recipes $type install ${packages.trim()}")
+            }
+            writeln(
+                """
                 ```
 
                 </TabItem>
                 <TabItem value="latest" label="Latest versions">
 
-                Install with `:LATEST` so you can later run `mod config recipes upgrade` to pull the newest versions without editing this command.
+                Install without a pinned version so you can later run `mod config recipes upgrade` to pull the newest versions without editing this command.
 
                 ```bash
-                mod config recipes jar install ${cliInstallGavsLatest}
+                """.trimIndent()
+            )
+            for ((type, packages) in latestInstalls) {
+                if (packages.isNotBlank()) writeln("mod config recipes $type install ${packages.trim()}")
+            }
+            //language=markdown
+            writeln(
+                """
                 ```
 
                 </TabItem>

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -42,6 +42,33 @@ class RecipeMarkdownGeneratorTest {
     }
 
     @Test
+    fun latestVersionsMultiEcosystemInstall(@TempDir tempDir: Path) {
+        fun mk(g: String, a: String, v: String): RecipeOrigin {
+            val o = RecipeOrigin(g, a, v, URI.create("file:///$a.jar"))
+            o.repositoryUrl = "https://github.com/openrewrite/$a/blob/main/"
+            o.license = Licenses.Apache2
+            return o
+        }
+        val origins = listOf(
+            mk("org.openrewrite.recipe", "rewrite-spring", "5.0.0"),
+            mk("org.openrewrite", "rewrite-python", "1.2.3"),
+            mk("org.openrewrite.recipe", "rewrite-migrate-python", "0.5.0"),
+            mk("org.openrewrite", "rewrite-javascript", "0.9.0"),
+            mk("io.moderne.recipe", "recipes-code-quality", "0.1.0"),
+        )
+        VersionWriter().createLatestVersionsMarkdown(tempDir, origins, "8.x", "2.x", "1.x", "6.x", "5.x")
+        val out = Files.readString(tempDir.resolve("latest-versions-of-every-openrewrite-module.md"))
+        assertThat(out).contains("mod config recipes jar install org.openrewrite.recipe:rewrite-spring:{{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_SPRING}}")
+        assertThat(out).contains("mod config recipes jar install org.openrewrite.recipe:rewrite-spring:LATEST")
+        assertThat(out).contains("mod config recipes pip install openrewrite=={{VERSION_ORG_OPENREWRITE_REWRITE_PYTHON}} openrewrite-migrate-python=={{VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON}}")
+        assertThat(out).contains("mod config recipes pip install openrewrite openrewrite-migrate-python")
+        assertThat(out).contains("mod config recipes npm install @openrewrite/rewrite@{{VERSION_ORG_OPENREWRITE_REWRITE_JAVASCRIPT}}")
+        assertThat(out).contains("mod config recipes npm install @openrewrite/rewrite")
+        assertThat(out).contains("mod config recipes nuget install OpenRewrite.CodeQuality@{{VERSION_IO_MODERNE_RECIPE_RECIPES_CODE_QUALITY}}")
+        assertThat(out).contains("mod config recipes nuget install OpenRewrite.CodeQuality")
+    }
+
+    @Test
     fun conflictingRecipesGetEditionSuffix() {
         // When both moderne and openrewrite have the same recipe, they should get edition suffixes
         val recipes = listOf(


### PR DESCRIPTION
## Summary
- `VersionWriter` previously hardcoded `mod config recipes jar install` for every recipe origin. It now partitions origins by ecosystem using the existing `PythonRecipeLoader.PYTHON_RECIPE_MODULES`, `TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES`, and `CSharpRecipeLoader.CSHARP_RECIPE_MODULES` registries, emitting one dedicated `mod config recipes <type> install ...` line per non-empty ecosystem in both the Pinned and Latest tabs of `latest-versions-of-every-openrewrite-module.md`.
- Version separators per CLI subcommand (verified against `mod config recipes <type> install --help`): `jar` uses `:`, `pip` uses `==`, `npm`/`nuget`/`go` use `@`. Go is wired up at the CLI but no Go recipe registry exists yet, so no Go line is emitted today.
- Added `RecipeMarkdownGeneratorTest.latestVersionsMultiEcosystemInstall` covering all four ecosystems for both pinned and latest install lines.

## Test plan
- [x] `./gradlew test`
- [ ] Spot-check the generated `latest-versions-of-every-openrewrite-module.md` in a downstream docs build to confirm the CLI Installation block renders correctly with multiple ecosystems.