### PR TITLE
Update C# recipe NuGet package names for TUnit and CodeQuality

### DIFF
--- a/src/main/kotlin/org/openrewrite/CSharpRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/CSharpRecipeLoader.kt
@@ -27,9 +27,9 @@ class CSharpRecipeLoader(
          * Registry mapping artifact IDs to their corresponding NuGet package names.
          */
         val CSHARP_RECIPE_MODULES = mapOf(
-            "recipes-code-quality" to "OpenRewrite.CodeQuality",
+            "recipes-code-quality" to "OpenRewrite.Recipes.CSharp.CodeQuality",
             "recipes-migrate-dotnet" to "OpenRewrite.Recipes.CSharp.Migration.Dotnet",
-            "recipes-tunit" to "OpenRewrite.TUnit"
+            "recipes-tunit" to "OpenRewrite.Recipes.CSharp.Migration.TUnit"
         )
 
         /**

--- a/src/test/kotlin/org/openrewrite/CSharpRecipeLoaderTest.kt
+++ b/src/test/kotlin/org/openrewrite/CSharpRecipeLoaderTest.kt
@@ -16,11 +16,11 @@ class CSharpRecipeLoaderTest {
             "recipes-tunit"
         )
         assertThat(CSharpRecipeLoader.CSHARP_RECIPE_MODULES["recipes-code-quality"])
-            .isEqualTo("OpenRewrite.CodeQuality")
+            .isEqualTo("OpenRewrite.Recipes.CSharp.CodeQuality")
         assertThat(CSharpRecipeLoader.CSHARP_RECIPE_MODULES["recipes-migrate-dotnet"])
             .isEqualTo("OpenRewrite.Recipes.CSharp.Migration.Dotnet")
         assertThat(CSharpRecipeLoader.CSHARP_RECIPE_MODULES["recipes-tunit"])
-            .isEqualTo("OpenRewrite.TUnit")
+            .isEqualTo("OpenRewrite.Recipes.CSharp.Migration.TUnit")
     }
 
     private fun descriptor(name: String, displayName: String, description: String,

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -64,8 +64,8 @@ class RecipeMarkdownGeneratorTest {
         assertThat(out).contains("mod config recipes pip install openrewrite openrewrite-migrate-python")
         assertThat(out).contains("mod config recipes npm install @openrewrite/rewrite@{{VERSION_ORG_OPENREWRITE_REWRITE_JAVASCRIPT}}")
         assertThat(out).contains("mod config recipes npm install @openrewrite/rewrite")
-        assertThat(out).contains("mod config recipes nuget install OpenRewrite.CodeQuality@{{VERSION_IO_MODERNE_RECIPE_RECIPES_CODE_QUALITY}}")
-        assertThat(out).contains("mod config recipes nuget install OpenRewrite.CodeQuality")
+        assertThat(out).contains("mod config recipes nuget install OpenRewrite.Recipes.CSharp.CodeQuality@{{VERSION_IO_MODERNE_RECIPE_RECIPES_CODE_QUALITY}}")
+        assertThat(out).contains("mod config recipes nuget install OpenRewrite.Recipes.CSharp.CodeQuality")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- The `recipes-csharp` project renamed all three of its NuGet packages, but [#320](https://github.com/openrewrite/rewrite-recipe-markdown-generator/pull/320) only updated the `Migration.Dotnet` entry in `CSHARP_RECIPE_MODULES`. The TUnit and CodeQuality entries were missed, so the generator has been resolving package IDs that haven't received a new publish since 2026-03-26 — and recipes from those modules (e.g. [`MigrateFromXUnit`](https://github.com/moderneinc/recipes-csharp/blob/main/OpenRewrite.Recipes.CSharp.Migration.TUnit/FromXUnit/MigrateFromXUnit.cs)) never make it into docs.moderne.io.

| Module | Was | Now |
| --- | --- | --- |
| code-quality | `OpenRewrite.CodeQuality` | `OpenRewrite.Recipes.CSharp.CodeQuality` |
| tunit | `OpenRewrite.TUnit` | `OpenRewrite.Recipes.CSharp.Migration.TUnit` |

Verified the new names resolve via `api.nuget.org/v3-flatcontainer/<id>/index.json` (latest `0.3.0-snapshot.20260603183020`); the old names stopped publishing on 2026-03-26.

## Test plan

- [ ] Re-run the generator and confirm `tunit/` and `codequality/` recipe trees appear in `moderneinc/moderne-docs` under `docs/user-documentation/recipes/recipe-catalog/csharp/recipes/csharp/...`
- [ ] Spot-check that `MigrateFromXUnit` renders a valid page