### PR TITLE
Report current CLI version from Maven Central in changelogs

### DIFF
--- a/src/main/kotlin/org/openrewrite/ChangelogWriter.kt
+++ b/src/main/kotlin/org/openrewrite/ChangelogWriter.kt
@@ -94,14 +94,10 @@ class ChangelogWriter {
 
         changelog.appendText("## Corresponding CLI version\n\n")
 
-        // Get the latest staging and stable versions of the CLI
-        val stagingVersion = getLatestStagingVersion()
+        // Get the latest version of the CLI
         val stableVersion = getLatestStableVersion()
         if (stableVersion != null) {
-            changelog.appendText("* Stable CLI version `${stableVersion}`\n")
-        }
-        if (stagingVersion != null) {
-            changelog.appendText("* Staging CLI version: `${stagingVersion}`\n\n")
+            changelog.appendText("* CLI version `${stableVersion}`\n\n")
         }
 
         // An example of what the changelog could look like after the below statements can be found here:

--- a/src/main/kotlin/org/openrewrite/CliVersion.kt
+++ b/src/main/kotlin/org/openrewrite/CliVersion.kt
@@ -1,40 +1,38 @@
 package org.openrewrite
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
+// The Moderne CLI is published as `io.moderne:moderne-cli`, with stable releases landing in Maven
+// Central. The older `moderne-cli-releases` GitHub repository is no longer updated (it stopped at the
+// 3.x line), so the version is sourced from the Maven metadata instead.
+private const val STABLE_METADATA_URL =
+    "https://repo1.maven.org/maven2/io/moderne/moderne-cli/maven-metadata.xml"
+
+private val RELEASE_TAG = Regex("<release>([^<]+)</release>")
+private val LATEST_TAG = Regex("<latest>([^<]+)</latest>")
+
 fun getLatestStableVersion(): String? {
-    val releases = getCliVersion("https://api.github.com/repos/moderneinc/moderne-cli-releases/releases/latest")
-    return releases?.get("tag_name")?.asText()
+    val metadata = getMavenMetadata(STABLE_METADATA_URL) ?: return null
+    // Prefer the explicit <release> (latest non-snapshot), falling back to <latest>.
+    return (RELEASE_TAG.find(metadata) ?: LATEST_TAG.find(metadata))?.groupValues?.get(1)
 }
 
-fun getLatestStagingVersion(): String? {
-    val releases = getCliVersion("https://api.github.com/repos/moderneinc/moderne-cli-releases/releases")
-    if (releases != null && releases.isArray && releases.size() > 0) {
-        return releases[0].get("tag_name")?.asText()
-    }
-    return null
-}
-
-private fun getCliVersion(url: String): JsonNode? {
+private fun getMavenMetadata(url: String): String? {
     return try {
         OkHttpClient()
             .newCall(Request.Builder().url(url).build())
             .execute()
             .use { response ->
                 if (response.isSuccessful) {
-                    val responseBody = response.body?.string() ?: return null
-                    val mapper = ObjectMapper()
-                    mapper.readTree(responseBody)
+                    response.body?.string()
                 } else {
-                    System.err.println("Failed to get latest version from GitHub: ${response.code}")
+                    System.err.println("Failed to get latest version from $url: ${response.code}")
                     null
                 }
             }
     } catch (e: Exception) {
-        System.err.println("Failed to get latest version from GitHub: ${e.message}")
+        System.err.println("Failed to get latest version from $url: ${e.message}")
         null
     }
 }


### PR DESCRIPTION
Changelog pages were reporting a 3.x CLI version because the version was sourced from the `moderneinc/moderne-cli-releases` GitHub repo, which is no longer updated past the 3.x line. The CLI is now published as `io.moderne:moderne-cli`, so this sources the version from Maven Central's `maven-metadata.xml` (`<release>`), which currently resolves to 4.3.2. The staging/snapshot version is dropped and the remaining line is relabeled from "Stable CLI version" to just "CLI version".