### PR TITLE
Remove rewrite-nodejs from the recipe classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The CI workflow in *this* repo also only runs with `-PlatestVersionsOnly=true`, 
 The generator loads TypeScript, Python, and C# recipes by spawning external RPC processes. To produce complete docs locally you need all of these on `PATH`:
 
 * **Java 21** — JVM-based recipes
-* **Node.js** — TypeScript recipes (`rewrite-javascript`, `rewrite-nodejs`, `rewrite-angular`, `rewrite-react`)
+* **Node.js** — TypeScript recipes (`rewrite-javascript`, `rewrite-angular`, `rewrite-react`)
 * **Python 3.10+ and `pip`** — Python recipes (`rewrite-python`, `rewrite-migrate-python`, `openrewrite-static-analysis`)
 * **.NET SDK** — C# recipes (`recipes-code-quality`, `recipes-migrate-dotnet`, `recipes-tunit`, `recipes-csharp-core`)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,7 +131,6 @@ dependencies {
     "recipe"("org.openrewrite.recipe:rewrite-migrate-kotlin:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-migrate-python:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-netty:$rewriteVersion")
-    "recipe"("org.openrewrite.recipe:rewrite-nodejs:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-okhttp:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-openapi:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-prethink:$rewriteVersion")

--- a/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/TypeScriptRecipeLoader.kt
@@ -29,7 +29,6 @@ class TypeScriptRecipeLoader(
          */
         val TYPESCRIPT_RECIPE_MODULES = mapOf(
             "rewrite-javascript" to "@openrewrite/rewrite",
-            "rewrite-nodejs" to "@openrewrite/recipes-nodejs",
             "rewrite-angular" to "@openrewrite/recipes-angular",
             "rewrite-react" to "@openrewrite/recipes-react"
         )


### PR DESCRIPTION
The `org.openrewrite.nodejs.*` dependency recipes (from the `rewrite-nodejs` artifact) duplicate the official `org.openrewrite.javascript.*` recipes that now live in `rewrite-javascript`, which confused users seeing two recipes for the same purpose ([Slack thread](https://moderneinc.slack.com/archives/C01S4M53THT/p1782137855190219?thread_ts=1781905373.880219&cid=C01S4M53THT)). This drops `rewrite-nodejs` from the recipe classpath so the redundant `nodejs/*` docs are no longer generated, and removes its now-dead TypeScript module registry entry and README reference. The recipes themselves still need to be deprecated upstream in the `rewrite-nodejs` repo.