### PR TITLE
Emit component-based recipe MDX for Moderne docs (forModerneDocs path)

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -1038,10 +1038,9 @@ ${props.toString().trimEnd()}
             if (!recipeDescriptor.examples.isNullOrEmpty()) {
                 emitSection("<ExampleList examples={${buildExamplesJson(recipeDescriptor)}}>", "## Examples", "</ExampleList>")
             }
-            // Usage mirrors writeUsage's skip for JS/Python/C# recipes (no UsageList contract yet).
-            if (!(isJavaScriptRecipe(recipeDescriptor) || isPythonRecipe(recipeDescriptor) || isCSharpRecipe(recipeDescriptor))) {
-                emitSection("<UsageList usage={${buildUsageJson(recipeDescriptor, origin)}}>", "## Usage", "</UsageList>")
-            }
+            // Usage: every recipe gets one. buildUsageJson sets the right install coordinates —
+            // npm/pip/nuget for JS/Python/C#, Maven/Gradle coordinates otherwise.
+            emitSection("<UsageList usage={${buildUsageJson(recipeDescriptor, origin)}}>", "## Usage", "</UsageList>")
             if (!recipeDescriptor.dataTables.isNullOrEmpty()) {
                 emitSection("<DataTableList tables={${buildDataTablesJson(recipeDescriptor)}}>", "## Data tables", "</DataTableList>")
             }
@@ -1063,10 +1062,13 @@ ${props.toString().trimEnd()}
      * Unlinkable recipes (not in recipeToSource) get an empty href.
      */
     private fun subRecipeJson(recipes: List<RecipeDescriptor>?): String {
-        val items = (recipes ?: emptyList<RecipeDescriptor>()).map { sub ->
-            val href = recipeToSource[sub.name]?.let { getRecipeLink(sub) } ?: ""
-            mapOf("name" to sub.displayName, "href" to href)
-        }
+        val items = (recipes ?: emptyList<RecipeDescriptor>())
+            // Skip internal "Precondition bellwether" recipes (rewrite-docs#250), like the markdown path.
+            .filter { it.displayName != "Precondition bellwether" }
+            .map { sub ->
+                val href = recipeToSource[sub.name]?.let { getRecipeLink(sub) } ?: ""
+                mapOf("name" to sub.displayName, "href" to href)
+            }
         return mapper.writeValueAsString(items)
     }
 
