### PR TITLE
Use per-distribution install coordinates for RecipeHeader artifact

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -968,7 +968,12 @@ ${props.toString().trimEnd()}
         val languages = listOf(getSourceLanguage(name))
         // License as plain text (not the markdown-link form the OpenRewrite docs path uses).
         val licenseText = origin.license.name
-        val artifact = "${origin.groupId}:${origin.artifactId}"
+        val artifact = when {
+            isJavaScriptRecipe(recipeDescriptor) -> getNpmPackageName(origin)
+            isPythonRecipe(recipeDescriptor) -> getPipPackageName(origin)
+            isCSharpRecipe(recipeDescriptor) -> getNuGetPackageName(origin)
+            else -> "${origin.groupId}:${origin.artifactId}"
+        }
         val appLink = "https://app.moderne.io/recipes/$name"
         val markdownUrl = MODERNE_DOCS_MARKDOWN_BASE_URL + recipePath + ".md"
 

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -133,17 +133,40 @@ class RecipeMarkdownWriterModerneDocsTest {
 
     @Test
     fun moderneDocsEmitsNpmUsageForJavaScriptRecipe(@TempDir dir: Path) {
-        val recipe = descriptor("org.openrewrite.javascript.FormatFoo", "Format foo", "Formats foo.")
+        // Uses `rewrite-angular` — a real entry in TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES —
+        // so this exercises the registry lookup (rather than the fallback that just prefixes @openrewrite/).
+        // If the mapping is ever removed from the registry, this test starts asserting the fallback
+        // package name, which is the signal we want.
+        val angularOrigin = RecipeOrigin("io.moderne.recipe", "rewrite-angular", "1.0.0", jar)
+            .apply { license = Licenses.Proprietary }
+        val recipe = descriptor(
+            "org.openrewrite.angular.UpgradeToAngular16",
+            "Upgrade to Angular 16", "Migrates Angular 15.x applications to Angular 16.",
+        )
         // isJavaScriptRecipe keys off a `typescript-search://` source URI.
-        val recipeToSource = mapOf(recipe.name to URI.create("typescript-search://rewrite-static-analysis/format"))
-        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = true)
-            .writeRecipe(recipe, dir, origin())
+        val recipeToSource = mapOf(recipe.name to URI.create("typescript-search://rewrite-angular/upgrade-to-angular-16"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, setOf(recipe.name), forModerneDocs = true)
+            .writeRecipe(recipe, dir, angularOrigin)
         val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
 
         // JS recipes get a UsageList with an npm package, not Maven/Gradle coordinates.
         assertThat(out).contains("<UsageList usage={")
-        assertThat(out).contains("\"npmPackage\":")
+        assertThat(out).contains("\"npmPackage\":\"@openrewrite/recipes-angular\"")
         assertThat(out).doesNotContain("\"groupId\":")
+
+        // The RecipeHeader `artifact` chip advertises the same install coordinates as the Usage section,
+        // not the Java Maven coordinates the recipe happens to ship alongside its .jar.
+        assertThat(out).contains("artifact={\"@openrewrite/recipes-angular\"}")
+        assertThat(out).doesNotContain("artifact={\"io.moderne.recipe:rewrite-angular\"}")
+    }
+
+    @Test
+    fun moderneDocsEmitsMavenArtifactForJavaRecipe(@TempDir dir: Path) {
+        // A Java recipe (no typescript-search:// / python-search:// / csharp-search:// source URI) keeps the
+        // groupId:artifactId chip — this is the default and the previous behaviour for every language.
+        val out = generate(singleRecipe(), dir, forModerneDocs = true)
+
+        assertThat(out).contains("artifact={\"org.openrewrite.recipe:rewrite-static-analysis\"}")
     }
 
     @Test


### PR DESCRIPTION
## Problem

On [pages like `UpgradeToAngular16`](https://docs.moderne.io/user-documentation/recipes/recipe-catalog/angular/upgradetoangular16/), the `RecipeHeader` "Artifact" chip showed `io.moderne.recipe:rewrite-angular` (Java Maven coordinates), while the Usage section — correctly — told users to run `mod config recipes npm install @openrewrite/recipes-angular`. The two coordinates disagreed for every TypeScript / Python / C# recipe.

## Cause

In `RecipeMarkdownWriter.writeRecipeToPathAsComponents` (the `forModerneDocs` path added in #344), the `artifact` prop passed to `<RecipeHeader>` was unconditionally built as `groupId:artifactId`:

```kotlin
val artifact = "${origin.groupId}:${origin.artifactId}"
```

Meanwhile, the sibling `buildUsageJson` already branched by recipe language and used the correct install package name (`npmPackage` / `pipPackage` / `nugetPackage`).

## Fix

Mirror the same `isJavaScriptRecipe` / `isPythonRecipe` / `isCSharpRecipe` branching for the header prop, reusing the existing `getNpmPackageName` / `getPipPackageName` / `getNuGetPackageName` helpers:

```kotlin
val artifact = when {
    isJavaScriptRecipe(recipeDescriptor) -> getNpmPackageName(origin)
    isPythonRecipe(recipeDescriptor)     -> getPipPackageName(origin)
    isCSharpRecipe(recipeDescriptor)     -> getNuGetPackageName(origin)
    else -> "${origin.groupId}:${origin.artifactId}"
}
```

## Tests

* Extended `moderneDocsEmitsNpmUsageForJavaScriptRecipe` to reproduce the actual `UpgradeToAngular16` case: origin `io.moderne.recipe:rewrite-angular`, `typescript-search://` source URI, `TYPESCRIPT_RECIPE_MODULES` registry lookup. Asserts the RecipeHeader chip renders `@openrewrite/recipes-angular` — the same string as the `UsageList` `npmPackage` prop — and does not render the Java Maven coordinates.
* Added `moderneDocsEmitsMavenArtifactForJavaRecipe` to guard the default Java path (`groupId:artifactId` still shows for recipes without a `typescript-search://` / `python-search://` / `csharp-search://` source URI).

## Companion change

The `artifact` prop on `<RecipeHeader>` in `moderne-docs` renders whatever string you hand it, so no code change is needed there. moderneinc/moderne-docs#820 loosens the prop docstring (which previously said "Maven coordinates \`groupId:artifactId\`") to reflect that it can now be an npm/pip/NuGet package name too.