### PR TITLE
Add recipes-kotlin module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     "recipe"("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
 
     // Moderne recipe modules (io.moderne.recipe)
+    "recipe"("io.moderne.recipe:recipes-kotlin:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-ai:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-angular:$rewriteVersion")
     "recipe"("io.moderne.recipe:rewrite-cryptography:$rewriteVersion")


### PR DESCRIPTION
## Summary
- Adds `io.moderne.recipe:recipes-kotlin` from https://github.com/moderneinc/recipes-kotlin to the `recipe` configuration so its recipes are included in the generated markdown docs.

## Test plan
- [ ] `./gradlew run` succeeds once `io.moderne.recipe:recipes-kotlin` is published to Maven Central
- [ ] Generated docs include recipes from `recipes-kotlin`