### PR TITLE
Fail a full doc generation when a configured recipe source yields nothing

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -63,9 +63,12 @@ class RecipeLoader {
     }
 
     /**
-     * Load recipes from the specified sources and classpath
+     * Load recipes from the specified sources and classpath.
+     *
+     * @param requireAllRecipeSources fail rather than warn when a configured RPC-backed language
+     * (TypeScript, Python, C#, Go) contributes no recipes at all.
      */
-    fun loadRecipes(): RecipeLoadResult {
+    fun loadRecipes(requireAllRecipeSources: Boolean = false): RecipeLoadResult {
         // Load Java/YAML recipes in parallel
         val environmentData = loadEnvironmentDataAsync()
 
@@ -106,12 +109,17 @@ class RecipeLoader {
             }
         }
 
+        // An RPC-backed language whose toolchain is broken yields zero descriptors rather than an
+        // error, so the run stays green while silently omitting every recipe in that language.
+        // Callers that replace their catalog wholesale then delete the corresponding pages.
+        val emptyRecipeSources = mutableListOf<String>()
+
         // Load TypeScript recipes via RPC
         println("\nChecking for TypeScript/JavaScript recipes...")
         val typeScriptLoader = TypeScriptRecipeLoader(recipeOrigins)
         val typeScriptResult = typeScriptLoader.loadTypeScriptRecipes()
         if (typeScriptResult.descriptors.isEmpty() && TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES.isNotEmpty()) {
-            System.err.println("WARNING: 0 TypeScript recipes loaded despite ${TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES.size} module(s) configured. Check that Node.js is installed.")
+            emptyRecipeSources += "TypeScript: 0 recipes from ${TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES.size} configured module(s). Check that Node.js is installed."
         }
 
         // Load Python recipes via RPC
@@ -119,7 +127,7 @@ class RecipeLoader {
         val pythonLoader = PythonRecipeLoader(recipeOrigins)
         val pythonResult = pythonLoader.loadPythonRecipes()
         if (pythonResult.descriptors.isEmpty() && PythonRecipeLoader.PYTHON_RECIPE_MODULES.isNotEmpty()) {
-            System.err.println("WARNING: 0 Python recipes loaded despite ${PythonRecipeLoader.PYTHON_RECIPE_MODULES.size} module(s) configured. Check that Python 3.10+ and pip are installed.")
+            emptyRecipeSources += "Python: 0 recipes from ${PythonRecipeLoader.PYTHON_RECIPE_MODULES.size} configured module(s). Check that Python 3.10+ and pip are installed."
         }
 
         // Load C# recipes via RPC, passing Java descriptors so delegatesTo can resolve
@@ -128,7 +136,7 @@ class RecipeLoader {
         val csharpLoader = CSharpRecipeLoader(recipeOrigins, javaDescriptors, classloader)
         val csharpResult = csharpLoader.loadCSharpRecipes()
         if (csharpResult.descriptors.isEmpty() && CSharpRecipeLoader.CSHARP_RECIPE_MODULES.isNotEmpty()) {
-            System.err.println("WARNING: 0 C# recipes loaded despite ${CSharpRecipeLoader.CSHARP_RECIPE_MODULES.size} module(s) configured. Check that .NET SDK is installed.")
+            emptyRecipeSources += "C#: 0 recipes from ${CSharpRecipeLoader.CSHARP_RECIPE_MODULES.size} configured module(s). Check that the .NET SDK is installed."
         }
 
         // Load Go recipes via RPC, passing Java descriptors so delegatesTo can resolve
@@ -136,8 +144,10 @@ class RecipeLoader {
         val goLoader = GoRecipeLoader(recipeOrigins, javaDescriptors, classloader)
         val goResult = goLoader.loadGoRecipes()
         if (goResult.descriptors.isEmpty() && GoRecipeLoader.GO_RECIPE_MODULES.isNotEmpty()) {
-            System.err.println("WARNING: 0 Go recipes loaded despite ${GoRecipeLoader.GO_RECIPE_MODULES.size} module(s) configured. Check that Go 1.25+ and the rewrite-go-rpc server are installed.")
+            emptyRecipeSources += "Go: 0 recipes from ${GoRecipeLoader.GO_RECIPE_MODULES.size} configured module(s). Check that Go 1.25+ and the rewrite-go-rpc server are installed."
         }
+
+        reportEmptyRecipeSources(emptyRecipeSources, requireAllRecipeSources)
 
         // Merge TypeScript, Python, C#, and Go results with Java/YAML results
         val allDescriptors = environmentData.flatMap { it.recipeDescriptors }.toMutableList()
@@ -302,6 +312,24 @@ class RecipeLoader {
          */
         fun sanitizePathSegment(segment: String): String {
             return segment.lowercase().replace("#", "sharp")
+        }
+
+        /**
+         * Fail — or warn, when the caller opted out — if a configured recipe source contributed
+         * nothing. A broken toolchain surfaces as zero descriptors rather than an exception, and
+         * docs pipelines that replace their catalog wholesale turn that into mass page deletion.
+         */
+        fun reportEmptyRecipeSources(emptyRecipeSources: List<String>, requireAllRecipeSources: Boolean) {
+            if (emptyRecipeSources.isEmpty()) {
+                return
+            }
+            val detail = emptyRecipeSources.joinToString("\n") { "  - $it" }
+            check(!requireAllRecipeSources) {
+                "No recipes loaded from configured source(s):\n$detail\n" +
+                    "Publishing this run would drop every recipe in those languages. Fix the toolchain, " +
+                    "narrow the run with --only-artifacts, or pass --allow-empty-recipe-sources to override."
+            }
+            System.err.println("WARNING: no recipes loaded from configured source(s):\n$detail")
         }
     }
 

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -92,6 +92,14 @@ class RecipeMarkdownGenerator : Runnable {
     )
     var onlyArtifacts: List<String> = emptyList()
 
+    @Option(
+        names = ["--allow-empty-recipe-sources"],
+        description = ["Warn instead of failing when a configured RPC-backed language (TypeScript, " +
+            "Python, C#, Go) contributes no recipes. Use when generating docs on a machine that " +
+            "deliberately lacks one of those toolchains."]
+    )
+    var allowEmptyRecipeSources: Boolean = false
+
     override fun run() {
         // OpenRewrite docs output (open-source recipes only)
         val outputPath = Paths.get(destinationDirectoryName)
@@ -180,8 +188,11 @@ class RecipeMarkdownGenerator : Runnable {
             return
         }
 
-        // Load recipe details into memory
-        val loadResult = recipeLoader.loadRecipes()
+        // Load recipe details into memory. A run restricted to a few artifacts is expected to miss
+        // whole languages, so only a full run insists every configured language contributed recipes.
+        val loadResult = recipeLoader.loadRecipes(
+            requireAllRecipeSources = onlyArtifacts.isEmpty() && !allowEmptyRecipeSources
+        )
         val allRecipeDescriptors = loadResult.allRecipeDescriptors
         val allCategoryDescriptors = loadResult.allCategoryDescriptors
         val allRecipes = loadResult.allRecipes

--- a/src/test/kotlin/org/openrewrite/RecipeLoaderTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeLoaderTest.kt
@@ -1,9 +1,43 @@
 package org.openrewrite
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.assertj.core.api.Assertions.assertThatNoException
 import org.junit.jupiter.api.Test
 
 class RecipeLoaderTest {
+
+    @Test
+    fun emptyRecipeSourceFailsAFullRun() {
+        assertThatIllegalStateException().isThrownBy {
+            RecipeLoader.reportEmptyRecipeSources(
+                listOf("Go: 0 recipes from 1 configured module(s). Check that Go 1.25+ and the rewrite-go-rpc server are installed."),
+                requireAllRecipeSources = true
+            )
+        }.withMessageContaining("Go: 0 recipes")
+            .withMessageContaining("--allow-empty-recipe-sources")
+    }
+
+    @Test
+    fun everyEmptyRecipeSourceIsReportedAtOnce() {
+        assertThatIllegalStateException().isThrownBy {
+            RecipeLoader.reportEmptyRecipeSources(listOf("Go: none", "C#: none"), requireAllRecipeSources = true)
+        }.withMessageContaining("Go: none").withMessageContaining("C#: none")
+    }
+
+    @Test
+    fun emptyRecipeSourceOnlyWarnsWhenNotRequired() {
+        assertThatNoException().isThrownBy {
+            RecipeLoader.reportEmptyRecipeSources(listOf("Go: none"), requireAllRecipeSources = false)
+        }
+    }
+
+    @Test
+    fun noEmptyRecipeSourcesIsAlwaysFine() {
+        assertThatNoException().isThrownBy {
+            RecipeLoader.reportEmptyRecipeSources(emptyList(), requireAllRecipeSources = true)
+        }
+    }
 
     @Test
     fun sanitizePathSegmentRemovesHash() {


### PR DESCRIPTION
## Problem

The four RPC-backed languages — TypeScript, Python, C#, Go — all fail soft. When the toolchain is broken, the loader catches the exception, prints a warning, and returns an empty descriptor list. Generation then completes successfully, having silently omitted every recipe in that language.

That is only a cosmetic problem if the consumer merges. It isn't: [moderne-docs](https://github.com/moderneinc/moderne-docs/blob/main/.github/workflows/update-docs.yml) does `rm -rf recipe-catalog` and copies the generator's output over it, so an empty result doesn't mean "nothing new" — it means "delete these pages."

- That is exactly what happened to Go. A Go toolchain mismatch (`compile: version "go1.24.13" does not match go tool version "go1.25.12"`, fixed by moderneinc/moderne-docs#897 and openrewrite/rewrite#8337) made every `recipes-go` install fail. Two consecutive green runs, on 2026-07-16 and 2026-07-20, deleted all 187 Go recipe pages from docs.moderne.io. Nobody noticed for eleven days — it surfaced only because someone asked why a specific recipe had no page.

The same trap is live for the other three today. The 07-20 run also logged `Failed to install recipes from rewrite-nodejs: npm install ... exited with code 1`.

## Change

Collect the empty sources across all four languages and fail once, listing all of them, rather than emitting four warnings nobody reads:

```
No recipes loaded from configured source(s):
  - Go: 0 recipes from 1 configured module(s). Check that Go 1.25+ and the rewrite-go-rpc server are installed.
Publishing this run would drop every recipe in those languages. Fix the toolchain, narrow the run with
--only-artifacts, or pass --allow-empty-recipe-sources to override.
```

Three escape hatches keep the existing workflows working:

* `--only-artifacts` runs are exempt. Narrowing to a few artifacts is expected to miss whole languages.
* `--latest-versions-only` returns before recipe loading, so the nightly version refresh is untouched.
* `--allow-empty-recipe-sources` opts out explicitly, for generating docs on a machine that deliberately lacks one of the toolchains.

## Testing

`reportEmptyRecipeSources` is extracted as a pure function so the decision is testable without a real classpath or toolchain; `RecipeLoaderTest` covers fail-when-required, warn-when-not, report-all-at-once, and the empty case. `./gradlew build` passes.

## Note for whoever merges

This will turn a currently-green CI run red the first time a toolchain breaks. That is the point — but it is worth confirming the docs workflows have a Go/Node/Python/.NET setup step before merging, so the first red build is a genuine one.