### PR TITLE
Split all-recipes.md into per-groupId pages

### DIFF
--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -394,43 +394,12 @@ class ListsOfRecipesWriter(
         recipeOrigins: Map<URI, RecipeOrigin>,
         recipeToSource: Map<String, URI>
     ) {
-        val markdown = outputPath.resolve("all-recipes.md")
-        Files.newBufferedWriter(markdown, StandardOpenOption.CREATE).useAndApply {
-            writeln(
-                //language=markdown
-                """
-            ---
-            description: A comprehensive list of all recipes organized by module.
-            ---
+        val grouped = groupByOrigin(allRecipeDescriptors, { it.name }, recipeOrigins, recipeToSource)
 
-            # All Recipes by Module
-
-            _This doc contains all recipes grouped by their module._
-
-            """.trimIndent()
-            )
-
-            writeln("Total recipes: ${allRecipeDescriptors.size}\n")
-
-            for ((groupId, artifactMap) in groupByOrigin(allRecipeDescriptors, { it.name }, recipeOrigins, recipeToSource)) {
-                writeln("\n## ${groupId}\n")
-
-                for ((artifactId, recipes) in artifactMap) {
-                    writeln("\n### ${artifactId}\n")
-                    val firstRecipeName = recipes.first().name
-                    val origin = RecipeMarkdownGenerator.findOrigin(recipeToSource[firstRecipeName], firstRecipeName, recipeOrigins)
-                    val licenseInfo = origin?.license?.name ?: "Unknown"
-                    writeln("_License: ${licenseInfo}_\n")
-                    writeln("_${recipes.size} recipe${if (recipes.size != 1) "s" else ""}_\n")
-
-                    for (recipe in recipes.sortedBy { it.name }) {
-                        val recipePath = RecipeMarkdownGenerator.getRecipePath(recipe)
-                        writeln("* [${recipe.name}](${recipeLinkBasePath}/${recipePath}.md)")
-                        writeln("  * **${recipe.displayNameEscapedMdx()}**")
-                        writeln("  * ${recipe.descriptionEscaped()}")
-                    }
-                }
-            }
+        for ((groupId, artifactMap) in grouped) {
+            writeGroupIdPage(groupId, artifactMap, recipeOrigins, recipeToSource)
         }
+
+        writeAllRecipesIndex(grouped)
     }
 }

--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -318,6 +318,44 @@ class ListsOfRecipesWriter(
         }
     }
 
+    private fun writeGroupIdPage(
+        groupId: String,
+        artifactMap: SortedMap<String, List<RecipeDescriptor>>,
+        recipeOrigins: Map<URI, RecipeOrigin>,
+        recipeToSource: Map<String, URI>
+    ) {
+        val pagePath = outputPath.resolve("all-recipes-${slugifyGroupId(groupId)}.md")
+        Files.newBufferedWriter(pagePath, StandardOpenOption.CREATE).useAndApply {
+            writeln(
+                //language=markdown
+                """
+                ---
+                description: Recipes in the ${groupId} module.
+                ---
+
+                # ${groupId}
+
+                """.trimIndent()
+            )
+
+            for ((artifactId, recipes) in artifactMap) {
+                writeln("\n## ${artifactId}\n")
+                val firstRecipeName = recipes.first().name
+                val origin = RecipeMarkdownGenerator.findOrigin(recipeToSource[firstRecipeName], firstRecipeName, recipeOrigins)
+                val licenseInfo = origin?.license?.name ?: "Unknown"
+                writeln("_License: ${licenseInfo}_\n")
+                writeln("_${recipes.size} recipe${if (recipes.size != 1) "s" else ""}_\n")
+
+                for (recipe in recipes.sortedBy { it.name }) {
+                    val recipePath = RecipeMarkdownGenerator.getRecipePath(recipe)
+                    writeln("* [${recipe.name}](${recipeLinkBasePath}/${recipePath}.md)")
+                    writeln("  * **${recipe.displayNameEscapedMdx()}**")
+                    writeln("  * ${recipe.descriptionEscaped()}")
+                }
+            }
+        }
+    }
+
     fun createAllRecipesByModule(
         recipeOrigins: Map<URI, RecipeOrigin>,
         recipeToSource: Map<String, URI>

--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -44,6 +44,9 @@ class ListsOfRecipesWriter(
             .toSortedMap()
     }
 
+    private fun slugifyGroupId(groupId: String): String =
+        groupId.lowercase().replace('.', '-')
+
     fun createModerneRecipes(
         moderneProprietaryRecipes: List<RecipeDescriptor>,
         recipeOrigins: Map<URI, RecipeOrigin>,

--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -375,10 +375,7 @@ class ListsOfRecipesWriter(
                 """.trimIndent()
             )
 
-            val totalRecipes = grouped.values.sumOf { artifactMap ->
-                artifactMap.values.sumOf { it.size }
-            }
-            writeln("Total recipes: ${totalRecipes}\n")
+            writeln("Total recipes: ${allRecipeDescriptors.size}\n")
 
             for ((groupId, artifactMap) in grouped) {
                 writeln("\n## ${groupId}\n")

--- a/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ListsOfRecipesWriter.kt
@@ -356,6 +356,40 @@ class ListsOfRecipesWriter(
         }
     }
 
+    private fun writeAllRecipesIndex(
+        grouped: SortedMap<String, SortedMap<String, List<RecipeDescriptor>>>
+    ) {
+        val markdown = outputPath.resolve("all-recipes.md")
+        Files.newBufferedWriter(markdown, StandardOpenOption.CREATE).useAndApply {
+            writeln(
+                //language=markdown
+                """
+                ---
+                description: A comprehensive list of all recipes organized by module.
+                ---
+
+                # All Recipes by Module
+
+                _This doc indexes per-module recipe lists. Click a groupId to see its recipes._
+
+                """.trimIndent()
+            )
+
+            val totalRecipes = grouped.values.sumOf { artifactMap ->
+                artifactMap.values.sumOf { it.size }
+            }
+            writeln("Total recipes: ${totalRecipes}\n")
+
+            for ((groupId, artifactMap) in grouped) {
+                writeln("\n## ${groupId}\n")
+                val slug = slugifyGroupId(groupId)
+                for (artifactId in artifactMap.keys) {
+                    writeln("* [${artifactId}](all-recipes-${slug}.md#${artifactId})")
+                }
+            }
+        }
+    }
+
     fun createAllRecipesByModule(
         recipeOrigins: Map<URI, RecipeOrigin>,
         recipeToSource: Map<String, URI>


### PR DESCRIPTION
## Summary

- Replaces the monolithic `all-recipes.md` with a slim index that links to one `all-recipes-<slug>.md` page per groupId, so the file is small enough to read and stops choking downstream docs builds.
- Applies to both output trees: `build/docs/` (OpenRewrite, open-source only) and `build/moderne-docs/lists/` (Moderne, all recipes).
- Filename slug is `groupId.lowercase().replace('.', '-')` (e.g. `org.openrewrite.java` → `all-recipes-org-openrewrite-java.md`). Index anchors use bare artifactIds, relying on the default Docusaurus heading-anchor convention. Sidebar updates in the consuming docs repos are out of scope (the README already calls out a separate manual step for changelog-style sidebar additions).

## Test plan

- [x] `./gradlew test`
- [ ] `./gradlew run` and confirm `build/docs/all-recipes.md` shrinks to an index plus per-groupId pages, and the same shape appears under `build/moderne-docs/lists/`
- [ ] Spot-check an anchor link from the index lands on the correct `## artifactId` heading in the corresponding per-groupId page