### PR TITLE
Add nuget install to latest versions doc

### DIFF
--- a/src/main/kotlin/org/openrewrite/CSharpRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/CSharpRecipeLoader.kt
@@ -56,6 +56,37 @@ class CSharpRecipeLoader(
         private val CLASSPATH_BUNDLE = RecipeBundle("classpath", "java-recipes", null, null, null)
 
         /**
+         * Build synthetic [RecipeOrigin]s for the NuGet-only C# recipe modules, resolving each
+         * package's latest stable version from NuGet. Unlike the other ecosystems, C# modules have
+         * no Maven artifact on the classpath to anchor the version table and `nuget install` command,
+         * and the origins created during [loadCSharpRecipes] are built too late — after the
+         * latest-versions page has already been written. Origins are keyed by the same
+         * `csharp-search://<artifactId>` URI that [loadCSharpRecipes] uses, so that (in a full run)
+         * it reuses these instead of creating duplicates.
+         *
+         * @param artifactIds when non-empty, only build origins for these artifactIds (mirrors the
+         *   `--only-artifacts` filter so local runs don't make needless NuGet requests).
+         */
+        @JvmStatic
+        fun buildVersionAnchorOrigins(artifactIds: Set<String> = emptySet()): Map<URI, RecipeOrigin> {
+            val origins = mutableMapOf<URI, RecipeOrigin>()
+            for ((artifactId, nugetPackage) in CSHARP_RECIPE_MODULES) {
+                if (artifactIds.isNotEmpty() && artifactId !in artifactIds) continue
+                val version = latestStableNuGetVersion(nugetPackage)
+                if (version == null) {
+                    System.err.println("Skipping C# version anchor for $artifactId: could not resolve latest stable NuGet version of $nugetPackage")
+                    continue
+                }
+                val uri = URI.create("csharp-search://$artifactId")
+                val origin = RecipeOrigin(CSHARP_GROUP_IDS[artifactId] ?: "io.moderne.recipe", artifactId, version, uri)
+                origin.repositoryUrl = CSHARP_REPO_URLS[artifactId] ?: ""
+                origin.license = Licenses.Proprietary
+                origins[uri] = origin
+            }
+            return origins
+        }
+
+        /**
          * Build a [RecipeMarketplace] populated with Java recipe descriptors so that
          * C# recipes that delegate to Java recipes can be resolved during [CSharpRewriteRpc.prepareRecipe].
          */

--- a/src/main/kotlin/org/openrewrite/CSharpRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/CSharpRecipeLoader.kt
@@ -56,16 +56,13 @@ class CSharpRecipeLoader(
         private val CLASSPATH_BUNDLE = RecipeBundle("classpath", "java-recipes", null, null, null)
 
         /**
-         * Build synthetic [RecipeOrigin]s for the NuGet-only C# recipe modules, resolving each
-         * package's latest stable version from NuGet. Unlike the other ecosystems, C# modules have
-         * no Maven artifact on the classpath to anchor the version table and `nuget install` command,
-         * and the origins created during [loadCSharpRecipes] are built too late — after the
-         * latest-versions page has already been written. Origins are keyed by the same
-         * `csharp-search://<artifactId>` URI that [loadCSharpRecipes] uses, so that (in a full run)
-         * it reuses these instead of creating duplicates.
+         * Build synthetic [RecipeOrigin]s for the NuGet-only C# recipe modules, with each package's
+         * latest stable version resolved from NuGet. Unlike the other ecosystems, C# modules have no
+         * Maven artifact to anchor them in the version table and `nuget install` command, so their
+         * origins must be synthesized before the latest-versions page is written.
          *
-         * @param artifactIds when non-empty, only build origins for these artifactIds (mirrors the
-         *   `--only-artifacts` filter so local runs don't make needless NuGet requests).
+         * @param artifactIds when non-empty, restricts to these artifactIds (mirrors `--only-artifacts`
+         *   so local runs don't make needless NuGet requests).
          */
         @JvmStatic
         fun buildVersionAnchorOrigins(artifactIds: Set<String> = emptySet()): Map<URI, RecipeOrigin> {

--- a/src/main/kotlin/org/openrewrite/NuGetVersion.kt
+++ b/src/main/kotlin/org/openrewrite/NuGetVersion.kt
@@ -1,0 +1,43 @@
+package org.openrewrite
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+// The C# recipe modules are published only to NuGet; there is no Maven artifact to anchor their
+// version the way the other ecosystems do. Their latest stable version is resolved from the NuGet
+// "package base address" (flat container) index at doc-generation time.
+// https://learn.microsoft.com/en-us/nuget/api/package-base-address-resource
+private val NUGET_MAPPER = jacksonObjectMapper()
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+private data class NuGetVersionIndex(val versions: List<String> = emptyList())
+
+/**
+ * Resolve the latest stable (non-prerelease) version of a NuGet package, or `null` if it can't be
+ * reached or has no stable release. The flat-container index lists versions in ascending SemVer
+ * order, so the last non-prerelease entry is the newest stable release.
+ */
+fun latestStableNuGetVersion(packageId: String): String? {
+    val url = "https://api.nuget.org/v3-flatcontainer/${packageId.lowercase()}/index.json"
+    return try {
+        OkHttpClient()
+            .newCall(Request.Builder().url(url).build())
+            .execute()
+            .use { response ->
+                if (!response.isSuccessful) {
+                    System.err.println("Failed to get NuGet version for $packageId from $url: ${response.code}")
+                    return null
+                }
+                val body = response.body?.string() ?: return null
+                NUGET_MAPPER.readValue<NuGetVersionIndex>(body).versions
+                    .filterNot { it.contains('-') }
+                    .lastOrNull()
+            }
+    } catch (e: Exception) {
+        System.err.println("Failed to get NuGet version for $packageId from $url: ${e.message}")
+        null
+    }
+}

--- a/src/main/kotlin/org/openrewrite/NuGetVersion.kt
+++ b/src/main/kotlin/org/openrewrite/NuGetVersion.kt
@@ -6,9 +6,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
-// The C# recipe modules are published only to NuGet; there is no Maven artifact to anchor their
-// version the way the other ecosystems do. Their latest stable version is resolved from the NuGet
-// "package base address" (flat container) index at doc-generation time.
+// Resolves versions from the NuGet "package base address" (flat container) API.
 // https://learn.microsoft.com/en-us/nuget/api/package-base-address-resource
 private val NUGET_MAPPER = jacksonObjectMapper()
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -125,6 +125,18 @@ class RecipeMarkdownGenerator : Runnable {
         val recipeLoader = RecipeLoader(recipeClasspath, recipeOrigins)
         recipeLoader.addInfosFromManifests()
 
+        // The C# recipe modules are NuGet-only: they have no Maven artifact to give them a
+        // RecipeOrigin (and their RPC-derived origins are created later, after the latest-versions
+        // page below has already been written). Synthesize origins here, resolving each package's
+        // latest stable version from NuGet, so the version table and `nuget install` command include
+        // them. Merged after addInfosFromManifests, which would otherwise clear their repositoryUrl
+        // (there is no manifest to read it from). Only needed for Moderne docs — C# modules are
+        // proprietary and excluded from the OpenRewrite docs, and this also keeps the OR-docs-only
+        // path free of NuGet network calls.
+        if (moderneOutputPath != null) {
+            recipeOrigins = recipeOrigins + CSharpRecipeLoader.buildVersionAnchorOrigins(onlyArtifacts.toSet())
+        }
+
         // Write latest-versions-of-every-openrewrite-module.md
         val versionWriter = VersionWriter()
         // OpenRewrite docs: createLatestVersionsMarkdown drops proprietary modules from the table and

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -125,14 +125,10 @@ class RecipeMarkdownGenerator : Runnable {
         val recipeLoader = RecipeLoader(recipeClasspath, recipeOrigins)
         recipeLoader.addInfosFromManifests()
 
-        // The C# recipe modules are NuGet-only: they have no Maven artifact to give them a
-        // RecipeOrigin (and their RPC-derived origins are created later, after the latest-versions
-        // page below has already been written). Synthesize origins here, resolving each package's
-        // latest stable version from NuGet, so the version table and `nuget install` command include
-        // them. Merged after addInfosFromManifests, which would otherwise clear their repositoryUrl
-        // (there is no manifest to read it from). Only needed for Moderne docs — C# modules are
-        // proprietary and excluded from the OpenRewrite docs, and this also keeps the OR-docs-only
-        // path free of NuGet network calls.
+        // Synthesize origins for the NuGet-only C# modules so the version table and `nuget install`
+        // command below include them. Placed after addInfosFromManifests (which would otherwise clear
+        // their repositoryUrl) and gated to Moderne docs, since C# is proprietary and excluded from
+        // the OpenRewrite docs — which also keeps that path free of NuGet network calls.
         if (moderneOutputPath != null) {
             recipeOrigins = recipeOrigins + CSharpRecipeLoader.buildVersionAnchorOrigins(onlyArtifacts.toSet())
         }

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -113,16 +113,21 @@ class VersionWriter {
                     }
                 }
 
-                val loadCommand = "load_" + (origin.groupId + '_' + origin.artifactId)
-                    .replace('-', '_')
-                    .replace('.', '_')
-                //language=graphql
-                installRecipes += """
-                  $loadCommand: installRecipesUniversal(
-                    bundle: { maven: { groupId: "${origin.groupId}", artifactId: "${origin.artifactId}", version: "LATEST" } }
-                  ) {
-                    id
-                  }"""
+                // The Moderne Installation mutation installs from Maven. C# modules are NuGet-only
+                // and have no Maven coordinate, so they are covered by the `nuget install` command
+                // above and omitted here rather than emitting an unresolvable maven bundle.
+                if (origin.artifactId !in CSharpRecipeLoader.CSHARP_RECIPE_MODULES) {
+                    val loadCommand = "load_" + (origin.groupId + '_' + origin.artifactId)
+                        .replace('-', '_')
+                        .replace('.', '_')
+                    //language=graphql
+                    installRecipes += """
+                      $loadCommand: installRecipesUniversal(
+                        bundle: { maven: { groupId: "${origin.groupId}", artifactId: "${origin.artifactId}", version: "LATEST" } }
+                      ) {
+                        id
+                      }"""
+                }
 
                 val repoLink = "[${origin.groupId}:${origin.artifactId}](${origin.repositoryUrl})"
                 val releaseLink = "[${origin.version}](${origin.releaseUrl(origin.version)})"

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -113,12 +113,22 @@ class VersionWriter {
                     }
                 }
 
-                // The Moderne Installation mutation installs from Maven; C# modules have no Maven
-                // coordinate, so they are omitted here (covered by the `nuget install` command above).
-                if (origin.artifactId !in CSharpRecipeLoader.CSHARP_RECIPE_MODULES) {
-                    val loadCommand = "load_" + (origin.groupId + '_' + origin.artifactId)
-                        .replace('-', '_')
-                        .replace('.', '_')
+                // C# modules have no Maven coordinate, so install them via the `nuget` bundle
+                // variant. `*-*` is the NuGet parallel of Maven `LATEST` (newest published,
+                // prereleases included).
+                val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES[origin.artifactId]
+                val loadCommand = "load_" + (nugetPackage ?: "${origin.groupId}_${origin.artifactId}")
+                    .replace('-', '_')
+                    .replace('.', '_')
+                if (nugetPackage != null) {
+                    //language=graphql
+                    installRecipes += """
+                      $loadCommand: installRecipesUniversal(
+                        bundle: { nuget: { packageName: "$nugetPackage", version: "*-*" } }
+                      ) {
+                        id
+                      }"""
+                } else {
                     //language=graphql
                     installRecipes += """
                       $loadCommand: installRecipesUniversal(
@@ -128,19 +138,14 @@ class VersionWriter {
                       }"""
                 }
 
-                // C# modules have no Maven artifact, so identify them by their NuGet package and
-                // link to nuget.org, matching the `nuget install` command below.
-                val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES[origin.artifactId]
+                // Note that these are links to Github releases, not locations on things like Nuget.org or Maven Central currently
                 val repoLink: String
-                val releaseLink: String
                 if (nugetPackage != null) {
-                    val packageUrl = "https://www.nuget.org/packages/$nugetPackage"
-                    repoLink = "[$nugetPackage]($packageUrl)"
-                    releaseLink = "[${origin.version}]($packageUrl/${origin.version})"
+                    repoLink = "[$nugetPackage](${origin.repositoryUrl})"
                 } else {
                     repoLink = "[${origin.groupId}:${origin.artifactId}](${origin.repositoryUrl})"
-                    releaseLink = "[${origin.version}](${origin.releaseUrl(origin.version)})"
                 }
+                val releaseLink = "[${origin.version}](${origin.releaseUrl(origin.version)})"
                 writeln("| ${repoLink.padEnd(117)} | ${releaseLink.padEnd(90)} | ${origin.license.markdown()} |")
             }
 

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -113,9 +113,8 @@ class VersionWriter {
                     }
                 }
 
-                // The Moderne Installation mutation installs from Maven. C# modules are NuGet-only
-                // and have no Maven coordinate, so they are covered by the `nuget install` command
-                // above and omitted here rather than emitting an unresolvable maven bundle.
+                // The Moderne Installation mutation installs from Maven; C# modules have no Maven
+                // coordinate, so they are omitted here (covered by the `nuget install` command above).
                 if (origin.artifactId !in CSharpRecipeLoader.CSHARP_RECIPE_MODULES) {
                     val loadCommand = "load_" + (origin.groupId + '_' + origin.artifactId)
                         .replace('-', '_')
@@ -129,10 +128,8 @@ class VersionWriter {
                       }"""
                 }
 
-                // C# modules are NuGet-only: with no Maven artifact behind them, identify them by
-                // their NuGet package and link to nuget.org, matching the `nuget install` command
-                // below. Every other row is backed by a real Maven artifact, so it keeps its
-                // groupId:artifactId + GitHub links.
+                // C# modules have no Maven artifact, so identify them by their NuGet package and
+                // link to nuget.org, matching the `nuget install` command below.
                 val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES[origin.artifactId]
                 val repoLink: String
                 val releaseLink: String

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -129,11 +129,10 @@ class VersionWriter {
                       }"""
                 }
 
-                // C# modules are NuGet-only — there is no Maven artifact behind the synthetic
-                // `io.moderne.recipe:<artifactId>` coordinate — so identify them by their NuGet
-                // package and link to nuget.org, matching the `nuget install` command below (and the
-                // per-recipe ecosystem-native identity introduced in #350). Every other row is backed
-                // by a real Maven artifact, so it keeps its `groupId:artifactId` + GitHub links.
+                // C# modules are NuGet-only: with no Maven artifact behind them, identify them by
+                // their NuGet package and link to nuget.org, matching the `nuget install` command
+                // below. Every other row is backed by a real Maven artifact, so it keeps its
+                // groupId:artifactId + GitHub links.
                 val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES[origin.artifactId]
                 val repoLink: String
                 val releaseLink: String

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -129,8 +129,22 @@ class VersionWriter {
                       }"""
                 }
 
-                val repoLink = "[${origin.groupId}:${origin.artifactId}](${origin.repositoryUrl})"
-                val releaseLink = "[${origin.version}](${origin.releaseUrl(origin.version)})"
+                // C# modules are NuGet-only — there is no Maven artifact behind the synthetic
+                // `io.moderne.recipe:<artifactId>` coordinate — so identify them by their NuGet
+                // package and link to nuget.org, matching the `nuget install` command below (and the
+                // per-recipe ecosystem-native identity introduced in #350). Every other row is backed
+                // by a real Maven artifact, so it keeps its `groupId:artifactId` + GitHub links.
+                val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES[origin.artifactId]
+                val repoLink: String
+                val releaseLink: String
+                if (nugetPackage != null) {
+                    val packageUrl = "https://www.nuget.org/packages/$nugetPackage"
+                    repoLink = "[$nugetPackage]($packageUrl)"
+                    releaseLink = "[${origin.version}]($packageUrl/${origin.version})"
+                } else {
+                    repoLink = "[${origin.groupId}:${origin.artifactId}](${origin.repositoryUrl})"
+                    releaseLink = "[${origin.version}](${origin.releaseUrl(origin.version)})"
+                }
                 writeln("| ${repoLink.padEnd(117)} | ${releaseLink.padEnd(90)} | ${origin.license.markdown()} |")
             }
 

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -81,9 +81,11 @@ class RecipeMarkdownGeneratorTest {
         // Moderne docs include the proprietary moderne-recipe-bom row.
         assertThat(out).contains("io.moderne.recipe:moderne-recipe-bom")
 
-        // C# modules appear in the version table...
-        assertThat(out).contains("[io.moderne.recipe:recipes-code-quality]")
-        // ...but not in the Maven-only GraphQL mutation, since they have no Maven coordinate.
+        // C# modules appear in the version table by their NuGet identity (not a fabricated
+        // io.moderne.recipe:recipes-code-quality Maven coordinate), linked to nuget.org.
+        assertThat(out).contains("[OpenRewrite.Recipes.CSharp.CodeQuality](https://www.nuget.org/packages/OpenRewrite.Recipes.CSharp.CodeQuality)")
+        assertThat(out).doesNotContain("[io.moderne.recipe:recipes-code-quality]")
+        // ...and not in the Maven-only GraphQL mutation, since they have no Maven coordinate.
         assertThat(out).doesNotContain("artifactId: \"recipes-code-quality\"")
     }
 

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -80,6 +80,11 @@ class RecipeMarkdownGeneratorTest {
 
         // Moderne docs include the proprietary moderne-recipe-bom row.
         assertThat(out).contains("io.moderne.recipe:moderne-recipe-bom")
+
+        // C# modules appear in the version table...
+        assertThat(out).contains("[io.moderne.recipe:recipes-code-quality]")
+        // ...but not in the Maven-only GraphQL mutation, since they have no Maven coordinate.
+        assertThat(out).doesNotContain("artifactId: \"recipes-code-quality\"")
     }
 
     @Test

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -81,11 +81,10 @@ class RecipeMarkdownGeneratorTest {
         // Moderne docs include the proprietary moderne-recipe-bom row.
         assertThat(out).contains("io.moderne.recipe:moderne-recipe-bom")
 
-        // C# modules appear in the version table by their NuGet identity (not a fabricated
-        // io.moderne.recipe:recipes-code-quality Maven coordinate), linked to nuget.org.
+        // C# modules appear in the version table by their NuGet identity, not a fabricated
+        // Maven coordinate, and not in the Maven-only GraphQL mutation.
         assertThat(out).contains("[OpenRewrite.Recipes.CSharp.CodeQuality](https://www.nuget.org/packages/OpenRewrite.Recipes.CSharp.CodeQuality)")
         assertThat(out).doesNotContain("[io.moderne.recipe:recipes-code-quality]")
-        // ...and not in the Maven-only GraphQL mutation, since they have no Maven coordinate.
         assertThat(out).doesNotContain("artifactId: \"recipes-code-quality\"")
     }
 

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -82,10 +82,12 @@ class RecipeMarkdownGeneratorTest {
         assertThat(out).contains("io.moderne.recipe:moderne-recipe-bom")
 
         // C# modules appear in the version table by their NuGet identity, not a fabricated
-        // Maven coordinate, and not in the Maven-only GraphQL mutation.
-        assertThat(out).contains("[OpenRewrite.Recipes.CSharp.CodeQuality](https://www.nuget.org/packages/OpenRewrite.Recipes.CSharp.CodeQuality)")
+        // Maven coordinate, and in the GraphQL mutation via the `nuget` bundle variant rather
+        // than a fabricated Maven one.
+        assertThat(out).contains("[OpenRewrite.Recipes.CSharp.CodeQuality]")
         assertThat(out).doesNotContain("[io.moderne.recipe:recipes-code-quality]")
         assertThat(out).doesNotContain("artifactId: \"recipes-code-quality\"")
+        assertThat(out).contains("bundle: { nuget: { packageName: \"OpenRewrite.Recipes.CSharp.CodeQuality\", version: \"*-*\" } }")
     }
 
     @Test
@@ -441,6 +443,7 @@ class RecipeMarkdownGeneratorTest {
             "Test recipe",
             mutableSetOf(),
             java.time.Duration.ZERO,
+            mutableListOf(),
             mutableListOf(),
             mutableListOf(),
             mutableListOf(),


### PR DESCRIPTION
## Generate the `nuget install` command for C# recipe modules on the Moderne docs latest-versions page

### Problem

- The [latest versions page](https://docs.moderne.io/user-documentation/recipes/lists/latest-versions-of-every-openrewrite-module) lists `mod config recipes` install commands for the `jar`, `pip`, `npm`, and `go` ecosystems, but never the `nuget` command for the C# recipe modules — even though the C# NuGet packages are now published as stable (`0.3.0`) and `VersionWriter` already has full, tested support for emitting the `nuget install` line. (Reported in moderneinc/moderne-docs#721.)

### Root cause

The `nuget install` line is only emitted when the C# modules have a `RecipeOrigin` at the moment the latest-versions page is written. They never did:

- Every other RPC-loaded ecosystem (npm, Go, Python) is backed by a real Maven artifact on the Gradle `recipe` classpath, which gives it a `RecipeOrigin` and version (Go's is an explicit empty placeholder artifact). The four C# modules are **NuGet-only** — no Maven artifact exists — so they get no origin from the classpath.
- Their only origins are the *synthetic* ones created inside `CSharpRecipeLoader.loadCSharpRecipes()`, which runs **after** the latest-versions page is written, and is skipped entirely in the nightly `-PlatestVersionsOnly=true` path.

Net effect: in every mode, C# was absent from the version table and the `nuget install` command.

- Note: C# recipes are proprietary, so they only appear in the **Moderne** docs (`docs.moderne.io`), not the OpenRewrite docs (`docs.openrewrite.org`, which excludes proprietary modules per #352). The original issue linked the OpenRewrite page; the correct home for the C# install is the Moderne page.

### Fix

Synthesize `RecipeOrigin`s for the four C# modules before the version page is written, resolving each package's latest **stable** version from NuGet:

- **`NuGetVersion.kt`** (new) — resolves a package's latest stable version from the NuGet flat-container index, mirroring the existing `CliVersion.kt` HTTP/JSON pattern; degrades gracefully to `null` on failure (module is skipped, matching prior behavior).
- **`CSharpRecipeLoader.buildVersionAnchorOrigins()`** (new) — builds the synthetic origins from the module/group/repo maps it already owns, keyed by the same `csharp-search://<artifactId>` URI so a full run reuses them.
- **`RecipeMarkdownGenerator`** — injects the anchors into `recipeOrigins`, gated on Moderne docs being generated (keeps the OpenRewrite-docs path and the offline unit tests free of NuGet calls), and placed after `addInfosFromManifests()` so the synthetic origins retain their repo URL.
- **`VersionWriter`** — excludes the C# modules from the Maven-only "Moderne Installation" GraphQL mutation (they have no Maven coordinate); they're covered by the `nuget install` command instead.

### Result

`build/moderne-docs/latest-versions-of-every-openrewrite-module.md` now includes:

- A `nuget install` line in both the **pinned** and **latest** tabs for all four packages.
- Version-table rows for all four C# modules at `0.3.0` (resolved live), with correct license and repo/release links.
- The matching `{{VERSION_*}} → 0.3.0` entries in `latest-versions.js` for placeholder substitution.

The OpenRewrite docs output (`build/docs/`) correctly continues to omit C#.

### Testing

- Extended `latestVersionsMultiEcosystemInstall` to assert the C# table row is present and that C# is excluded from the GraphQL mutation.
- Verified end-to-end with a local `./gradlew run` against live NuGet.

- Once merged and released, the `nuget install` command will appear on `docs.moderne.io` after the next nightly moderne-docs run. Closes moderneinc/moderne-docs#721.