### PR TITLE
Add support for Go recipe doc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ The CI workflow in *this* repo also only runs with `-PlatestVersionsOnly=true`, 
 
 ### Prerequisites
 
-The generator loads TypeScript, Python, and C# recipes by spawning external RPC processes. To produce complete docs locally you need all of these on `PATH`:
+The generator loads TypeScript, Python, C#, and Go recipes by spawning external RPC processes. To produce complete docs locally you need all of these on `PATH`:
 
 * **Java 21** — JVM-based recipes
 * **Node.js** — TypeScript recipes (`rewrite-javascript`, `rewrite-nodejs`, `rewrite-angular`, `rewrite-react`)
 * **Python 3.10+ and `pip`** — Python recipes (`rewrite-python`, `rewrite-migrate-python`, `openrewrite-static-analysis`)
 * **.NET SDK** — C# recipes (`recipes-code-quality`, `recipes-migrate-dotnet`, `recipes-tunit`, `recipes-csharp-core`)
+* **Go 1.23+ and the `rewrite-go-rpc` server** — Go recipes (`recipes-go`). Build the server with `go install github.com/openrewrite/rewrite/rewrite-go/cmd/rpc@latest` (ideally pinned to the Go-module tag matching the `rewrite-go` release), then make it discoverable as `rewrite-go-rpc` on `PATH` — the `go install` binary is named `rpc`, so symlink or copy it (e.g. `ln -s "$(go env GOPATH)/bin/rpc" "$(go env GOPATH)/bin/rewrite-go-rpc"`). Installing recipes also requires network access so the server can `go get` the Go recipe module.
 
 If a toolchain is missing, the corresponding loader prints a warning and skips those recipes. The build still succeeds, so a local `./gradlew run` without all four toolchains silently produces incomplete docs. Most contributors don't have all four installed — if you need a complete regeneration, trigger the scheduled workflows above rather than running locally.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation("org.openrewrite:rewrite-javascript")
     implementation("org.openrewrite:rewrite-csharp")
     implementation("org.openrewrite:rewrite-python")
+    implementation("org.openrewrite:rewrite-go")
 
     // Runtime dependencies
     runtimeOnly("org.slf4j:slf4j-simple:1.7.30")
