### PR TITLE
Add io.axoniq to the allow list

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -540,6 +540,7 @@ class RecipeMarkdownGenerator : Runnable {
                 recipe.name.startsWith("androidx") ||
                 recipe.name.startsWith("com.google") ||
                 recipe.name.startsWith("com.oracle") ||
+                recipe.name.startsWith("io.axoniq") ||
                 recipe.name.startsWith("io.quarkus") ||
                 recipe.name.startsWith("io.quakus") ||
                 recipe.name.startsWith("org.apache") ||

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -155,7 +155,8 @@ class RecipeMarkdownGeneratorTest {
         // Third-party recipes should never get edition suffixes
         val recipes = listOf(
             "com.google.errorprone.SomeRecipe",
-            "org.apache.camel.SomeRecipe"
+            "org.apache.camel.SomeRecipe",
+            "io.axoniq.framework.migration.UpgradeAxon4ToAxoniq5"
         )
         initializeConflictDetection(recipes)
 
@@ -163,6 +164,8 @@ class RecipeMarkdownGeneratorTest {
             .isEqualTo("com/google/errorprone/somerecipe")
         assertThat(getRecipePath("org.apache.camel.SomeRecipe"))
             .isEqualTo("org/apache/camel/somerecipe")
+        assertThat(getRecipePath("io.axoniq.framework.migration.UpgradeAxon4ToAxoniq5"))
+            .isEqualTo("io/axoniq/framework/migration/upgradeaxon4toaxoniq5")
     }
 
     @Test


### PR DESCRIPTION
So recipe generation can work

@timtebeek I tried generating the docs for the OR docs and it failed: https://github.com/openrewrite/rewrite-docs/actions/runs/26897826713/job/79341691700

I believe this change should help - but wanted to make sure you didn't have any concerns first.