### PR TITLE
Render recipe title/description as markdown; fix sub-recipe links; add --only-artifacts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -231,6 +231,12 @@ tasks.named<JavaExec>("run").configure {
     if (latestVersionsOnly) {
         arguments.add("--latest-versions-only")
     }
+    // -PrecipeArtifacts=rewrite-circleci,rewrite-static-analysis restricts loading to those artifacts for
+    // fast local iteration (the full classpath is still resolved for transitive/delegatesTo lookups).
+    val recipeArtifacts = providers.gradleProperty("recipeArtifacts").getOrElse("")
+    if (recipeArtifacts.isNotEmpty()) {
+        arguments.add("--only-artifacts=$recipeArtifacts")
+    }
     args = arguments
     doFirst {
         logger.lifecycle("Recipe modules: ")

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -83,6 +83,15 @@ class RecipeMarkdownGenerator : Runnable {
     @Option(names = ["--latest-versions-only"])
     var latestVersionsOnly: Boolean = false
 
+    @Option(
+        names = ["--only-artifacts"],
+        split = ",",
+        description = ["Restrict recipe loading to these artifactIds (e.g. rewrite-circleci). Greatly " +
+            "speeds up local testing; the full classpath is still resolved for transitive/delegatesTo lookups. " +
+            "Sub-recipes from artifacts not in the list will have empty links."]
+    )
+    var onlyArtifacts: List<String> = emptyList()
+
     override fun run() {
         // OpenRewrite docs output (open-source recipes only)
         val outputPath = Paths.get(destinationDirectoryName)
@@ -106,6 +115,11 @@ class RecipeMarkdownGenerator : Runnable {
         }
 
         var recipeOrigins: Map<URI, RecipeOrigin> = RecipeOrigin.parse(recipeSources)
+        if (onlyArtifacts.isNotEmpty()) {
+            val keep = onlyArtifacts.toSet()
+            recipeOrigins = recipeOrigins.filterValues { it.artifactId in keep }
+            println("Restricting recipe loading to ${recipeOrigins.size} artifact(s) matching $keep")
+        }
 
         // Add manifest information
         val recipeLoader = RecipeLoader(recipeClasspath, recipeOrigins)

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -1008,10 +1008,10 @@ ${props.toString().trimEnd()}
             writeln("/>")
             newLine()
 
-            // RecipeHeader — always emitted
+            // RecipeHeader — always emitted. Title and description are passed as markdown children
+            // (RecipeHeader.Title / RecipeHeader.Description) so Docusaurus renders their inline code and
+            // links natively, instead of as pre-flattened string props.
             writeln("<RecipeHeader")
-            writeln("  displayName={${mapper.writeValueAsString(recipeDescriptor.displayName)}}")
-            writeln("  description={${mapper.writeValueAsString(description)}}")
             writeln("  type={${mapper.writeValueAsString(recipeType)}}")
             writeln("  languages={${mapper.writeValueAsString(languages)}}")
             writeln("  tags={${mapper.writeValueAsString(tags)}}")
@@ -1023,7 +1023,11 @@ ${props.toString().trimEnd()}
             if (isProprietary) {
                 writeln("  moderneOnly")
             }
-            writeln("/>")
+            writeln(">")
+            newLine()
+            emitHeaderSlot("RecipeHeader.Title", recipeDescriptor.displayName ?: name)
+            emitHeaderSlot("RecipeHeader.Description", description)
+            writeln("</RecipeHeader>")
             newLine()
 
             // Sections: the `## ` heading is the component's children, blank-line-wrapped (below) so MDX
@@ -1067,6 +1071,27 @@ ${props.toString().trimEnd()}
     }
 
     /**
+     * Emit a `<RecipeHeader.Title>` / `<RecipeHeader.Description>` slot with its content as markdown
+     * children, blank-line-wrapped so MDX parses it. Already-block markdown (fenced code, lists,
+     * headings) is emitted verbatim; inline prose is collapsed to one line with the JSX-significant
+     * characters escaped. Empty content emits nothing (the component falls back gracefully).
+     */
+    private fun BufferedWriter.emitHeaderSlot(tag: String, text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return
+        if (HEADER_BLOCK_MARKDOWN_REGEX.containsMatchIn(trimmed)) {
+            writeln("<$tag>")
+            newLine()
+            writeln(trimmed)
+            newLine()
+            writeln("</$tag>")
+        } else {
+            writeln("<$tag>${mdxSafeInline(trimmed.replace("\n", " "))}</$tag>")
+        }
+        newLine()
+    }
+
+    /**
      * Build the JSON array of `{ name, href }` for RecipeList's `recipes` and `preconditions` props.
      * Unlinkable recipes (not in recipeToSource) get an empty href.
      */
@@ -1075,7 +1100,10 @@ ${props.toString().trimEnd()}
             // Skip internal "Precondition bellwether" recipes (rewrite-docs#250), like the markdown path.
             .filter { it.displayName != "Precondition bellwether" }
             .map { sub ->
-                val href = recipeToSource[sub.name]?.let { getRecipeLink(sub) } ?: ""
+                // Absolute site path (see MODERNE_DOCS_CATALOG_PATH) with a trailing slash — the component
+                // renders this in a raw <a href> with no Docusaurus relative-link rewriting, and the site
+                // (default trailingSlash) 301-redirects the slashless form, so emit the canonical 200 URL.
+                val href = recipeToSource[sub.name]?.let { getRecipeLink(sub, MODERNE_DOCS_CATALOG_PATH) + "/" } ?: ""
                 mapOf("name" to sub.displayName, "href" to href)
             }
         return mapper.writeValueAsString(items)
@@ -1266,6 +1294,34 @@ ${props.toString().trimEnd()}
 
         private const val MODERNE_DOCS_MARKDOWN_BASE_URL =
             "https://raw.githubusercontent.com/moderneinc/moderne-docs/refs/heads/main/docs/user-documentation/recipes/recipe-catalog/"
+
+        // Site-root path of the recipe catalog. Sub-recipe links in the component output must be absolute
+        // from this base: rendered in a raw <a href>, a relative path would resolve against the current
+        // recipe URL (e.g. .../commonstaticanalysis/staticanalysis/foo) instead of the catalog root.
+        private const val MODERNE_DOCS_CATALOG_PATH = "/user-documentation/recipes/recipe-catalog/"
+
+        // A recipe title/description is "already" block markdown (emit verbatim) when it has a fenced code
+        // block, a heading, or a list; otherwise it is treated as inline prose.
+        private val HEADER_BLOCK_MARKDOWN_REGEX = Regex("```|(^|\\n)#{1,6}\\s|\\n\\s*[-*+]\\s|\\n\\s*\\d+\\.\\s")
+
+        /**
+         * Escape the JSX-significant characters (`<` opens a tag, `{` opens an expression) that fall
+         * OUTSIDE inline-code spans, so a plain-prose title/description is safe to embed as inline MDX.
+         * Inside `code` spans MDX leaves them literal, so they are passed through unescaped.
+         */
+        private fun mdxSafeInline(text: String): String {
+            val sb = StringBuilder(text.length)
+            var inCode = false
+            for (ch in text) {
+                when {
+                    ch == '`' -> { inCode = !inCode; sb.append(ch) }
+                    !inCode && ch == '<' -> sb.append("&lt;")
+                    !inCode && ch == '{' -> sb.append("&#123;")
+                    else -> sb.append(ch)
+                }
+            }
+            return sb.toString()
+        }
 
         // CLI/YAML option-example formatting (compiled once instead of per option per recipe).
         private val YAML_SPECIAL_START_REGEX = Regex("^[{}\\[\\],`|=%@*!?-].*")

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -92,6 +92,11 @@ class RecipeMarkdownWriterModerneDocsTest {
         assertThat(out).contains("type={\"Single recipe\"}")
         assertThat(out).contains("moderneOnly")          // proprietary
 
+        // Title + description are emitted as markdown children (not string props) so MDX renders the
+        // inline code in the title and any links in the description natively.
+        assertThat(out).contains("<RecipeHeader.Title>Replace `foo`</RecipeHeader.Title>")
+        assertThat(out).contains("<RecipeHeader.Description>Replaces foo with bar.</RecipeHeader.Description>")
+
         // Options + Examples + Usage, each with the heading passed as a blank-line-wrapped child.
         assertThat(out).contains("<OptionsTable options={")
         assertThat(out).contains("\n\n## Options\n\n</OptionsTable>")
@@ -139,6 +144,39 @@ class RecipeMarkdownWriterModerneDocsTest {
         assertThat(out).contains("<UsageList usage={")
         assertThat(out).contains("\"npmPackage\":")
         assertThat(out).doesNotContain("\"groupId\":")
+    }
+
+    @Test
+    fun moderneDocsEmitsAbsoluteHrefForSubRecipes(@TempDir dir: Path) {
+        val sub = singleRecipe() // org.openrewrite.java.ReplaceFoo
+        val composite = descriptor(
+            "org.openrewrite.java.CompositeFoo", "Composite foo", "Runs foo.", recipeList = listOf(sub),
+        )
+        val recipeToSource = mapOf(sub.name to URI.create("file:///tmp/recipes.jar"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = true)
+            .writeRecipe(composite, dir, origin())
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        // Sub-recipe links are absolute from the catalog root with a trailing slash (a relative path would
+        // double up against the current recipe URL in a raw <a href>; the slashless form 301-redirects).
+        assertThat(out).contains("\"href\":\"/user-documentation/recipes/recipe-catalog/java/replacefoo/\"")
+    }
+
+    @Test
+    fun moderneDocsRendersDescriptionMarkdownAndEscapesJsxOpeners(@TempDir dir: Path) {
+        val recipe = descriptor(
+            "org.openrewrite.java.LinkFoo", "Link foo",
+            "Use `Map<String>` and see [docs](https://example.com/x). Compare a < b.",
+        )
+        RecipeMarkdownWriter(mutableMapOf(), emptyMap(), emptySet(), forModerneDocs = true)
+            .writeRecipe(recipe, dir, origin())
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        // The markdown link is preserved verbatim; the `<` inside the code span stays literal; the bare
+        // `<` outside code is escaped so MDX doesn't read it as a JSX tag.
+        assertThat(out).contains(
+            "<RecipeHeader.Description>Use `Map<String>` and see [docs](https://example.com/x). Compare a &lt; b.</RecipeHeader.Description>",
+        )
     }
 
     @Test


### PR DESCRIPTION
- Follow-up to #346. Fixes how the component recipe pages render on docs.moderne.io now that they're live.

## Problems (visible on live recipe pages)

1. **Descriptions render markdown links as raw text.** `RecipeHeader` received the description as a flattened string prop and only the bespoke `renderWithCode` (backticks only) ran on it, so `[orb](https://…)` showed literally. ~10% of descriptions contain links; 63% contain inline code; ~6% contain fenced blocks.
2. **Sub-recipe / precondition links are broken.** `RecipeList` emitted **relative** hrefs (e.g. `staticanalysis/foo`) rendered in a raw `<a href>`, which the browser resolves against the current recipe URL — e.g. `…/commonstaticanalysis/staticanalysis/foo` (404).
3. **No way to test a subset** — every local generation loaded all ~80 recipe artifacts (~8 min).

## Changes

- **Title/description as markdown children.** Emit `<RecipeHeader.Title>` / `<RecipeHeader.Description>` with the text as markdown, so Docusaurus renders inline code and links natively (same pattern as the section `##` headings). Already-block-markdown descriptions (fenced code, lists) are emitted verbatim; inline prose has its JSX-significant `<`/`{` **outside** code spans escaped so MDX doesn't read them as tags/expressions.
- **Absolute sub-recipe links.** Emit absolute catalog paths **with a trailing slash** (the site's default `trailingSlash` 301-redirects the slashless form; trailing slash is a direct 200).
- **`-PrecipeArtifacts=<artifactId,…>`** (`--only-artifacts`) restricts recipe loading to specific artifacts for fast iteration (~8 min → seconds); the full classpath is still resolved for transitive/`delegatesTo` lookups. Sub-recipes from unlisted artifacts get empty links (documented).

Requires the companion moderne-docs change (compound `RecipeHeader` with `.Title`/`.Description` slots). That component is backward compatible — it falls back to the string props — so this can merge independently.

## Verification

- All generator unit tests pass (new: markdown children, JSX-opener escaping, absolute+trailing-slash hrefs).
- Generated a filtered catalog (`rewrite-circleci,rewrite-static-analysis`), MDX-linted clean, and confirmed in `yarn start:examples`: description links render as real `<a>`, titles render inline `<code>`, block descriptions render lists/code, sub-recipe links resolve to absolute catalog URLs.