@@ -78,6 +79,7 @@ dependencies {
     "recipe"("org.openrewrite:rewrite-core:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-csharp:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-docker:$rewriteVersion")
+    "recipe"("org.openrewrite:rewrite-go:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-gradle:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-groovy:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-hcl:$rewriteVersion")
@@ -146,6 +148,10 @@ dependencies {
     "recipe"("org.openrewrite.recipe:rewrite-terraform:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-testing-frameworks:$rewriteVersion")
     "recipe"("org.openrewrite.recipe:rewrite-third-party:$rewriteVersion")
+
+    // Go recipes load via the Go RPC at doc-gen time (see GoRecipeLoader); this empty Maven artifact
+    // only anchors the version-table row and the RecipeOrigin the Go recipes are attributed to.
+    "recipe"("org.openrewrite.recipe:recipes-go:$rewriteVersion")
 
     // Moderne recipe modules (io.moderne.recipe)
     "recipe"("io.moderne.recipe:recipes-kotlin:$rewriteVersion")

--- a/src/main/kotlin/org/openrewrite/GoRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/GoRecipeLoader.kt
@@ -1,0 +1,220 @@
+@file:Suppress("SENSELESS_COMPARISON")
+
+package org.openrewrite
+
+import org.openrewrite.config.RecipeDescriptor
+import org.openrewrite.golang.rpc.GoRewriteRpc
+import org.openrewrite.marketplace.RecipeBundle
+import org.openrewrite.marketplace.RecipeBundleReader
+import org.openrewrite.marketplace.RecipeBundleResolver
+import org.openrewrite.marketplace.RecipeListing
+import org.openrewrite.marketplace.RecipeMarketplace
+import java.net.URI
+
+/**
+ * Loads Go recipes via RPC from a `rewrite-go-rpc` (Go) process: start the server, install the Go
+ * recipe module, then enumerate descriptors. Mirrors [CSharpRecipeLoader] — because Go recipes can
+ * delegate to Java recipes, the RPC is seeded with a marketplace of the Java descriptors (and a
+ * classpath resolver) so `prepareRecipe` can resolve them.
+ *
+ * Requires a Go toolchain and the `rewrite-go-rpc` server on `PATH`
+ * (built from github.com/openrewrite/rewrite/rewrite-go/cmd/rpc).
+ */
+class GoRecipeLoader(
+    private val recipeOrigins: Map<URI, RecipeOrigin>,
+    private val javaDescriptors: Collection<RecipeDescriptor> = emptyList(),
+    private val classloader: ClassLoader = GoRecipeLoader::class.java.classLoader
+) {
+
+    companion object {
+        /** Artifact ID -> Go module path. Add new Go recipe modules here. */
+        val GO_RECIPE_MODULES = mapOf(
+            "recipes-go" to "github.com/moderneinc/recipes-go"
+        )
+
+        // Used only to synthesize an origin if a Go module ever lacks a Maven artifact (recipes-go has one).
+        private val GO_GROUP_IDS = mapOf(
+            "recipes-go" to "org.openrewrite.recipe"
+        )
+        private val GO_REPO_URLS = mapOf(
+            "recipes-go" to "https://github.com/moderneinc/recipes-go/blob/main/"
+        )
+
+        private val CLASSPATH_BUNDLE = RecipeBundle("classpath", "java-recipes", null, null, null)
+
+        /** Marketplace of Java descriptors so Go recipes that delegate to Java resolve in [GoRewriteRpc.prepareRecipe]. */
+        @JvmStatic
+        fun buildMarketplace(descriptors: Collection<RecipeDescriptor>): RecipeMarketplace {
+            val marketplace = RecipeMarketplace()
+            for (descriptor in descriptors) {
+                marketplace.install(RecipeListing.fromDescriptor(descriptor, CLASSPATH_BUNDLE), emptyList())
+            }
+            return marketplace
+        }
+    }
+
+    data class GoRecipeResult(
+        val descriptors: List<RecipeDescriptor>,
+        val recipeToSource: Map<String, URI>,
+        val syntheticOrigins: Map<URI, RecipeOrigin> = emptyMap()
+    )
+
+    private fun mapRecipeToSourceUri(recipeName: String, artifactId: String): URI {
+        return URI.create("go-search://$artifactId/$recipeName")
+    }
+
+    /** Type-appropriate placeholder for a required option (the RPC may do strict type conversion). */
+    private fun placeholderForType(type: String?): Any {
+        return when (type?.lowercase()) {
+            "int", "int32", "int64", "long", "short", "byte" -> 0
+            "float", "double", "decimal" -> 0.0
+            "bool", "boolean" -> false
+            else -> "PlaceholderValueToFoolValidation"
+        }
+    }
+
+    /** Resolves delegated-to Java recipes from the classpath. */
+    private fun classpathResolver(): RecipeBundleResolver {
+        return object : RecipeBundleResolver {
+            override fun getEcosystem() = CLASSPATH_BUNDLE.packageEcosystem
+
+            override fun resolve(bundle: RecipeBundle): RecipeBundleReader {
+                val loader = org.openrewrite.internal.RecipeLoader(classloader)
+                return object : RecipeBundleReader {
+                    override fun getBundle() = bundle
+                    override fun read() = RecipeMarketplace()
+                    override fun describe(listing: RecipeListing) = loader.load(listing.name, emptyMap()).descriptor
+                    override fun prepare(listing: RecipeListing, options: MutableMap<String, Any>) =
+                        loader.load(listing.name, options)
+                }
+            }
+        }
+    }
+
+    /** Loads Go recipes from their Go modules via RPC. */
+    fun loadGoRecipes(): GoRecipeResult {
+        if (GO_RECIPE_MODULES.isEmpty()) {
+            println("No Go recipe modules configured.")
+            return GoRecipeResult(emptyList(), emptyMap())
+        }
+
+        data class GoPackageInfo(val artifactId: String, val goModule: String, val version: String?)
+
+        val packagesToLoad = GO_RECIPE_MODULES.map { (artifactId, goModule) ->
+            val origin = recipeOrigins.values.firstOrNull { it.artifactId == artifactId }
+            GoPackageInfo(artifactId, goModule, origin?.version)
+        }
+
+        println("Found ${packagesToLoad.size} Go recipe module(s): ${packagesToLoad.joinToString { it.artifactId }}")
+
+        val marketplace = buildMarketplace(javaDescriptors)
+        if (javaDescriptors.isNotEmpty()) {
+            println("Registered ${javaDescriptors.size} Java recipe(s) in marketplace for delegatesTo resolution")
+        }
+        // A delegating Go recipe's prepareRecipe returns the Java descriptor; track Java names to re-attribute below.
+        val javaRecipeNames = javaDescriptors.map { it.name }.toSet()
+
+        var rpc: GoRewriteRpc? = null
+        try {
+            rpc = GoRewriteRpc.builder()
+                .marketplace(marketplace)
+                .resolvers(listOf(classpathResolver()))
+                .get()
+            println("Started Go RPC process for Go recipe loading")
+
+            val allDescriptors = mutableListOf<RecipeDescriptor>()
+            val recipeToSource = mutableMapOf<String, URI>()
+
+            for (pkg in packagesToLoad) {
+                try {
+                    // Go module versions are tagged vX.Y.Z; the Maven origin version is X.Y.Z.
+                    val goVersion = pkg.version?.let { if (it.startsWith("v")) it else "v$it" }
+                    val versionLabel = goVersion ?: "latest"
+                    println("Installing Go recipes from module: ${pkg.goModule}@$versionLabel")
+
+                    val response = if (goVersion != null) {
+                        rpc.installRecipes(pkg.goModule, goVersion)
+                    } else {
+                        rpc.installRecipes(pkg.goModule)
+                    }
+                    println("  Installed ${response.recipesInstalled} recipe(s) from ${pkg.goModule}")
+
+                    val allListings = rpc.getMarketplace(RecipeBundle("go", pkg.goModule, null, null, null))
+                        .allRecipes
+
+                    val descriptors = allListings.mapNotNull { listing ->
+                        // getMarketplace is accumulative; skip recipes already attributed.
+                        if (listing.name in recipeToSource) return@mapNotNull null
+                        try {
+                            val requiredOptions = listing.options
+                                .filter { it.isRequired }
+                                .associate { it.name to placeholderForType(it.type) }
+                            val descriptor = rpc.prepareRecipe(listing.name, requiredOptions).descriptor
+
+                            // A delegatesTo-Java recipe returns the Java-named descriptor; rebuild it under
+                            // the Go name so the Go recipe gets its own doc page.
+                            if (descriptor.name != listing.name && descriptor.name in javaRecipeNames) {
+                                RecipeDescriptor(
+                                    listing.name,
+                                    listing.displayName,
+                                    listing.displayName,
+                                    listing.description,
+                                    emptySet(),
+                                    null,
+                                    listing.options,
+                                    listOf(descriptor),
+                                    emptyList(),
+                                    emptyList(),
+                                    emptyList(),
+                                    emptyList(),
+                                    emptyList(),
+                                    mapRecipeToSourceUri(listing.name, pkg.artifactId)
+                                )
+                            } else {
+                                descriptor
+                            }
+                        } catch (e: Exception) {
+                            System.err.println("Warning: Failed to prepare recipe ${listing.name}: ${e.message}")
+                            null
+                        }
+                    }
+
+                    for (descriptor in descriptors) {
+                        if (descriptor.name in javaRecipeNames) continue
+                        recipeToSource[descriptor.name] = mapRecipeToSourceUri(descriptor.name, pkg.artifactId)
+                    }
+                    allDescriptors.addAll(descriptors.filter { it.name !in javaRecipeNames })
+
+                } catch (e: Exception) {
+                    System.err.println("Warning: Failed to load recipes from ${pkg.artifactId}: ${e.message}")
+                    e.printStackTrace()
+                }
+            }
+
+            println("Retrieved ${allDescriptors.size} Go recipe descriptor(s) via RPC")
+
+            // Defensive: synthesize an origin only if a module lacks a Maven artifact (recipes-go has one).
+            val syntheticOrigins = mutableMapOf<URI, RecipeOrigin>()
+            for (pkg in packagesToLoad) {
+                if (recipeOrigins.values.any { it.artifactId == pkg.artifactId }) continue
+                val syntheticUri = URI.create("go-search://${pkg.artifactId}")
+                val groupId = GO_GROUP_IDS[pkg.artifactId] ?: "org.openrewrite.recipe"
+                val origin = RecipeOrigin(groupId, pkg.artifactId, pkg.version ?: "latest", syntheticUri)
+                origin.repositoryUrl = GO_REPO_URLS[pkg.artifactId] ?: ""
+                origin.license = Licenses.Proprietary
+                syntheticOrigins[syntheticUri] = origin
+                println("Created synthetic origin for ${pkg.artifactId} (Go-module-only package)")
+            }
+
+            return GoRecipeResult(allDescriptors, recipeToSource, syntheticOrigins)
+
+        } catch (e: Exception) {
+            System.err.println("WARNING: Failed to load Go recipes. Ensure Go 1.23+ and the rewrite-go-rpc server are installed and available on PATH.")
+            System.err.println("  ${e.message}")
+            return GoRecipeResult(emptyList(), emptyMap())
+        } finally {
+            rpc?.shutdown()
+            println("Shut down Go RPC process")
+        }
+    }
+}

--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -131,7 +131,15 @@ class RecipeLoader {
             System.err.println("WARNING: 0 C# recipes loaded despite ${CSharpRecipeLoader.CSHARP_RECIPE_MODULES.size} module(s) configured. Check that .NET SDK is installed.")
         }
 
-        // Merge TypeScript, Python, and C# results with Java/YAML results
+        // Load Go recipes via RPC, passing Java descriptors so delegatesTo can resolve
+        println("\nChecking for Go recipes...")
+        val goLoader = GoRecipeLoader(recipeOrigins, javaDescriptors, classloader)
+        val goResult = goLoader.loadGoRecipes()
+        if (goResult.descriptors.isEmpty() && GoRecipeLoader.GO_RECIPE_MODULES.isNotEmpty()) {
+            System.err.println("WARNING: 0 Go recipes loaded despite ${GoRecipeLoader.GO_RECIPE_MODULES.size} module(s) configured. Check that Go 1.23+ and the rewrite-go-rpc server are installed.")
+        }
+
+        // Merge TypeScript, Python, C#, and Go results with Java/YAML results
         val allDescriptors = environmentData.flatMap { it.recipeDescriptors }.toMutableList()
         allDescriptors.addAll(typeScriptResult.descriptors)
         recipeToSource.putAll(typeScriptResult.recipeToSource)
@@ -139,6 +147,8 @@ class RecipeLoader {
         recipeToSource.putAll(pythonResult.recipeToSource)
         allDescriptors.addAll(csharpResult.descriptors)
         recipeToSource.putAll(csharpResult.recipeToSource)
+        allDescriptors.addAll(goResult.descriptors)
+        recipeToSource.putAll(goResult.recipeToSource)
 
         // Deduplicate recipes by name (same recipe may be discovered from multiple JARs
         // when scanJar is called with the full classpath as dependencies)
@@ -158,7 +168,7 @@ class RecipeLoader {
             allCategoryDescriptors = environmentData.flatMap { it.categoryDescriptors }.distinctBy { it.packageName },
             allRecipes = environmentData.flatMap { it.recipes }.distinctBy { it.name },
             recipeToSource = recipeToSource,
-            additionalOrigins = pythonResult.syntheticOrigins + csharpResult.syntheticOrigins,
+            additionalOrigins = pythonResult.syntheticOrigins + csharpResult.syntheticOrigins + goResult.syntheticOrigins,
             crossCategoryPaths = allCrossCategoryPaths
         )
     }

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -177,6 +177,11 @@ class RecipeMarkdownGenerator : Runnable {
             .filter { it.artifactId in CSharpRecipeLoader.CSHARP_RECIPE_MODULES }
             .forEach { it.license = Licenses.Proprietary }
 
+        // Go recipe modules are always proprietary
+        recipeOrigins.values
+            .filter { it.artifactId in GoRecipeLoader.GO_RECIPE_MODULES }
+            .forEach { it.license = Licenses.Proprietary }
+
         println("Found ${allRecipeDescriptors.size} descriptor(s).")
 
         // Detect conflicting paths between io.moderne and org.openrewrite recipes
@@ -209,7 +214,8 @@ class RecipeMarkdownGenerator : Runnable {
                 (origin != null && isModerneDocsOnly(origin)) ||
                     source?.toString()?.startsWith("typescript-search://") == true ||
                     source?.toString()?.startsWith("python-search://") == true ||
-                    source?.toString()?.startsWith("csharp-search://") == true
+                    source?.toString()?.startsWith("csharp-search://") == true ||
+                    source?.toString()?.startsWith("go-search://") == true
             }
             .map { it.name }
             .toSet()
@@ -488,6 +494,12 @@ class RecipeMarkdownGenerator : Runnable {
             // Handle C# recipes with custom URI scheme
             if (rawUri.startsWith("csharp-search://")) {
                 val artifactId = rawUri.substringAfter("csharp-search://").substringBefore("/")
+                return recipeOrigins.values.firstOrNull { it.artifactId == artifactId }
+            }
+
+            // Handle Go recipes with custom URI scheme
+            if (rawUri.startsWith("go-search://")) {
+                val artifactId = rawUri.substringAfter("go-search://").substringBefore("/")
                 return recipeOrigins.values.firstOrNull { it.artifactId == artifactId }
             }
 

--- a/src/main/kotlin/org/openrewrite/RecipeOrigin.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeOrigin.kt
@@ -82,6 +82,15 @@ class RecipeOrigin(
                     .removeSuffix("/")
                 "https://github.com/search?type=code&q=repo:${repoPath}+${searchRecipeName}"
             }
+            sourceString.startsWith("go-search://") -> {
+                val searchRecipeName = sourceString.substringAfter("go-search://$artifactId/")
+                val repoPath = repositoryUrl
+                    .substringAfter("github.com/")
+                    .substringBefore("/blob/")
+                    .substringBefore("/tree/")
+                    .removeSuffix("/")
+                "https://github.com/search?type=code&q=repo:${repoPath}+${searchRecipeName}"
+            }
             // YAML recipes will have a source that ends with META-INF/rewrite/something.yml
             sourceString.endsWith(".yml") -> {
                 val ymlPath = sourceString.substring(source.toString().lastIndexOf("META-INF"))

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -67,6 +67,8 @@ class VersionWriter {
             var cliInstallNpmLatest = ""
             var cliInstallNugetPinned = ""
             var cliInstallNugetLatest = ""
+            var cliInstallGoPinned = ""
+            var cliInstallGoLatest = ""
             var installRecipes = ""
             for (origin in recipeOrigins) {
 
@@ -86,6 +88,12 @@ class VersionWriter {
                         val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES.getValue(origin.artifactId)
                         cliInstallNugetPinned += "$nugetPackage@$versionPlaceholder "
                         cliInstallNugetLatest += "$nugetPackage "
+                    }
+                    in GoRecipeLoader.GO_RECIPE_MODULES -> {
+                        // Go modules are installed from source by module path, pinned with a vX.Y.Z tag.
+                        val goModule = GoRecipeLoader.GO_RECIPE_MODULES.getValue(origin.artifactId)
+                        cliInstallGoPinned += "$goModule@v$versionPlaceholder "
+                        cliInstallGoLatest += "$goModule "
                     }
                     else -> {
                         cliInstallJarPinned += "${origin.groupId}:${origin.artifactId}:$versionPlaceholder "
@@ -114,12 +122,14 @@ class VersionWriter {
                 "pip" to cliInstallPipPinned,
                 "npm" to cliInstallNpmPinned,
                 "nuget" to cliInstallNugetPinned,
+                "go" to cliInstallGoPinned,
             )
             val latestInstalls = listOf(
                 "jar" to cliInstallJarLatest,
                 "pip" to cliInstallPipLatest,
                 "npm" to cliInstallNpmLatest,
                 "nuget" to cliInstallNugetLatest,
+                "go" to cliInstallGoLatest,
             )
 
             //language=markdown

--- a/src/test/kotlin/org/openrewrite/GoRecipeLoaderTest.kt
+++ b/src/test/kotlin/org/openrewrite/GoRecipeLoaderTest.kt
@@ -1,0 +1,48 @@
+package org.openrewrite
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.openrewrite.config.OptionDescriptor
+import org.openrewrite.config.RecipeDescriptor
+import java.net.URI
+
+class GoRecipeLoaderTest {
+
+    @Test
+    fun registryMapsRecipesGoToGoModulePath() {
+        assertThat(GoRecipeLoader.GO_RECIPE_MODULES)
+            .containsEntry("recipes-go", "github.com/moderneinc/recipes-go")
+    }
+
+    private fun descriptor(name: String, displayName: String, description: String,
+                           options: List<OptionDescriptor> = emptyList()): RecipeDescriptor {
+        return RecipeDescriptor(
+            name, displayName, displayName, description,
+            emptySet(), null, options, emptyList(), emptyList(),
+            emptyList(), emptyList(), emptyList(), emptyList(),
+            URI.create("file:///test")
+        )
+    }
+
+    @Test
+    fun buildMarketplacePopulatesFromJavaDescriptors() {
+        // Go recipes delegate to Java (e.g. golang.ChangeMethodName -> java.ChangeMethodName); seed those so prepareRecipe resolves.
+        val descriptors = listOf(
+            descriptor("org.openrewrite.java.ChangeMethodName", "Change method name", "Rename a method"),
+            descriptor("org.openrewrite.java.ChangeType", "Change type", "Change a type reference")
+        )
+
+        val marketplace = GoRecipeLoader.buildMarketplace(descriptors)
+
+        assertThat(marketplace.findRecipe("org.openrewrite.java.ChangeMethodName")).isNotNull
+        assertThat(marketplace.findRecipe("org.openrewrite.java.ChangeType")).isNotNull
+        assertThat(marketplace.findRecipe("org.openrewrite.java.NonExistent")).isNull()
+    }
+
+    @Test
+    fun buildMarketplaceHandlesEmptyDescriptors() {
+        val marketplace = GoRecipeLoader.buildMarketplace(emptyList())
+
+        assertThat(marketplace.allRecipes).isEmpty()
+    }
+}

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -56,6 +56,7 @@ class RecipeMarkdownGeneratorTest {
             mk("org.openrewrite.recipe", "rewrite-migrate-python", "0.5.0"),
             mk("org.openrewrite", "rewrite-javascript", "0.9.0"),
             mk("io.moderne.recipe", "recipes-code-quality", "0.1.0"),
+            mk("org.openrewrite.recipe", "recipes-go", "0.4.1"),
         )
         VersionWriter().createLatestVersionsMarkdown(tempDir, origins, "8.x", "2.x", "1.x", "6.x", "5.x")
         val out = Files.readString(tempDir.resolve("latest-versions-of-every-openrewrite-module.md"))
@@ -67,6 +68,8 @@ class RecipeMarkdownGeneratorTest {
         assertThat(out).contains("mod config recipes npm install @openrewrite/rewrite")
         assertThat(out).contains("mod config recipes nuget install OpenRewrite.Recipes.CSharp.CodeQuality@{{VERSION_IO_MODERNE_RECIPE_RECIPES_CODE_QUALITY}}")
         assertThat(out).contains("mod config recipes nuget install OpenRewrite.Recipes.CSharp.CodeQuality")
+        assertThat(out).contains("mod config recipes go install github.com/moderneinc/recipes-go@v{{VERSION_ORG_OPENREWRITE_RECIPE_RECIPES_GO}}")
+        assertThat(out).contains("mod config recipes go install github.com/moderneinc/recipes-go")
 
         // The Moderne Installation GraphQL mutation must use installRecipesUniversal with a
         // RecipeBundleInput; loadRecipesAsync was removed from the Moderne API.
@@ -230,6 +233,28 @@ class RecipeMarkdownGeneratorTest {
 
         assertThat(found).isNotNull
         assertThat(found!!.artifactId).isEqualTo("recipes-code-quality")
+    }
+
+    @Test
+    fun findOriginHandlesGoSearchScheme() {
+        val mavenUri = URI.create("file:///recipes-go.jar")
+        val origin = RecipeOrigin("org.openrewrite.recipe", "recipes-go", "0.4.1", mavenUri)
+        origin.license = Licenses.Proprietary
+        val origins = mapOf(mavenUri to origin)
+
+        val source = URI.create("go-search://recipes-go/org.openrewrite.golang.codequality.SimplifyBooleanExpression")
+        val found = RecipeMarkdownGenerator.findOrigin(source, "org.openrewrite.golang.codequality.SimplifyBooleanExpression", origins)
+
+        assertThat(found).isNotNull
+        assertThat(found!!.artifactId).isEqualTo("recipes-go")
+    }
+
+    @Test
+    fun golangRecipesMapToGolangDirectory() {
+        // org.openrewrite.golang.* maps to golang/... via the existing org.openrewrite path logic.
+        initializeConflictDetection(emptyList())
+        assertThat(getRecipePath("org.openrewrite.golang.codequality.SimplifyBooleanExpression"))
+            .isEqualTo("golang/codequality/simplifybooleanexpression")
     }
 
     @Test

--- a/src/test/kotlin/org/openrewrite/RecipeOriginTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeOriginTest.kt
@@ -52,6 +52,18 @@ class RecipeOriginTest {
     }
 
     @Test
+    fun goRecipeGithubUrl() {
+        val origin = RecipeOrigin("org.openrewrite.recipe", "recipes-go", "0.4.1", URI.create("go-search://recipes-go"))
+        origin.repositoryUrl = "https://github.com/moderneinc/recipes-go/blob/main/"
+
+        val githubUrl = origin.githubUrl(
+            "org.openrewrite.golang.codequality.SimplifyBooleanExpression",
+            URI.create("go-search://recipes-go/org.openrewrite.golang.codequality.SimplifyBooleanExpression")
+        )
+        assertThat(githubUrl).isEqualTo("https://github.com/search?type=code&q=repo:moderneinc/recipes-go+org.openrewrite.golang.codequality.SimplifyBooleanExpression")
+    }
+
+    @Test
     fun blankRepositoryUrlIsNotCoreLibrary() {
         val origin = RecipeOrigin("org.openrewrite", "rewrite-java", "8.0.0", URI.create("file:///tmp/foo"))
 


### PR DESCRIPTION
- Fixes: https://github.com/openrewrite/rewrite-recipe-markdown-generator/issues/312

I'm unsure if we should merge this in yet as the app tenant doesn't appear to have these recipes so the links to app would be broken.