### PR TITLE
Escape MDX-significant characters in changelog recipe descriptions

### DIFF
--- a/src/main/kotlin/org/openrewrite/ChangelogWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ChangelogWriter.kt
@@ -130,7 +130,7 @@ class ChangelogWriter {
             changelog.appendText("## New Recipes\n")
 
             for (newRecipe in newRecipes) {
-                changelog.appendText("\n* [${newRecipe.name}](${newRecipe.docLink}): ${newRecipe.description.trim()} ")
+                changelog.appendText("\n* [${newRecipe.name}](${newRecipe.docLink}): ${escapeMdxOutsideCodeSpans(newRecipe.description.trim())} ")
             }
 
             changelog.appendText("\n\n")
@@ -140,7 +140,7 @@ class ChangelogWriter {
             changelog.appendText("## Removed Recipes\n")
 
             for (removedRecipe in removedRecipes) {
-                changelog.appendText("\n* **${removedRecipe.name}**: ${removedRecipe.description.trim()} ")
+                changelog.appendText("\n* **${removedRecipe.name}**: ${escapeMdxOutsideCodeSpans(removedRecipe.description.trim())} ")
             }
 
             changelog.appendText("\n\n")

--- a/src/main/kotlin/org/openrewrite/RecipeDescriptorExtensions.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeDescriptorExtensions.kt
@@ -60,6 +60,29 @@ fun escapeMdx(string: String): String = escapeHtml(string)
     .replace("{", "\\{")
     .replace("}", "\\}")
 
+// Escapes MDX-significant characters (`<`, `{`, `}`) that would otherwise be parsed as JSX
+// when a description is rendered inline (e.g. in the changelog), while leaving content inside
+// backtick code spans untouched. Inside a code span MDX treats these characters literally, and
+// escaping them there would surface the raw entities/backslashes in the rendered page.
+fun escapeMdxOutsideCodeSpans(string: String): String {
+    val sb = StringBuilder(string.length)
+    var inCodeSpan = false
+    for (c in string) {
+        when {
+            c == '`' -> {
+                inCodeSpan = !inCodeSpan
+                sb.append(c)
+            }
+            inCodeSpan -> sb.append(c)
+            c == '<' -> sb.append("&lt;")
+            c == '{' -> sb.append("\\{")
+            c == '}' -> sb.append("\\}")
+            else -> sb.append(c)
+        }
+    }
+    return sb.toString()
+}
+
 fun RecipeDescriptor.asYaml(): String {
     val s = StringBuilder()
     s.appendLine("""

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -232,6 +232,35 @@ class RecipeMarkdownGeneratorTest {
         assertThat(found!!.artifactId).isEqualTo("recipes-code-quality")
     }
 
+    @Test
+    fun escapeMdxOutsideCodeSpansEscapesUnbalancedTagsInProse() {
+        // The literal `<EntitySimpleName>` would be parsed by MDX as an unclosed JSX tag and
+        // break the docs build (https://github.com/openrewrite/rewrite-docs changelog build).
+        assertThat(escapeMdxOutsideCodeSpans("annotates the field with @EventTag(key = \"<EntitySimpleName>\")."))
+            .isEqualTo("annotates the field with @EventTag(key = \"&lt;EntitySimpleName>\").")
+    }
+
+    @Test
+    fun escapeMdxOutsideCodeSpansEscapesCurlyBracesInProse() {
+        assertThat(escapeMdxOutsideCodeSpans("rewrite the configurations { } block"))
+            .isEqualTo("rewrite the configurations \\{ \\} block")
+    }
+
+    @Test
+    fun escapeMdxOutsideCodeSpansLeavesCodeSpansUntouched() {
+        // Generics inside backticks are valid and must render verbatim, not as escaped entities.
+        assertThat(escapeMdxOutsideCodeSpans("Replace `Predicate<T>` with `Predicate.not(x)`"))
+            .isEqualTo("Replace `Predicate<T>` with `Predicate.not(x)`")
+        assertThat(escapeMdxOutsideCodeSpans("the `java { }` extension block"))
+            .isEqualTo("the `java { }` extension block")
+    }
+
+    @Test
+    fun escapeMdxOutsideCodeSpansHandlesMixedContent() {
+        assertThat(escapeMdxOutsideCodeSpans("set idType = <ResolvedType>.class via `autodetected(<IdType>.class)`"))
+            .isEqualTo("set idType = &lt;ResolvedType>.class via `autodetected(<IdType>.class)`")
+    }
+
     private fun initializeConflictDetection(recipeNames: List<String>) {
         val descriptors = recipeNames.map { createDescriptor(it) }
         RecipeMarkdownGenerator.initializeConflictDetection(descriptors)


### PR DESCRIPTION
## Problem

The changelog writer emits recipe descriptions verbatim as inline Markdown list items (`* [name](link): description`). When a description contains an **unbalanced** angle-bracket token outside a code span — e.g. `AddEventTagAnnotation`'s `@EventTag(key = "<EntitySimpleName>")` — MDX parses `<EntitySimpleName>` as an unclosed JSX tag and the rewrite-docs site build fails:

```
Error: MDX compilation failed for file ".../docs/changelog/8-85-0-Release.md"
Cause: Expected a closing tag for `<EntitySimpleName>` before the end of `paragraph`
```

Recipe **pages** don't hit this because they wrap descriptions in fenced code blocks; the changelog inlines them, so it needs escaping. (Balanced tags like `<type>test-jar</type>` and backtick-wrapped generics like `Class<R>` already compile fine, which is why this only surfaced now.)

## Fix

Add `escapeMdxOutsideCodeSpans()` and apply it to the New/Removed recipe descriptions in `ChangelogWriter`. It escapes `<`, `{`, `}` in prose while leaving content inside backtick code spans untouched — so legitimate generics (`` `Predicate<T>` ``) and DSL blocks (`` `java { }` ``) still render verbatim, and a blanket escape doesn't surface raw `&lt;`/`\{` entities inside code spans.

Only newly generated changelogs are affected (each run generates one new `*-Release.md`); existing committed changelogs are not regenerated.

## Context

- The 8.85.0 changelog was hand-patched in [rewrite-docs#515](https://github.com/openrewrite/rewrite-docs/pull/515) to unblock that build; this fixes the generator so future releases are MDX-safe automatically.

Unit tests cover unbalanced tags, curly braces, preserved code spans, and mixed content.