@@ -1091,8 +1093,10 @@ ${props.toString().trimEnd()}
     }
 
     /**
-     * Build the JSON array for ExampleList.
-     * Shape per the spec (variants, unchanged, parameters).
+     * Build the JSON array for ExampleList: one object per example with `parameters`, an optional
+     * `unchanged` source, and `variants` (before/after/diff per source). The example's prose
+     * `description` is intentionally not emitted — the redesigned ExampleList renders examples by
+     * source language and has no per-example description field.
      */
     private fun buildExamplesJson(recipeDescriptor: RecipeDescriptor): String {
         val examples = recipeDescriptor.examples ?: emptyList()
@@ -1168,31 +1172,39 @@ ${props.toString().trimEnd()}
      */
     private fun buildUsageJson(recipeDescriptor: RecipeDescriptor, origin: RecipeOrigin): String {
         val name = recipeDescriptor.name
-        val options = recipeDescriptor.options ?: emptyList()
-        val requiresConfiguration = options.any { it.isRequired }
-
         val usageMap = mutableMapOf<String, Any?>(
             "recipeName" to name,
             "displayName" to recipeDescriptor.displayName,
-            "groupId" to origin.groupId,
-            "artifactId" to origin.artifactId,
-            "versionKey" to origin.versionPlaceholderKey(),
-            "requiresConfiguration" to requiresConfiguration
         )
 
-        // Build cliOptions string (shares the per-option example formatting with writeUsage).
-        val cliOptions = if (requiresConfiguration) {
-            options.filter { it.isRequired || it.example != null }
-                .joinToString("") { " --recipe-option \"${it.name}=${cliOptionExample(it)}\"" }
-        } else {
-            ""
-        }
-        if (cliOptions.isNotEmpty()) {
-            usageMap["cliOptions"] = cliOptions
-        }
+        // JS/Python/C# recipes install from their own package managers (matching the markdown path's
+        // per-ecosystem <RunRecipe>); everything else uses the Maven/Gradle coordinates + CLI options.
+        when {
+            isJavaScriptRecipe(recipeDescriptor) -> usageMap["npmPackage"] = getNpmPackageName(origin)
+            isPythonRecipe(recipeDescriptor) -> usageMap["pipPackage"] = getPipPackageName(origin)
+            isCSharpRecipe(recipeDescriptor) -> usageMap["nugetPackage"] = getNuGetPackageName(origin)
+            else -> {
+                val options = recipeDescriptor.options ?: emptyList()
+                val requiresConfiguration = options.any { it.isRequired }
+                usageMap["groupId"] = origin.groupId
+                usageMap["artifactId"] = origin.artifactId
+                usageMap["versionKey"] = origin.versionPlaceholderKey()
+                usageMap["requiresConfiguration"] = requiresConfiguration
 
-        if (hasConflict(name)) {
-            usageMap["useFullyQualifiedCliName"] = true
+                // cliOptions shares the per-option example formatting with writeUsage.
+                val cliOptions = if (requiresConfiguration) {
+                    options.filter { it.isRequired || it.example != null }
+                        .joinToString("") { " --recipe-option \"${it.name}=${cliOptionExample(it)}\"" }
+                } else {
+                    ""
+                }
+                if (cliOptions.isNotEmpty()) {
+                    usageMap["cliOptions"] = cliOptions
+                }
+                if (hasConflict(name)) {
+                    usageMap["useFullyQualifiedCliName"] = true
+                }
+            }
         }
 
         return mapper.writeValueAsString(usageMap)

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -25,8 +25,6 @@ class RecipeMarkdownWriter(
     val forModerneDocs: Boolean = false
 ) {
 
-    private val mapper = jacksonObjectMapper()
-
     /**
      * Check if a recipe is proprietary based on its name.
      */
@@ -134,17 +132,8 @@ class RecipeMarkdownWriter(
         val formattedLongRecipeName = recipeDescriptor.name.replace("_".toRegex(), "\\\\_").trim()
         Files.createDirectories(recipeMarkdownPath.parent)
         Files.newBufferedWriter(recipeMarkdownPath, StandardOpenOption.CREATE).useAndApply {
-            // For Moderne docs, add canonical link to OpenRewrite docs for open source recipes
-            val canonicalHead = if (forModerneDocs && !isProprietaryRecipe(recipeDescriptor.name)) {
-                """
-<head>
-  <link rel="canonical" href="https://docs.openrewrite.org/recipes/${getRecipePath(recipeDescriptor)}" />
-</head>
-
-"""
-            } else {
-                ""
-            }
+            // Note: the Moderne-docs canonical-link <head> is emitted by writeModerneComponentRecipe;
+            // this path only runs for OpenRewrite docs (forModerneDocs is always false here).
             write(
                 """
 ---
@@ -152,7 +141,7 @@ title: "${formattedRecipeTitle.replace("&#39;", "'")}"
 sidebar_label: "${formattedRecipeTitle.replace("&#39;", "'")}"
 ---
 
-${canonicalHead}import Tabs from '@theme/Tabs';
+import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import RunRecipe from '@site/src/components/RunRecipe';
 
@@ -1032,12 +1021,15 @@ ${props.toString().trimEnd()}
             // parses it as a real heading node and the native Docusaurus TOC picks it up. JSON props are
             // built lazily, only for sections that are actually emitted.
             // Definition = preconditions + sub-recipe list. Emit when either is present (a single recipe
-            // can have preconditions without a recipe list).
+            // can have preconditions without a recipe list). Unlike the OpenRewrite markdown path this is
+            // not suppressed for proprietary recipes — Moderne docs shows their definitions too.
             val hasPreconditions = !recipeDescriptor.preconditions.isNullOrEmpty()
             if (!recipeDescriptor.recipeList.isNullOrEmpty() || hasPreconditions) {
                 val recipesJson = subRecipeJson(recipeDescriptor.recipeList)
-                val preconditionsAttr =
-                    if (hasPreconditions) " preconditions={${subRecipeJson(recipeDescriptor.preconditions)}}" else ""
+                val preconditionsAttr = recipeDescriptor.preconditions
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let { " preconditions={${subRecipeJson(it)}}" }
+                    ?: ""
                 emitSection("<RecipeList recipes={$recipesJson}$preconditionsAttr>", "## Definition", "</RecipeList>")
             }
             if (!recipeDescriptor.options.isNullOrEmpty()) {
@@ -1072,7 +1064,7 @@ ${props.toString().trimEnd()}
      */
     private fun subRecipeJson(recipes: List<RecipeDescriptor>?): String {
         val items = (recipes ?: emptyList<RecipeDescriptor>()).map { sub ->
-            val href = if (recipeToSource.containsKey(sub.name)) getRecipeLink(sub) else ""
+            val href = recipeToSource[sub.name]?.let { getRecipeLink(sub) } ?: ""
             mapOf("name" to sub.displayName, "href" to href)
         }
         return mapper.writeValueAsString(items)
@@ -1189,14 +1181,11 @@ ${props.toString().trimEnd()}
         )
 
         // Build cliOptions string (shares the per-option example formatting with writeUsage).
-        var cliOptions = ""
-        if (requiresConfiguration) {
-            for (option in options) {
-                if (!option.isRequired && option.example == null) {
-                    continue
-                }
-                cliOptions += " --recipe-option \"${option.name}=${cliOptionExample(option)}\""
-            }
+        val cliOptions = if (requiresConfiguration) {
+            options.filter { it.isRequired || it.example != null }
+                .joinToString("") { " --recipe-option \"${it.name}=${cliOptionExample(it)}\"" }
+        } else {
+            ""
         }
         if (cliOptions.isNotEmpty()) {
             usageMap["cliOptions"] = cliOptions
@@ -1251,6 +1240,9 @@ ${props.toString().trimEnd()}
     }
 
     companion object {
+        // Stateless + thread-safe; one instance for the whole run rather than per writer.
+        private val mapper = jacksonObjectMapper()
+
         private const val MODERNE_DOCS_MARKDOWN_BASE_URL =
             "https://raw.githubusercontent.com/moderneinc/moderne-docs/refs/heads/main/docs/user-documentation/recipes/recipe-catalog/"
 

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -1031,8 +1031,14 @@ ${props.toString().trimEnd()}
             // Sections: the `## ` heading is the component's children, blank-line-wrapped (below) so MDX
             // parses it as a real heading node and the native Docusaurus TOC picks it up. JSON props are
             // built lazily, only for sections that are actually emitted.
-            if (!recipeDescriptor.recipeList.isNullOrEmpty()) {  // composite recipes only
-                emitSection("<RecipeList recipes={${buildRecipeListJson(recipeDescriptor)}}>", "## Definition", "</RecipeList>")
+            // Definition = preconditions + sub-recipe list. Emit when either is present (a single recipe
+            // can have preconditions without a recipe list).
+            val hasPreconditions = !recipeDescriptor.preconditions.isNullOrEmpty()
+            if (!recipeDescriptor.recipeList.isNullOrEmpty() || hasPreconditions) {
+                val recipesJson = subRecipeJson(recipeDescriptor.recipeList)
+                val preconditionsAttr =
+                    if (hasPreconditions) " preconditions={${subRecipeJson(recipeDescriptor.preconditions)}}" else ""
+                emitSection("<RecipeList recipes={$recipesJson}$preconditionsAttr>", "## Definition", "</RecipeList>")
             }
             if (!recipeDescriptor.options.isNullOrEmpty()) {
                 emitSection("<OptionsTable options={${buildOptionsJson(recipeDescriptor)}}>", "## Options", "</OptionsTable>")
@@ -1061,16 +1067,12 @@ ${props.toString().trimEnd()}
     }
 
     /**
-     * Build the JSON array for RecipeList.
-     * Shape: { name: string; href: string }[]
+     * Build the JSON array of `{ name, href }` for RecipeList's `recipes` and `preconditions` props.
+     * Unlinkable recipes (not in recipeToSource) get an empty href.
      */
-    private fun buildRecipeListJson(recipeDescriptor: RecipeDescriptor): String {
-        val items = (recipeDescriptor.recipeList ?: emptyList<RecipeDescriptor>()).map { sub ->
-            val href = if (recipeToSource.containsKey(sub.name)) {
-                getRecipeLink(sub)
-            } else {
-                ""
-            }
+    private fun subRecipeJson(recipes: List<RecipeDescriptor>?): String {
+        val items = (recipes ?: emptyList<RecipeDescriptor>()).map { sub ->
+            val href = if (recipeToSource.containsKey(sub.name)) getRecipeLink(sub) else ""
             mapOf("name" to sub.displayName, "href" to href)
         }
         return mapper.writeValueAsString(items)

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -2,6 +2,7 @@
 
 package org.openrewrite
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.difflib.DiffUtils
 import com.github.difflib.patch.Patch
 import org.openrewrite.RecipeMarkdownGenerator.Companion.getRecipePath
@@ -22,6 +23,8 @@ class RecipeMarkdownWriter(
     val proprietaryRecipeNames: Set<String>,
     val forModerneDocs: Boolean = false
 ) {
+
+    private val mapper = jacksonObjectMapper()
 
     /**
      * Check if a recipe is proprietary based on its name.
@@ -122,6 +125,8 @@ class RecipeMarkdownWriter(
         origin: RecipeOrigin,
         crossCategoryNote: String?
     ) {
+        if (forModerneDocs) { writeModerneComponentRecipe(recipeDescriptor, recipeMarkdownPath, origin, crossCategoryNote); return }
+
         val formattedRecipeTitle = recipeDescriptor.displayNameEscaped()  // For YAML frontmatter (no curly brace escaping)
         val formattedRecipeTitleMdx = recipeDescriptor.displayNameEscapedMdx()  // For MDX content (with curly brace escaping)
         val formattedRecipeDescription = getFormattedRecipeDescription(recipeDescriptor.description)
@@ -940,7 +945,357 @@ ${props.toString().trimEnd()}
         return diffContent.toString()
     }
 
+    // -------------------------------------------------------------------------
+    // Moderne docs MDX component output
+    // -------------------------------------------------------------------------
+
+    /**
+     * Emits an MDX file that delegates all rendering to React components.
+     * Only called when forModerneDocs == true.
+     */
+    private fun writeModerneComponentRecipe(
+        recipeDescriptor: RecipeDescriptor,
+        recipeMarkdownPath: Path,
+        origin: RecipeOrigin,
+        @Suppress("UNUSED_PARAMETER") crossCategoryNote: String?
+    ) {
+        val name = recipeDescriptor.name
+        val title = recipeDescriptor.displayNameEscaped().replace("&#39;", "'")
+        val isProprietary = isProprietaryRecipe(name)
+
+        // Canonical <head> block for open-source recipes
+        val canonicalHead = if (!isProprietary) {
+            """
+<head>
+  <link rel="canonical" href="https://docs.openrewrite.org/recipes/${getRecipePath(recipeDescriptor)}" />
+</head>
+
+"""
+        } else {
+            ""
+        }
+
+        val recipeType = if (recipeDescriptor.recipeList.isNullOrEmpty()) "Single recipe" else "Composite recipe"
+        val language = getSourceLanguage(name)
+        val licenseText = resolveLicensePlainText(origin)
+        val fqName = name
+        val artifact = "${origin.groupId}:${origin.artifactId}"
+        val appLink = "https://app.moderne.io/recipes/$name"
+        val markdownUrl = MODERNE_DOCS_MARKDOWN_BASE_URL + getRecipePath(recipeDescriptor) + ".md"
+
+        // Source URL — omit for proprietary or when no source URI available
+        val sourceUrl: String? = if (!isProprietary) {
+            val recipeSource = recipeToSource[name]
+            if (recipeSource != null) origin.githubUrl(name, recipeSource) else null
+        } else null
+
+        // JSON props
+        val description = recipeDescriptor.description ?: ""
+        val tags = recipeDescriptor.tags?.toList() ?: emptyList<String>()
+        val languages = listOf(language)
+
+        val recipesJson = buildRecipeListJson(recipeDescriptor)
+        val optionsJson = buildOptionsJson(recipeDescriptor)
+        val examplesJson = buildExamplesJson(recipeDescriptor)
+        val usageJson = buildUsageJson(recipeDescriptor, origin)
+        val dataTablesJson = buildDataTablesJson(recipeDescriptor)
+
+        Files.createDirectories(recipeMarkdownPath.parent)
+        Files.newBufferedWriter(recipeMarkdownPath, StandardOpenOption.CREATE).useAndApply {
+            //language=markdown
+            writeln("---")
+            writeln("title: \"$title\"")
+            writeln("sidebar_label: \"$title\"")
+            writeln("hide_title: true")
+            writeln("---")
+            newLine()
+
+            if (canonicalHead.isNotEmpty()) {
+                write(canonicalHead)
+            }
+
+            writeln("import { RecipeHeader, RecipeMeta, RecipeList, OptionsTable, ExampleList, UsageList, DataTableList } from '@site/src/components/recipe';")
+            newLine()
+
+            // RecipeMeta — always emitted
+            writeln("<RecipeMeta")
+            writeln("  displayName={${mapper.writeValueAsString(recipeDescriptor.displayName)}}")
+            writeln("  description={${mapper.writeValueAsString(description)}}")
+            writeln("  fqName={${mapper.writeValueAsString(fqName)}}")
+            writeln("  languages={${mapper.writeValueAsString(languages)}}")
+            writeln("  license={${mapper.writeValueAsString(licenseText)}}")
+            if (sourceUrl != null) {
+                writeln("  sourceUrl={${mapper.writeValueAsString(sourceUrl)}}")
+            }
+            writeln("/>")
+            newLine()
+
+            // RecipeHeader — always emitted
+            writeln("<RecipeHeader")
+            writeln("  displayName={${mapper.writeValueAsString(recipeDescriptor.displayName)}}")
+            writeln("  description={${mapper.writeValueAsString(description)}}")
+            writeln("  type={${mapper.writeValueAsString(recipeType)}}")
+            writeln("  languages={${mapper.writeValueAsString(languages)}}")
+            writeln("  tags={${mapper.writeValueAsString(tags)}}")
+            writeln("  license={${mapper.writeValueAsString(licenseText)}}")
+            writeln("  fqName={${mapper.writeValueAsString(fqName)}}")
+            writeln("  artifact={${mapper.writeValueAsString(artifact)}}")
+            writeln("  appLink={${mapper.writeValueAsString(appLink)}}")
+            writeln("  markdownUrl={${mapper.writeValueAsString(markdownUrl)}}")
+            if (isProprietary) {
+                writeln("  moderneOnly")
+            }
+            writeln("/>")
+            newLine()
+
+            // RecipeList — only for composite recipes
+            if (!recipeDescriptor.recipeList.isNullOrEmpty()) {
+                writeln("<RecipeList recipes={$recipesJson}>")
+                newLine()
+                writeln("## Definition")
+                newLine()
+                writeln("</RecipeList>")
+                newLine()
+            }
+
+            // OptionsTable — only when options exist
+            if (!recipeDescriptor.options.isNullOrEmpty()) {
+                writeln("<OptionsTable options={$optionsJson}>")
+                newLine()
+                writeln("## Options")
+                newLine()
+                writeln("</OptionsTable>")
+                newLine()
+            }
+
+            // ExampleList — only when examples exist
+            if (!recipeDescriptor.examples.isNullOrEmpty()) {
+                writeln("<ExampleList examples={$examplesJson}>")
+                newLine()
+                writeln("## Examples")
+                newLine()
+                writeln("</ExampleList>")
+                newLine()
+            }
+
+            // UsageList — always emitted (mirrors writeUsage skip conditions for JS/Python/C#)
+            val skipUsage = isJavaScriptRecipe(recipeDescriptor) ||
+                isPythonRecipe(recipeDescriptor) ||
+                isCSharpRecipe(recipeDescriptor)
+            if (!skipUsage) {
+                writeln("<UsageList usage={$usageJson}>")
+                newLine()
+                writeln("## Usage")
+                newLine()
+                writeln("</UsageList>")
+                newLine()
+            }
+
+            // DataTableList — only when dataTables exist
+            if (!recipeDescriptor.dataTables.isNullOrEmpty()) {
+                writeln("<DataTableList tables={$dataTablesJson}>")
+                newLine()
+                writeln("## Data tables")
+                newLine()
+                writeln("</DataTableList>")
+                newLine()
+            }
+        }
+    }
+
+    /**
+     * Resolve the license as plain text (no markdown link syntax).
+     */
+    private fun resolveLicensePlainText(origin: RecipeOrigin): String {
+        return origin.license.name
+    }
+
+    /**
+     * Build the JSON array for RecipeList.
+     * Shape: { name: string; href: string }[]
+     */
+    private fun buildRecipeListJson(recipeDescriptor: RecipeDescriptor): String {
+        val items = (recipeDescriptor.recipeList ?: emptyList<RecipeDescriptor>()).map { sub ->
+            val href = if (recipeToSource.containsKey(sub.name)) {
+                getRecipeLink(sub)
+            } else {
+                ""
+            }
+            mapOf("name" to sub.displayName, "href" to href)
+        }
+        return mapper.writeValueAsString(items)
+    }
+
+    /**
+     * Build the JSON array for OptionsTable.
+     * Shape: { type: string; name: string; required: boolean; description: string; example?: string }[]
+     */
+    private fun buildOptionsJson(recipeDescriptor: RecipeDescriptor): String {
+        val items = (recipeDescriptor.options ?: emptyList()).map { option ->
+            val entry = mutableMapOf<String, Any?>(
+                "type" to (option.type ?: "String"),
+                "name" to (option.name ?: "unknown"),
+                "required" to option.isRequired,
+                "description" to (option.description ?: "")
+            )
+            if (option.example != null) {
+                entry["example"] = option.example
+            }
+            entry
+        }
+        return mapper.writeValueAsString(items)
+    }
+
+    /**
+     * Build the JSON array for ExampleList.
+     * Shape per the spec (variants, unchanged, parameters).
+     */
+    private fun buildExamplesJson(recipeDescriptor: RecipeDescriptor): String {
+        val examples = recipeDescriptor.examples ?: emptyList()
+        val options = recipeDescriptor.options ?: emptyList()
+
+        val items = examples.map { example ->
+            val exMap = mutableMapOf<String, Any?>()
+
+            // parameters — zip option names with example parameter values
+            if (example.parameters != null && example.parameters.isNotEmpty() && options.isNotEmpty()) {
+                val params = options.zip(example.parameters).map { (opt, value) ->
+                    mapOf("parameter" to (opt.name ?: "unknown"), "value" to value)
+                }
+                exMap["parameters"] = params
+            }
+
+            val variants = mutableListOf<Map<String, Any?>>()
+            var unchangedSet = false
+
+            for (source in example.sources) {
+                val after = source.after
+                val hasChange = after != null && after.isNotEmpty()
+                val lang = source.language ?: "text"
+
+                when {
+                    !hasChange -> {
+                        // no change — set unchanged (first such source only)
+                        if (!unchangedSet) {
+                            exMap["unchanged"] = mapOf(
+                                "language" to lang,
+                                "code" to (source.before ?: "")
+                            )
+                            unchangedSet = true
+                        }
+                    }
+                    source.before == null -> {
+                        // new file
+                        variants.add(
+                            mapOf(
+                                "language" to lang,
+                                "before" to "",
+                                "after" to after!!,
+                                "newFile" to true
+                            )
+                        )
+                    }
+                    else -> {
+                        // before → after with diff
+                        val diff = generateDiff(source.path, source.before, after!!)
+                        variants.add(
+                            mapOf(
+                                "language" to lang,
+                                "before" to source.before,
+                                "after" to after,
+                                "diff" to diff,
+                                "newFile" to false
+                            )
+                        )
+                    }
+                }
+            }
+
+            exMap["variants"] = variants
+            exMap
+        }
+
+        return mapper.writeValueAsString(items)
+    }
+
+    /**
+     * Build the JSON object for UsageList.
+     * Mirrors writeUsage's logic for determining which props to include.
+     */
+    private fun buildUsageJson(recipeDescriptor: RecipeDescriptor, origin: RecipeOrigin): String {
+        val name = recipeDescriptor.name
+        val options = recipeDescriptor.options ?: emptyList()
+        val requiresConfiguration = options.any { it.isRequired }
+
+        val usageMap = mutableMapOf<String, Any?>(
+            "recipeName" to name,
+            "displayName" to recipeDescriptor.displayName,
+            "groupId" to origin.groupId,
+            "artifactId" to origin.artifactId,
+            "versionKey" to origin.versionPlaceholderKey(),
+            "requiresConfiguration" to requiresConfiguration
+        )
+
+        // Build cliOptions string (mirrors writeUsage logic)
+        var cliOptions = ""
+        if (requiresConfiguration) {
+            for (option in options) {
+                if (!option.isRequired && option.example == null) {
+                    continue
+                }
+                val optionExample = option.example
+                val ex = if (optionExample != null && option.type == "String" &&
+                    (optionExample.matches("^[{}\\[\\],`|=%@*!?-].*".toRegex()) ||
+                            optionExample.matches(".*:\\s.*".toRegex()))
+                ) {
+                    "'" + optionExample + "'"
+                } else if (optionExample != null && option.type == "String" && optionExample.contains('\n')) {
+                    ">\n        " + optionExample.replace("\n", "\n        ")
+                } else if (option.type == "boolean") {
+                    "false"
+                } else {
+                    option.example
+                }
+                cliOptions += " --recipe-option \"${option.name}=$ex\""
+            }
+        }
+        if (cliOptions.isNotEmpty()) {
+            usageMap["cliOptions"] = cliOptions
+        }
+
+        if (hasConflict(name)) {
+            usageMap["useFullyQualifiedCliName"] = true
+        }
+
+        return mapper.writeValueAsString(usageMap)
+    }
+
+    /**
+     * Build the JSON array for DataTableList.
+     * Shape: { name: string; displayName: string; description: string; columns: { name: string; description: string }[] }[]
+     */
+    private fun buildDataTablesJson(recipeDescriptor: RecipeDescriptor): String {
+        val dataTables = recipeDescriptor.dataTables ?: emptyList()
+        val items = dataTables.map { dt ->
+            mapOf(
+                "name" to dt.name,
+                "displayName" to dt.displayName,
+                "description" to (dt.description ?: ""),
+                "columns" to (dt.columns ?: emptyList()).map { col ->
+                    mapOf(
+                        "name" to col.displayName,
+                        "description" to (col.description ?: "")
+                    )
+                }
+            )
+        }
+        return mapper.writeValueAsString(items)
+    }
+
     companion object {
+        private const val MODERNE_DOCS_MARKDOWN_BASE_URL =
+            "https://raw.githubusercontent.com/moderneinc/moderne-docs/refs/heads/main/docs/user-documentation/recipes/recipe-catalog/"
+
         private fun printValue(value: Any): String =
             if (value is Array<*>) {
                 value.contentDeepToString()

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -9,6 +9,7 @@ import org.openrewrite.RecipeMarkdownGenerator.Companion.getRecipePath
 import org.openrewrite.RecipeMarkdownGenerator.Companion.hasConflict
 import org.openrewrite.RecipeMarkdownGenerator.Companion.useAndApply
 import org.openrewrite.RecipeMarkdownGenerator.Companion.writeln
+import org.openrewrite.config.OptionDescriptor
 import org.openrewrite.config.RecipeDescriptor
 import java.io.BufferedWriter
 import java.net.URI
@@ -678,20 +679,8 @@ import RunRecipe from '@site/src/components/RunRecipe';
                 if (!option.isRequired && option.example == null) {
                     continue
                 }
-                val optionExample = option.example
                 val isList = option.type == "List" || option.type.startsWith("List<")
-                val ex = if (optionExample != null && option.type == "String" &&
-                    (optionExample.matches("^[{}\\[\\],`|=%@*!?-].*".toRegex()) ||
-                            optionExample.matches(".*:\\s.*".toRegex()))
-                ) {
-                    "'" + optionExample + "'"
-                } else if (optionExample != null && option.type == "String" && optionExample.contains('\n')) {
-                    ">\n        " + optionExample.replace("\n", "\n        ")
-                } else if (option.type == "boolean") {
-                    "false"
-                } else {
-                    option.example
-                }
+                val ex = cliOptionExample(option)
                 cliOptions += " --recipe-option \"${option.name}=$ex\""
                 if (isList) {
                     writeln("      ${option.name}:")
@@ -962,12 +951,13 @@ ${props.toString().trimEnd()}
         val name = recipeDescriptor.name
         val title = recipeDescriptor.displayNameEscaped().replace("&#39;", "'")
         val isProprietary = isProprietaryRecipe(name)
+        val recipePath = getRecipePath(recipeDescriptor)
 
         // Canonical <head> block for open-source recipes
         val canonicalHead = if (!isProprietary) {
             """
 <head>
-  <link rel="canonical" href="https://docs.openrewrite.org/recipes/${getRecipePath(recipeDescriptor)}" />
+  <link rel="canonical" href="https://docs.openrewrite.org/recipes/$recipePath" />
 </head>
 
 """
@@ -976,12 +966,12 @@ ${props.toString().trimEnd()}
         }
 
         val recipeType = if (recipeDescriptor.recipeList.isNullOrEmpty()) "Single recipe" else "Composite recipe"
-        val language = getSourceLanguage(name)
-        val licenseText = resolveLicensePlainText(origin)
-        val fqName = name
+        val languages = listOf(getSourceLanguage(name))
+        // License as plain text (not the markdown-link form the OpenRewrite docs path uses).
+        val licenseText = origin.license.name
         val artifact = "${origin.groupId}:${origin.artifactId}"
         val appLink = "https://app.moderne.io/recipes/$name"
-        val markdownUrl = MODERNE_DOCS_MARKDOWN_BASE_URL + getRecipePath(recipeDescriptor) + ".md"
+        val markdownUrl = MODERNE_DOCS_MARKDOWN_BASE_URL + recipePath + ".md"
 
         // Source URL — omit for proprietary or when no source URI available
         val sourceUrl: String? = if (!isProprietary) {
@@ -989,16 +979,8 @@ ${props.toString().trimEnd()}
             if (recipeSource != null) origin.githubUrl(name, recipeSource) else null
         } else null
 
-        // JSON props
         val description = recipeDescriptor.description ?: ""
         val tags = recipeDescriptor.tags?.toList() ?: emptyList<String>()
-        val languages = listOf(language)
-
-        val recipesJson = buildRecipeListJson(recipeDescriptor)
-        val optionsJson = buildOptionsJson(recipeDescriptor)
-        val examplesJson = buildExamplesJson(recipeDescriptor)
-        val usageJson = buildUsageJson(recipeDescriptor, origin)
-        val dataTablesJson = buildDataTablesJson(recipeDescriptor)
 
         Files.createDirectories(recipeMarkdownPath.parent)
         Files.newBufferedWriter(recipeMarkdownPath, StandardOpenOption.CREATE).useAndApply {
@@ -1010,9 +992,7 @@ ${props.toString().trimEnd()}
             writeln("---")
             newLine()
 
-            if (canonicalHead.isNotEmpty()) {
-                write(canonicalHead)
-            }
+            write(canonicalHead)   // "" for proprietary recipes — a no-op
 
             writeln("import { RecipeHeader, RecipeMeta, RecipeList, OptionsTable, ExampleList, UsageList, DataTableList } from '@site/src/components/recipe';")
             newLine()
@@ -1021,7 +1001,7 @@ ${props.toString().trimEnd()}
             writeln("<RecipeMeta")
             writeln("  displayName={${mapper.writeValueAsString(recipeDescriptor.displayName)}}")
             writeln("  description={${mapper.writeValueAsString(description)}}")
-            writeln("  fqName={${mapper.writeValueAsString(fqName)}}")
+            writeln("  fqName={${mapper.writeValueAsString(name)}}")
             writeln("  languages={${mapper.writeValueAsString(languages)}}")
             writeln("  license={${mapper.writeValueAsString(licenseText)}}")
             if (sourceUrl != null) {
@@ -1038,7 +1018,7 @@ ${props.toString().trimEnd()}
             writeln("  languages={${mapper.writeValueAsString(languages)}}")
             writeln("  tags={${mapper.writeValueAsString(tags)}}")
             writeln("  license={${mapper.writeValueAsString(licenseText)}}")
-            writeln("  fqName={${mapper.writeValueAsString(fqName)}}")
+            writeln("  fqName={${mapper.writeValueAsString(name)}}")
             writeln("  artifact={${mapper.writeValueAsString(artifact)}}")
             writeln("  appLink={${mapper.writeValueAsString(appLink)}}")
             writeln("  markdownUrl={${mapper.writeValueAsString(markdownUrl)}}")
@@ -1048,66 +1028,36 @@ ${props.toString().trimEnd()}
             writeln("/>")
             newLine()
 
-            // RecipeList — only for composite recipes
-            if (!recipeDescriptor.recipeList.isNullOrEmpty()) {
-                writeln("<RecipeList recipes={$recipesJson}>")
-                newLine()
-                writeln("## Definition")
-                newLine()
-                writeln("</RecipeList>")
-                newLine()
+            // Sections: the `## ` heading is the component's children, blank-line-wrapped (below) so MDX
+            // parses it as a real heading node and the native Docusaurus TOC picks it up. JSON props are
+            // built lazily, only for sections that are actually emitted.
+            if (!recipeDescriptor.recipeList.isNullOrEmpty()) {  // composite recipes only
+                emitSection("<RecipeList recipes={${buildRecipeListJson(recipeDescriptor)}}>", "## Definition", "</RecipeList>")
             }
-
-            // OptionsTable — only when options exist
             if (!recipeDescriptor.options.isNullOrEmpty()) {
-                writeln("<OptionsTable options={$optionsJson}>")
-                newLine()
-                writeln("## Options")
-                newLine()
-                writeln("</OptionsTable>")
-                newLine()
+                emitSection("<OptionsTable options={${buildOptionsJson(recipeDescriptor)}}>", "## Options", "</OptionsTable>")
             }
-
-            // ExampleList — only when examples exist
             if (!recipeDescriptor.examples.isNullOrEmpty()) {
-                writeln("<ExampleList examples={$examplesJson}>")
-                newLine()
-                writeln("## Examples")
-                newLine()
-                writeln("</ExampleList>")
-                newLine()
+                emitSection("<ExampleList examples={${buildExamplesJson(recipeDescriptor)}}>", "## Examples", "</ExampleList>")
             }
-
-            // UsageList — always emitted (mirrors writeUsage skip conditions for JS/Python/C#)
-            val skipUsage = isJavaScriptRecipe(recipeDescriptor) ||
-                isPythonRecipe(recipeDescriptor) ||
-                isCSharpRecipe(recipeDescriptor)
-            if (!skipUsage) {
-                writeln("<UsageList usage={$usageJson}>")
-                newLine()
-                writeln("## Usage")
-                newLine()
-                writeln("</UsageList>")
-                newLine()
+            // Usage mirrors writeUsage's skip for JS/Python/C# recipes (no UsageList contract yet).
+            if (!(isJavaScriptRecipe(recipeDescriptor) || isPythonRecipe(recipeDescriptor) || isCSharpRecipe(recipeDescriptor))) {
+                emitSection("<UsageList usage={${buildUsageJson(recipeDescriptor, origin)}}>", "## Usage", "</UsageList>")
             }
-
-            // DataTableList — only when dataTables exist
             if (!recipeDescriptor.dataTables.isNullOrEmpty()) {
-                writeln("<DataTableList tables={$dataTablesJson}>")
-                newLine()
-                writeln("## Data tables")
-                newLine()
-                writeln("</DataTableList>")
-                newLine()
+                emitSection("<DataTableList tables={${buildDataTablesJson(recipeDescriptor)}}>", "## Data tables", "</DataTableList>")
             }
         }
     }
 
-    /**
-     * Resolve the license as plain text (no markdown link syntax).
-     */
-    private fun resolveLicensePlainText(origin: RecipeOrigin): String {
-        return origin.license.name
+    /** Emit a recipe-section component with its `## ` heading as a blank-line-wrapped children slot. */
+    private fun BufferedWriter.emitSection(openTag: String, heading: String, closeTag: String) {
+        writeln(openTag)
+        newLine()
+        writeln(heading)
+        newLine()
+        writeln(closeTag)
+        newLine()
     }
 
     /**
@@ -1236,27 +1186,14 @@ ${props.toString().trimEnd()}
             "requiresConfiguration" to requiresConfiguration
         )
 
-        // Build cliOptions string (mirrors writeUsage logic)
+        // Build cliOptions string (shares the per-option example formatting with writeUsage).
         var cliOptions = ""
         if (requiresConfiguration) {
             for (option in options) {
                 if (!option.isRequired && option.example == null) {
                     continue
                 }
-                val optionExample = option.example
-                val ex = if (optionExample != null && option.type == "String" &&
-                    (optionExample.matches("^[{}\\[\\],`|=%@*!?-].*".toRegex()) ||
-                            optionExample.matches(".*:\\s.*".toRegex()))
-                ) {
-                    "'" + optionExample + "'"
-                } else if (optionExample != null && option.type == "String" && optionExample.contains('\n')) {
-                    ">\n        " + optionExample.replace("\n", "\n        ")
-                } else if (option.type == "boolean") {
-                    "false"
-                } else {
-                    option.example
-                }
-                cliOptions += " --recipe-option \"${option.name}=$ex\""
+                cliOptions += " --recipe-option \"${option.name}=${cliOptionExample(option)}\""
             }
         }
         if (cliOptions.isNotEmpty()) {
@@ -1292,9 +1229,32 @@ ${props.toString().trimEnd()}
         return mapper.writeValueAsString(items)
     }
 
+    /**
+     * The example value for an option as it appears in the Moderne CLI run command / rewrite.yml.
+     * Shared by [writeUsage] (markdown) and [buildUsageJson] (component prop) so the two stay in sync.
+     */
+    private fun cliOptionExample(option: OptionDescriptor): String? {
+        val optionExample = option.example
+        return if (optionExample != null && option.type == "String" &&
+            (optionExample.matches(YAML_SPECIAL_START_REGEX) || optionExample.matches(YAML_COLON_SPACE_REGEX))
+        ) {
+            "'" + optionExample + "'"
+        } else if (optionExample != null && option.type == "String" && optionExample.contains('\n')) {
+            ">\n        " + optionExample.replace("\n", "\n        ")
+        } else if (option.type == "boolean") {
+            "false"
+        } else {
+            option.example
+        }
+    }
+
     companion object {
         private const val MODERNE_DOCS_MARKDOWN_BASE_URL =
             "https://raw.githubusercontent.com/moderneinc/moderne-docs/refs/heads/main/docs/user-documentation/recipes/recipe-catalog/"
+
+        // CLI/YAML option-example formatting (compiled once instead of per option per recipe).
+        private val YAML_SPECIAL_START_REGEX = Regex("^[{}\\[\\],`|=%@*!?-].*")
+        private val YAML_COLON_SPACE_REGEX = Regex(".*:\\s.*")
 
         private fun printValue(value: Any): String =
             if (value is Array<*>) {

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -53,6 +53,8 @@ class RecipeMarkdownWriterModerneDocsTest {
     private fun compositeRecipe() = descriptor(
         "org.openrewrite.java.CompositeFoo", "Composite foo", "Runs several foo recipes.",
         recipeList = listOf(singleRecipe())
+    ).withPreconditions(
+        listOf(descriptor("org.openrewrite.java.search.FindFoo", "Find foo", "Finds foo."))
     )
 
     private fun writer(forModerneDocs: Boolean, proprietary: Set<String> = emptySet()) =
@@ -112,6 +114,9 @@ class RecipeMarkdownWriterModerneDocsTest {
         assertThat(out).doesNotContain("moderneOnly")     // open source
         assertThat(out).contains("<RecipeList recipes={")
         assertThat(out).contains("\n\n## Definition\n\n</RecipeList>")
+        // Preconditions are fed through to RecipeList's `preconditions` prop (Jayd's #798 change).
+        assertThat(out).contains("preconditions={")
+        assertThat(out).contains("\"name\":\"Find foo\"")
         // Open-source recipe keeps the canonical link to OpenRewrite docs.
         assertThat(out).contains("rel=\"canonical\"")
         assertThat(out).contains("docs.openrewrite.org")

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -57,9 +57,6 @@ class RecipeMarkdownWriterModerneDocsTest {
         listOf(descriptor("org.openrewrite.java.search.FindFoo", "Find foo", "Finds foo."))
     )
 
-    private fun writer(forModerneDocs: Boolean, proprietary: Set<String> = emptySet()) =
-        RecipeMarkdownWriter(mutableMapOf(), emptyMap(), proprietary, forModerneDocs)
-
     private fun generate(
         recipe: RecipeDescriptor,
         dir: Path,
@@ -67,7 +64,8 @@ class RecipeMarkdownWriterModerneDocsTest {
         license: License = Licenses.Apache2,
         proprietary: Set<String> = emptySet(),
     ): String {
-        writer(forModerneDocs, proprietary).writeRecipe(recipe, dir, origin(license))
+        RecipeMarkdownWriter(mutableMapOf(), emptyMap(), proprietary, forModerneDocs)
+            .writeRecipe(recipe, dir, origin(license))
         val md = Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow()
         return Files.readString(md)
     }

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -1,0 +1,145 @@
+package org.openrewrite
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.openrewrite.config.OptionDescriptor
+import org.openrewrite.config.RecipeDescriptor
+import org.openrewrite.config.RecipeExample
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+
+/**
+ * Verifies the `forModerneDocs = true` component-MDX output of [RecipeMarkdownWriter].
+ * Constructs descriptors directly so it does not depend on recipe loading (which needs Python/pip).
+ */
+class RecipeMarkdownWriterModerneDocsTest {
+
+    private val jar = URI.create("file:///tmp/recipes.jar")
+
+    private fun origin(license: License = Licenses.Apache2) =
+        RecipeOrigin("org.openrewrite.recipe", "rewrite-static-analysis", "1.0.0", jar)
+            .apply { this.license = license }
+
+    private fun example() = RecipeExample().apply {
+        description = ""
+        parameters = listOf("true")
+        sources = listOf(RecipeExample.Source("class A {}\n", "class B {}\n", null, "java"))
+    }
+
+    private fun singleRecipe() = RecipeDescriptor(
+        "org.openrewrite.java.ReplaceFoo",
+        "Replace `foo`",
+        "Replace foo",
+        "Replaces foo with bar.",
+        setOf("RSPEC-S1192"),
+        Duration.ofMinutes(5),
+        listOf(
+            OptionDescriptor(
+                "includeTestSources", "Boolean", "Include test sources",
+                "Changes apply to test sources.", "true", null, false, null
+            )
+        ),
+        emptyList(),                 // recipeList -> single recipe
+        emptyList(),                 // dataTables
+        emptyList(),                 // maintainers
+        emptyList(),                 // contributors
+        listOf(example()),
+        jar
+    )
+
+    private fun compositeRecipe() = RecipeDescriptor(
+        "org.openrewrite.java.CompositeFoo",
+        "Composite foo",
+        "Composite foo",
+        "Runs several foo recipes.",
+        setOf("RSPEC-S1192"),
+        Duration.ofMinutes(5),
+        emptyList(),                 // options
+        listOf(singleRecipe()),      // recipeList -> composite
+        emptyList(),
+        emptyList(),
+        emptyList(),
+        listOf(example()),
+        jar
+    )
+
+    private fun writer(forModerneDocs: Boolean, proprietary: Set<String> = emptySet()) =
+        RecipeMarkdownWriter(mutableMapOf(), emptyMap(), proprietary, forModerneDocs)
+
+    private fun generate(
+        recipe: RecipeDescriptor,
+        dir: Path,
+        forModerneDocs: Boolean,
+        license: License = Licenses.Apache2,
+        proprietary: Set<String> = emptySet(),
+    ): String {
+        writer(forModerneDocs, proprietary).writeRecipe(recipe, dir, origin(license))
+        val md = Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow()
+        return Files.readString(md)
+    }
+
+    @Test
+    fun moderneDocsEmitsComponentsForSingleRecipe(@TempDir dir: Path) {
+        val out = generate(
+            singleRecipe(), dir, forModerneDocs = true,
+            license = Licenses.MSAL, proprietary = setOf("org.openrewrite.java.ReplaceFoo")
+        )
+
+        // Frontmatter: hide_title, and no markdown H1 (RecipeHeader renders the title).
+        assertThat(out).contains("hide_title: true")
+        assertThat(out.lineSequence().none { it.startsWith("# ") }).isTrue()
+
+        // Component import + header components.
+        assertThat(out).contains("from '@site/src/components/recipe'")
+        assertThat(out).contains("<RecipeMeta")
+        assertThat(out).contains("<RecipeHeader")
+        assertThat(out).contains("type={\"Single recipe\"}")
+        assertThat(out).contains("moderneOnly")          // proprietary
+
+        // Options + Examples + Usage, each with the heading passed as a blank-line-wrapped child.
+        assertThat(out).contains("<OptionsTable options={")
+        assertThat(out).contains("\n\n## Options\n\n</OptionsTable>")
+        assertThat(out).contains("<ExampleList examples={")
+        assertThat(out).contains("\n\n## Examples\n\n</ExampleList>")
+        assertThat(out).contains("<UsageList usage={")
+        assertThat(out).contains("\n\n## Usage\n\n</UsageList>")
+
+        // Options JSON uses the component's field names.
+        assertThat(out).contains("\"name\":\"includeTestSources\"")
+        assertThat(out).contains("\"required\":false")
+        // Example variant carries before/after.
+        assertThat(out).contains("\"before\":\"class A {}")
+        assertThat(out).contains("\"after\":\"class B {}")
+    }
+
+    @Test
+    fun moderneDocsEmitsDefinitionForCompositeRecipe(@TempDir dir: Path) {
+        val out = generate(compositeRecipe(), dir, forModerneDocs = true)
+
+        assertThat(out).contains("type={\"Composite recipe\"}")
+        assertThat(out).doesNotContain("moderneOnly")     // open source
+        assertThat(out).contains("<RecipeList recipes={")
+        assertThat(out).contains("\n\n## Definition\n\n</RecipeList>")
+        // Open-source recipe keeps the canonical link to OpenRewrite docs.
+        assertThat(out).contains("rel=\"canonical\"")
+        assertThat(out).contains("docs.openrewrite.org")
+    }
+
+    @Test
+    fun openRewriteDocsOutputUnchangedForSingleRecipe(@TempDir dir: Path) {
+        // Proprietary license so writeSourceLinks takes its Moderne-only branch and doesn't require a
+        // source URI lookup (this test only guards that the OpenRewrite path is untouched).
+        val out = generate(
+            singleRecipe(), dir, forModerneDocs = false,
+            license = Licenses.Proprietary, proprietary = setOf("org.openrewrite.java.ReplaceFoo")
+        )
+
+        // The OpenRewrite path still renders a markdown H1 and no recipe components.
+        assertThat(out).contains("# Replace `foo`")
+        assertThat(out).doesNotContain("<RecipeHeader")
+        assertThat(out).doesNotContain("hide_title: true")
+    }
+}

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -52,7 +52,11 @@ class RecipeMarkdownWriterModerneDocsTest {
 
     private fun compositeRecipe() = descriptor(
         "org.openrewrite.java.CompositeFoo", "Composite foo", "Runs several foo recipes.",
-        recipeList = listOf(singleRecipe())
+        // Includes a "Precondition bellwether" that must be filtered out of the rendered list.
+        recipeList = listOf(
+            singleRecipe(),
+            descriptor("org.openrewrite.java.BellwetherFoo", "Precondition bellwether", "internal"),
+        )
     ).withPreconditions(
         listOf(descriptor("org.openrewrite.java.search.FindFoo", "Find foo", "Finds foo."))
     )
@@ -115,9 +119,26 @@ class RecipeMarkdownWriterModerneDocsTest {
         // Preconditions are fed through to RecipeList's `preconditions` prop (Jayd's #798 change).
         assertThat(out).contains("preconditions={")
         assertThat(out).contains("\"name\":\"Find foo\"")
+        // Internal "Precondition bellwether" recipes are filtered out (rewrite-docs#250).
+        assertThat(out).doesNotContain("Precondition bellwether")
         // Open-source recipe keeps the canonical link to OpenRewrite docs.
         assertThat(out).contains("rel=\"canonical\"")
         assertThat(out).contains("docs.openrewrite.org")
+    }
+
+    @Test
+    fun moderneDocsEmitsNpmUsageForJavaScriptRecipe(@TempDir dir: Path) {
+        val recipe = descriptor("org.openrewrite.javascript.FormatFoo", "Format foo", "Formats foo.")
+        // isJavaScriptRecipe keys off a `typescript-search://` source URI.
+        val recipeToSource = mapOf(recipe.name to URI.create("typescript-search://rewrite-static-analysis/format"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = true)
+            .writeRecipe(recipe, dir, origin())
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        // JS recipes get a UsageList with an npm package, not Maven/Gradle coordinates.
+        assertThat(out).contains("<UsageList usage={")
+        assertThat(out).contains("\"npmPackage\":")
+        assertThat(out).doesNotContain("\"groupId\":")
     }
 
     @Test

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -29,41 +29,30 @@ class RecipeMarkdownWriterModerneDocsTest {
         sources = listOf(RecipeExample.Source("class A {}\n", "class B {}\n", null, "java"))
     }
 
-    private fun singleRecipe() = RecipeDescriptor(
-        "org.openrewrite.java.ReplaceFoo",
-        "Replace `foo`",
-        "Replace foo",
-        "Replaces foo with bar.",
-        setOf("RSPEC-S1192"),
-        Duration.ofMinutes(5),
-        listOf(
+    private fun descriptor(
+        name: String,
+        displayName: String,
+        description: String,
+        options: List<OptionDescriptor> = emptyList(),
+        recipeList: List<RecipeDescriptor> = emptyList(),
+    ) = RecipeDescriptor(
+        name, displayName, displayName, description, setOf("RSPEC-S1192"), Duration.ofMinutes(5),
+        options, recipeList, emptyList(), emptyList(), emptyList(), listOf(example()), jar
+    )
+
+    private fun singleRecipe() = descriptor(
+        "org.openrewrite.java.ReplaceFoo", "Replace `foo`", "Replaces foo with bar.",
+        options = listOf(
             OptionDescriptor(
                 "includeTestSources", "Boolean", "Include test sources",
                 "Changes apply to test sources.", "true", null, false, null
             )
-        ),
-        emptyList(),                 // recipeList -> single recipe
-        emptyList(),                 // dataTables
-        emptyList(),                 // maintainers
-        emptyList(),                 // contributors
-        listOf(example()),
-        jar
+        )
     )
 
-    private fun compositeRecipe() = RecipeDescriptor(
-        "org.openrewrite.java.CompositeFoo",
-        "Composite foo",
-        "Composite foo",
-        "Runs several foo recipes.",
-        setOf("RSPEC-S1192"),
-        Duration.ofMinutes(5),
-        emptyList(),                 // options
-        listOf(singleRecipe()),      // recipeList -> composite
-        emptyList(),
-        emptyList(),
-        emptyList(),
-        listOf(example()),
-        jar
+    private fun compositeRecipe() = descriptor(
+        "org.openrewrite.java.CompositeFoo", "Composite foo", "Runs several foo recipes.",
+        recipeList = listOf(singleRecipe())
     )
 
     private fun writer(forModerneDocs: Boolean, proprietary: Set<String> = emptySet()) =


### PR DESCRIPTION
- Implements #343.

## What this does

- When `forModerneDocs == true`, `RecipeMarkdownWriter` now emits MDX that renders the redesigned moderne-docs recipe-detail React components ([moderneinc/moderne-docs#794](https://github.com/moderneinc/moderne-docs/pull/794)) instead of raw markdown. The OpenRewrite docs path (`forModerneDocs == false`) is **untouched**.

A new `writeModerneComponentRecipe()` is dispatched at the top of `writeRecipeToPath`; all existing `write*` markdown methods are left as-is.

## Emitted shape

* `hide_title: true` frontmatter, **no `# H1`** (RecipeHeader renders the title)
* component import + `<RecipeMeta>` / `<RecipeHeader>` (props: displayName, description, type, languages, tags, license, fqName, artifact, appLink, markdownUrl, `moderneOnly`)
* `<RecipeList>` (composite) / `<OptionsTable>` (single) / `<ExampleList>` / `<UsageList>` / `<DataTableList>`, each wrapping its `## ` heading as a **blank-line-wrapped children slot** so the native Docusaurus TOC + anchor IDs are preserved
* section data serialized to inline JSON props via Jackson, matching the components' TypeScript prop shapes (e.g. `required` not `isRequired`; data-table column `name` from the column's display name; example sources mapped to `variants[]` / `unchanged` with a precomputed `diff`)

Field sources: `languages` from `getSourceLanguage(name)`; `type` from `recipeList` emptiness; `moderneOnly` from the proprietary set; `artifact` from `groupId:artifactId`; `appLink`/`markdownUrl` deterministic from the recipe name/path; `license` from `origin.license.name`.

### Sample output (proprietary single recipe)

```mdx
---
title: "Replace `foo`"
sidebar_label: "Replace `foo`"
hide_title: true
---

import { RecipeHeader, RecipeMeta, RecipeList, OptionsTable, ExampleList, UsageList, DataTableList } from '@site/src/components/recipe';

<RecipeMeta displayName={"Replace `foo`"} description={"…"} fqName={"…"} languages={["Java"]} license={"Moderne Source Available License"} />

<RecipeHeader … artifact={"org.openrewrite.recipe:rewrite-static-analysis"} appLink={"…"} markdownUrl={"…"} moderneOnly />

<OptionsTable options={[{"type":"Boolean","name":"includeTestSources","required":false,"description":"…","example":"true"}]}>

## Options

</OptionsTable>

<ExampleList examples={[{"parameters":[{"parameter":"includeTestSources","value":"true"}],"variants":[{"language":"java","before":"…","after":"…","diff":"…","newFile":false}]}]}>

## Examples

</ExampleList>
```

## Verification

* New `RecipeMarkdownWriterModerneDocsTest` (constructs descriptors directly, so it doesn't require recipe loading) covers: Moderne single recipe (hide_title, no H1, header components, `moderneOnly`, Options/Examples/Usage with blank-line-wrapped headings, JSON field names), Moderne composite (Definition + canonical link), and the unchanged OpenRewrite path. `./gradlew test` passes.
* A full `./gradlew run` could not be exercised in this environment (the Python recipe loader requires a working Python 3.10+/pip toolchain), so end-to-end generation against the live recipe set still needs a CI/local run.

## Open questions / follow-ups

- * **Data-passing approach:** this PR uses inline JSON prop expressions (issue #343 option 1). If page size/escaping becomes a concern we can switch to a co-located `.data` module.
* **`markdownUrl`** is hardcoded to the `moderneinc/moderne-docs` `main` raw base + recipe path — confirm that's the desired source-of-truth URL.
* **`languages`** is a single derived label from the recipe name prefix; composite recipes spanning multiple languages get just the top-level label.
