### PR TITLE
Add `recipes-scala` to the recipe catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     mavenLocal()
     mavenCentral()
-    maven { url = uri("https://central.sonatype.org/content/repositories/snapshots/") }
+    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
     maven { url = uri("https://maven.diffblue.com/snapshot") }
     gradlePluginPortal()
 }
@@ -142,6 +142,7 @@ dependencies {
     "recipe"("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
 
     // Moderne recipe modules (io.moderne.recipe)
+    "recipe"("io.moderne.recipe:recipes-scala:latest.integration")
     "recipe"("io.moderne.recipe:rewrite-ai:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-angular:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-cryptography:$rewriteVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,7 +142,7 @@ dependencies {
     "recipe"("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
 
     // Moderne recipe modules (io.moderne.recipe)
-    "recipe"("io.moderne.recipe:recipes-scala:latest.integration")
+    "recipe"("io.moderne.recipe:recipes-scala:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-ai:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-angular:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-cryptography:$rewriteVersion")


### PR DESCRIPTION
## Summary
- Adds `io.moderne.recipe:recipes-scala` from [moderneinc/recipes-scala](https://github.com/moderneinc/recipes-scala) so its recipes show up in the generated catalog.
- Pulled in via `latest.integration` because no release has been tagged yet — only `0.1.0-SNAPSHOT` is published.
- Also fixes the Sonatype snapshots repo URL (`central.sonatype.org/content/repositories/snapshots/` → `central.sonatype.com/repository/maven-snapshots/`); the old URL returned 404, which was needed to actually resolve the snapshot.

## Test plan
- [ ] `./gradlew run` succeeds and the Scala recipes appear under `build/moderne-docs/`
- [ ] Once `recipes-scala` cuts a release, switch this entry back to `$rewriteVersion`