### PR TITLE
Fix corrupted component MDX from same-path recipe writes

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -221,6 +221,13 @@ class RecipeMarkdownGenerator : Runnable {
             RecipeMarkdownWriter(recipeContainedBy, recipeToSource, proprietaryRecipeNames, forModerneDocs = true)
         } else null
 
+        // Every recipe's natural output path in the Moderne catalog (which lists ALL recipes). A
+        // cross-category duplicate — e.g. java.ChangeType surfaced under python/ because it works on
+        // Python code — must not overwrite a recipe that natively owns that path (python.ChangeType),
+        // otherwise the two clobber each other into one file. OpenRewrite docs avoid this because the
+        // native recipe is often proprietary and skipped there; the Moderne catalog writes both.
+        val moderneNativeRecipePaths = allRecipeDescriptors.mapTo(HashSet()) { getRecipePath(it) }
+
         for (recipeDescriptor in allRecipeDescriptors) {
             val recipeSource = recipeToSource[recipeDescriptor.name]
             requireNotNull(recipeSource) { "Could not find source URI for recipe " + recipeDescriptor.name }
@@ -235,6 +242,8 @@ class RecipeMarkdownGenerator : Runnable {
             val extraPaths = crossCategoryPaths[recipeDescriptor.name]
             if (extraPaths != null && moderneRecipeMarkdownWriter != null) {
                 for (extraPath in extraPaths) {
+                    // Don't let this duplicate clobber a recipe that natively owns the path.
+                    if (extraPath in moderneNativeRecipePaths) continue
                     moderneRecipeMarkdownWriter.writeRecipeTo(recipeDescriptor, moderneRecipeCatalogPath!!, origin, extraPath)
                 }
             }
@@ -249,7 +258,10 @@ class RecipeMarkdownGenerator : Runnable {
             // Write non-proprietary recipes to OpenRewrite docs
             recipeMarkdownWriter.writeRecipe(recipeDescriptor, recipesPath, origin)
 
-            // Write cross-category duplicates to OpenRewrite docs
+            // Write cross-category duplicates to OpenRewrite docs. No native-path skip here (unlike the
+            // Moderne loop above): proprietary recipes are excluded from OpenRewrite docs, so a duplicate
+            // legitimately fills a slot whose native owner isn't written here. TRUNCATE_EXISTING still
+            // guards against stale-tail corruption if two open-source recipes ever claim the same path.
             if (extraPaths != null) {
                 for (extraPath in extraPaths) {
                     recipeMarkdownWriter.writeRecipeTo(recipeDescriptor, recipesPath, origin, extraPath)

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -118,6 +118,17 @@ class RecipeMarkdownWriter(
         writeRecipeToPath(recipeDescriptor, recipeMarkdownPath, origin, null)
     }
 
+    /**
+     * Open a recipe markdown file for (over)writing. TRUNCATE_EXISTING is essential: the same path can be
+     * written more than once in a run (a recipe's native page and a cross-category duplicate of a different
+     * recipe can resolve to it). Without truncation a shorter second write leaves a stale tail from the
+     * first, which silently corrupts plain markdown and produces unparseable MDX in the component output.
+     */
+    private fun newRecipeWriter(recipeMarkdownPath: Path): BufferedWriter {
+        Files.createDirectories(recipeMarkdownPath.parent)
+        return Files.newBufferedWriter(recipeMarkdownPath, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)
+    }
+
     private fun writeRecipeToPath(
         recipeDescriptor: RecipeDescriptor,
         recipeMarkdownPath: Path,
@@ -130,8 +141,7 @@ class RecipeMarkdownWriter(
         val formattedRecipeTitleMdx = recipeDescriptor.displayNameEscapedMdx()  // For MDX content (with curly brace escaping)
         val formattedRecipeDescription = getFormattedRecipeDescription(recipeDescriptor.description)
         val formattedLongRecipeName = recipeDescriptor.name.replace("_".toRegex(), "\\\\_").trim()
-        Files.createDirectories(recipeMarkdownPath.parent)
-        Files.newBufferedWriter(recipeMarkdownPath, StandardOpenOption.CREATE).useAndApply {
+        newRecipeWriter(recipeMarkdownPath).useAndApply {
             // Note: the Moderne-docs canonical-link <head> is emitted by writeModerneComponentRecipe;
             // this path only runs for OpenRewrite docs (forModerneDocs is always false here).
             write(
@@ -971,8 +981,7 @@ ${props.toString().trimEnd()}
         val description = recipeDescriptor.description ?: ""
         val tags = recipeDescriptor.tags?.toList() ?: emptyList<String>()
 
-        Files.createDirectories(recipeMarkdownPath.parent)
-        Files.newBufferedWriter(recipeMarkdownPath, StandardOpenOption.CREATE).useAndApply {
+        newRecipeWriter(recipeMarkdownPath).useAndApply {
             //language=markdown
             writeln("---")
             writeln("title: \"$title\"")

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -142,6 +142,32 @@ class RecipeMarkdownWriterModerneDocsTest {
     }
 
     @Test
+    fun moderneDocsTruncatesStaleContentWhenSamePathWrittenTwice(@TempDir dir: Path) {
+        // A recipe's native page and a cross-category duplicate of a different recipe can resolve to the
+        // same path. The second (shorter) write must fully replace the first, not leave a stale tail that
+        // produces unparseable MDX.
+        val writer = RecipeMarkdownWriter(mutableMapOf(), emptyMap(), emptySet(), forModerneDocs = true)
+
+        // First: a content-heavy recipe (definition + examples + usage) at a shared relative path.
+        writer.writeRecipeTo(compositeRecipe(), dir, origin(), "shared/page")
+        val longText = Files.readString(dir.resolve("shared/page.md"))
+        assertThat(longText).contains("## Examples", "Composite foo")
+
+        // Then: a minimal recipe (no definition/options/examples — only header + usage) to the SAME path.
+        val minimal = RecipeDescriptor(
+            "org.openrewrite.java.Tiny", "Tiny", "Tiny", "A tiny recipe.", emptySet(), Duration.ofMinutes(1),
+            emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), jar
+        )
+        writer.writeRecipeTo(minimal, dir, origin(), "shared/page")
+        val shortText = Files.readString(dir.resolve("shared/page.md"))
+
+        assertThat(shortText.length).isLessThan(longText.length)
+        assertThat(shortText.trimEnd()).endsWith("</UsageList>")
+        // No stale tail bleeding through from the first, longer write.
+        assertThat(shortText).doesNotContain("## Examples", "## Definition", "Composite foo")
+    }
+
+    @Test
     fun openRewriteDocsOutputUnchangedForSingleRecipe(@TempDir dir: Path) {
         // Proprietary license so writeSourceLinks takes its Moderne-only branch and doesn't require a
         // source URI lookup (this test only guards that the OpenRewrite path is untouched).


### PR DESCRIPTION
## Problem

- The first `Update docs` run after the component-MDX generator merged (#344) failed at `yarn lint:markdown:recipes`: four Python recipe pages (`python/changetype`, `changemethodname`, `deletemethodargument`, `reordermethodarguments`) emitted **unparseable MDX**, so the job aborted before committing — the Moderne docs site never picked up the new component pages.

## Root cause

A **path collision** in the Moderne catalog (which lists *every* recipe):

* `python.ChangeType` natively owns `python/changetype.md`, while `java.ChangeType` is *also* placed there by the cross-category feature ("this Java recipe works on Python code").
* The writer opened files with `StandardOpenOption.CREATE` **only**, which drops the `TRUNCATE_EXISTING` you get by default from `newBufferedWriter`. So the shorter second write left a **stale tail** from the first. Harmless-looking in plain markdown; unparseable JSX in the component output.

OpenRewrite docs never hit this because the native recipe is typically proprietary and skipped there — only the all-recipes Moderne catalog writes both.

## Fix

1. Always open recipe files with `TRUNCATE_EXISTING` (extracted into a `newRecipeWriter` helper used by both the markdown and component paths).
2. In the Moderne loop, skip a cross-category duplicate whose resolved path is natively owned by another recipe, so the native page wins regardless of write order. The OpenRewrite loop is intentionally left unguarded (proprietary natives aren't written there, so duplicates legitimately fill those slots) — documented inline.
3. Added a regression test asserting a shorter second write to the same path fully replaces the first (no stale tail).

## Verification

* Regenerated the **full** catalog: **0 unparseable files** (was 4).
* Full `yarn build` of moderne-docs: `[SUCCESS]` — **7,714 pages including all 7,335 recipe pages**, no MDX compilation errors.
* All generator unit tests pass.