### PR TITLE
Pin Python recipe pip install commands to an explicit version

### DIFF
--- a/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
@@ -57,7 +57,7 @@ class PythonRecipeLoader(
          * Modules whose pip package uses independent versioning from the Maven artifact.
          * For these, we always install the latest pip version rather than trying to match the Maven version.
          */
-        private val INDEPENDENT_PIP_VERSIONING = setOf(
+        val INDEPENDENT_PIP_VERSIONING = setOf(
             "rewrite-static-analysis-python"
         )
     }

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -588,14 +588,20 @@ import RunRecipe from '@site/src/components/RunRecipe';
         // Handle Python recipes
         if (isPythonRecipe(recipeDescriptor)) {
             val pipPackageName = getPipPackageName(origin)
+            val props = StringBuilder()
+            props.appendLine("  recipeName=\"${recipeDescriptor.name}\"")
+            props.appendLine("  displayName=\"${recipeDescriptor.displayNameEscapedMdx()}\"")
+            props.appendLine("  pipPackage=\"$pipPackageName\"")
+            // Pin the pip package to an explicit version matching the Maven artifact version, except for
+            // modules whose pip package is versioned independently (those always install the latest).
+            if (origin.artifactId !in PythonRecipeLoader.INDEPENDENT_PIP_VERSIONING) {
+                props.appendLine("  versionKey=\"${origin.versionPlaceholderKey()}\"")
+            }
             writeln(
                 """
-                <RunRecipe
-                  recipeName="${recipeDescriptor.name}"
-                  displayName="${recipeDescriptor.displayNameEscapedMdx()}"
-                  pipPackage="$pipPackageName"
-                />
-                """.trimIndent()
+<RunRecipe
+${props.toString().trimEnd()}
+/>""".trimIndent()
             )
             return
         }
@@ -1223,7 +1229,14 @@ ${props.toString().trimEnd()}
         // per-ecosystem <RunRecipe>); everything else uses the Maven/Gradle coordinates + CLI options.
         when {
             isJavaScriptRecipe(recipeDescriptor) -> usageMap["npmPackage"] = getNpmPackageName(origin)
-            isPythonRecipe(recipeDescriptor) -> usageMap["pipPackage"] = getPipPackageName(origin)
+            isPythonRecipe(recipeDescriptor) -> {
+                usageMap["pipPackage"] = getPipPackageName(origin)
+                // Pin the pip package to an explicit version matching the Maven artifact version, except
+                // for modules whose pip package is versioned independently (those install the latest).
+                if (origin.artifactId !in PythonRecipeLoader.INDEPENDENT_PIP_VERSIONING) {
+                    usageMap["versionKey"] = origin.versionPlaceholderKey()
+                }
+            }
             isCSharpRecipe(recipeDescriptor) -> usageMap["nugetPackage"] = getNuGetPackageName(origin)
             else -> {
                 val options = recipeDescriptor.options ?: emptyList()

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -161,6 +161,46 @@ class RecipeMarkdownWriterModerneDocsTest {
     }
 
     @Test
+    fun moderneDocsEmitsPinnedPipInstallForPythonRecipe(@TempDir dir: Path) {
+        // Uses `rewrite-migrate-python` — a real entry in PythonRecipeLoader.PYTHON_RECIPE_MODULES — so the
+        // Usage section pins the pip package to the module's version placeholder, matching the Maven version.
+        val pythonOrigin = RecipeOrigin("org.openrewrite.recipe", "rewrite-migrate-python", "0.5.0", jar)
+            .apply { license = Licenses.Proprietary }
+        val recipe = descriptor(
+            "org.openrewrite.python.migrate.UpgradePythonVersion",
+            "Upgrade Python version", "Upgrades the Python version.",
+        )
+        val recipeToSource = mapOf(recipe.name to URI.create("python-search://rewrite-migrate-python/upgrade-python-version"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, setOf(recipe.name), forModerneDocs = true)
+            .writeRecipe(recipe, dir, pythonOrigin)
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        // Python recipes install from pip with an explicit version, not Maven/Gradle coordinates.
+        assertThat(out).contains("\"pipPackage\":\"openrewrite-migrate-python\"")
+        assertThat(out).contains("\"versionKey\":\"VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON\"")
+        assertThat(out).doesNotContain("\"groupId\":")
+    }
+
+    @Test
+    fun moderneDocsOmitsVersionForIndependentlyVersionedPythonRecipe(@TempDir dir: Path) {
+        // `rewrite-static-analysis-python` is in PythonRecipeLoader.INDEPENDENT_PIP_VERSIONING: its pip package
+        // is versioned independently of the Maven artifact, so the Usage section installs the latest (no version).
+        val pythonOrigin = RecipeOrigin("org.openrewrite.recipe", "rewrite-static-analysis-python", "1.0.0", jar)
+            .apply { license = Licenses.Proprietary }
+        val recipe = descriptor(
+            "org.openrewrite.python.staticanalysis.CodeCleanup",
+            "Code cleanup", "Cleans up Python code.",
+        )
+        val recipeToSource = mapOf(recipe.name to URI.create("python-search://rewrite-static-analysis-python/code-cleanup"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, setOf(recipe.name), forModerneDocs = true)
+            .writeRecipe(recipe, dir, pythonOrigin)
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        assertThat(out).contains("\"pipPackage\":\"openrewrite-static-analysis\"")
+        assertThat(out).doesNotContain("\"versionKey\":")
+    }
+
+    @Test
     fun moderneDocsEmitsMavenArtifactForJavaRecipe(@TempDir dir: Path) {
         // A Java recipe (no typescript-search:// / python-search:// / csharp-search:// source URI) keeps the
         // groupId:artifactId chip — this is the default and the previous behaviour for every language.


### PR DESCRIPTION
## What

The per-recipe **Usage** section for Python recipes previously rendered an unpinned install command (\`mod config recipes pip install openrewrite-migrate-python\`), unlike the Java jar path and the aggregate "latest versions" page (\`VersionWriter\`), which both pin an explicit version.

This change makes the per-recipe Usage sections pin the pip package to an explicit version.

## How

Python usage is emitted through two paths, both of which funnel into moderne-docs' \`RunRecipe\` component. Both now emit a \`versionKey\`:

- \`RecipeMarkdownWriter.writeUsage\` → \`<RunRecipe pipPackage=... versionKey=.../>\`
- \`RecipeMarkdownWriter.buildUsageJson\` → \`<UsageList>\` JSON with \`versionKey\`

\`PythonRecipeLoader.INDEPENDENT_PIP_VERSIONING\` is now visible to the writer so it can **skip** pinning for \`rewrite-static-analysis-python\`, whose pip package is versioned independently of the Maven artifact and is intentionally installed latest.

The docs-side render change lives in moderneinc/moderne-docs (companion PR).

## Result

A \`rewrite-migrate-python\` recipe page now shows:

\`\`\`shell
mod config recipes pip install openrewrite-migrate-python==0.9.2
\`\`\`

## Tests

Added two tests to \`RecipeMarkdownWriterModerneDocsTest\`: one asserting the pinned \`versionKey\` for \`rewrite-migrate-python\`, one asserting no version is emitted for the independently-versioned \`rewrite-static-analysis-python\`. Full test suite passes.