### PR TITLE
Render `go install` on Go recipe pages instead of a no-op `jar install`

### DIFF
--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -432,8 +432,12 @@ class RecipeMarkdownGenerator : Runnable {
 
 
     companion object {
-        /** Modules whose docs should only appear in Moderne docs, regardless of license. */
-        private val MODERNE_DOCS_ONLY_MODULES = setOf("rewrite-devcenter")
+        /**
+         * Modules whose docs should only appear in Moderne docs, regardless of license. Go recipe modules
+         * are listed structurally rather than relying on their jar manifest: the Maven artifact is only a
+         * version/license carrier, and the recipes themselves are Moderne proprietary.
+         */
+        private val MODERNE_DOCS_ONLY_MODULES = setOf("rewrite-devcenter") + GoRecipeLoader.GO_RECIPE_MODULES.keys
 
         internal fun isModerneDocsOnly(origin: RecipeOrigin): Boolean =
             origin.license == Licenses.Proprietary || origin.artifactId in MODERNE_DOCS_ONLY_MODULES

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -582,14 +582,15 @@ import RunRecipe from '@site/src/components/RunRecipe';
      * Every non-JVM ecosystem stamps its recipes with a `<language>-search://` source URI. Falling through to
      * the Maven/Gradle branch for one of those renders a `jar install` of a metadata-only stub: the command
      * succeeds, installs zero recipes, and the failure only surfaces later when `mod run` cannot find the
-     * recipe. Fail the generation instead, so adding an ecosystem forces a matching branch here.
+     * recipe. Fail the generation instead, so adding an ecosystem forces either a matching branch here or a
+     * filter that keeps its recipes out of these docs entirely.
      */
     private fun requireHandledEcosystem(recipeDescriptor: RecipeDescriptor) {
         val scheme = recipeToSource[recipeDescriptor.name]?.scheme ?: return
         check(!scheme.endsWith("-search")) {
-            "Recipe ${recipeDescriptor.name} has an unhandled '$scheme://' source URI. " +
-                    "Add a branch to RecipeMarkdownWriter for this ecosystem; otherwise its docs would " +
-                    "advertise Maven coordinates that install no recipes."
+            "Recipe ${recipeDescriptor.name} has an unhandled '$scheme://' source URI. Either give this " +
+                    "ecosystem its own branch in RecipeMarkdownWriter, or exclude its recipes from these " +
+                    "docs; otherwise they advertise Maven coordinates that install no recipes."
         }
     }
 
@@ -653,22 +654,9 @@ ${props.toString().trimEnd()}
             return
         }
 
-        // Handle Go recipes
-        if (isGoRecipe(recipeDescriptor)) {
-            val goModuleName = getGoModuleName(origin)
-            writeln(
-                """
-                <RunRecipe
-                  recipeName="${recipeDescriptor.name}"
-                  displayName="${recipeDescriptor.displayNameEscapedMdx()}"
-                  goPackage="$goModuleName"
-                  versionKey="${origin.versionPlaceholderKey()}"
-                />
-                """.trimIndent()
-            )
-            return
-        }
-
+        // Deliberately no Go branch: Go recipes are Moderne proprietary, so RecipeMarkdownGenerator
+        // filters them out of the OpenRewrite docs — the only docs this method writes. Reaching here
+        // with one means that filter has broken, which the check below turns into a build failure.
         requireHandledEcosystem(recipeDescriptor)
 
         val suppressJava = recipeDescriptor.name.contains(".csharp.") ||
@@ -1276,8 +1264,8 @@ ${props.toString().trimEnd()}
             "displayName" to recipeDescriptor.displayName,
         )
 
-        // JS/Python/C#/Go recipes install from their own package managers (matching the markdown path's
-        // per-ecosystem <RunRecipe>); everything else uses the Maven/Gradle coordinates + CLI options.
+        // JS/Python/C#/Go recipes install from their own package managers; everything else uses the
+        // Maven/Gradle coordinates + CLI options.
         when {
             isJavaScriptRecipe(recipeDescriptor) -> usageMap["npmPackage"] = getNpmPackageName(origin)
             isPythonRecipe(recipeDescriptor) -> {

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -74,6 +74,14 @@ class RecipeMarkdownWriter(
     }
 
     /**
+     * Determines if a recipe is a Go recipe based on its source URI.
+     */
+    private fun isGoRecipe(recipeDescriptor: RecipeDescriptor): Boolean {
+        val recipeSource = recipeToSource[recipeDescriptor.name] ?: return false
+        return recipeSource.toString().startsWith("go-search://")
+    }
+
+    /**
      * Write a recipe to a custom path (for cross-category duplicates).
      * The target language is derived from the first segment of the custom path (e.g., "python" from "python/changemethodname").
      */
@@ -561,6 +569,30 @@ import RunRecipe from '@site/src/components/RunRecipe';
             ?: origin.artifactId
     }
 
+    /**
+     * Gets the Go module path for a Go recipe module.
+     * Uses the single source of truth from GoRecipeLoader.
+     */
+    private fun getGoModuleName(origin: RecipeOrigin): String {
+        return GoRecipeLoader.GO_RECIPE_MODULES[origin.artifactId]
+            ?: origin.artifactId
+    }
+
+    /**
+     * Every non-JVM ecosystem stamps its recipes with a `<language>-search://` source URI. Falling through to
+     * the Maven/Gradle branch for one of those renders a `jar install` of a metadata-only stub: the command
+     * succeeds, installs zero recipes, and the failure only surfaces later when `mod run` cannot find the
+     * recipe. Fail the generation instead, so adding an ecosystem forces a matching branch here.
+     */
+    private fun requireHandledEcosystem(recipeDescriptor: RecipeDescriptor) {
+        val scheme = recipeToSource[recipeDescriptor.name]?.scheme ?: return
+        check(!scheme.endsWith("-search")) {
+            "Recipe ${recipeDescriptor.name} has an unhandled '$scheme://' source URI. " +
+                    "Add a branch to RecipeMarkdownWriter for this ecosystem; otherwise its docs would " +
+                    "advertise Maven coordinates that install no recipes."
+        }
+    }
+
     private fun BufferedWriter.writeUsage(
         recipeDescriptor: RecipeDescriptor,
         origin: RecipeOrigin
@@ -620,6 +652,24 @@ ${props.toString().trimEnd()}
             )
             return
         }
+
+        // Handle Go recipes
+        if (isGoRecipe(recipeDescriptor)) {
+            val goModuleName = getGoModuleName(origin)
+            writeln(
+                """
+                <RunRecipe
+                  recipeName="${recipeDescriptor.name}"
+                  displayName="${recipeDescriptor.displayNameEscapedMdx()}"
+                  goPackage="$goModuleName"
+                  versionKey="${origin.versionPlaceholderKey()}"
+                />
+                """.trimIndent()
+            )
+            return
+        }
+
+        requireHandledEcosystem(recipeDescriptor)
 
         val suppressJava = recipeDescriptor.name.contains(".csharp.") ||
                 recipeDescriptor.name.contains(".dotnet.") ||
@@ -978,6 +1028,7 @@ ${props.toString().trimEnd()}
             isJavaScriptRecipe(recipeDescriptor) -> getNpmPackageName(origin)
             isPythonRecipe(recipeDescriptor) -> getPipPackageName(origin)
             isCSharpRecipe(recipeDescriptor) -> getNuGetPackageName(origin)
+            isGoRecipe(recipeDescriptor) -> getGoModuleName(origin)
             else -> "${origin.groupId}:${origin.artifactId}"
         }
         val appLink = "https://app.moderne.io/recipes/$name"
@@ -1225,7 +1276,7 @@ ${props.toString().trimEnd()}
             "displayName" to recipeDescriptor.displayName,
         )
 
-        // JS/Python/C# recipes install from their own package managers (matching the markdown path's
+        // JS/Python/C#/Go recipes install from their own package managers (matching the markdown path's
         // per-ecosystem <RunRecipe>); everything else uses the Maven/Gradle coordinates + CLI options.
         when {
             isJavaScriptRecipe(recipeDescriptor) -> usageMap["npmPackage"] = getNpmPackageName(origin)
@@ -1238,7 +1289,14 @@ ${props.toString().trimEnd()}
                 }
             }
             isCSharpRecipe(recipeDescriptor) -> usageMap["nugetPackage"] = getNuGetPackageName(origin)
+            isGoRecipe(recipeDescriptor) -> {
+                // Go modules are installed from source by module path, pinned with a vX.Y.Z tag
+                // derived from the Maven artifact version.
+                usageMap["goPackage"] = getGoModuleName(origin)
+                usageMap["versionKey"] = origin.versionPlaceholderKey()
+            }
             else -> {
+                requireHandledEcosystem(recipeDescriptor)
                 val options = recipeDescriptor.options ?: emptyList()
                 val requiresConfiguration = options.any { it.isRequired }
                 usageMap["groupId"] = origin.groupId

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -141,6 +141,20 @@ class RecipeMarkdownGeneratorTest {
     }
 
     @Test
+    fun goModulesAreModerneDocsOnlyRegardlessOfManifestLicense() {
+        // Go recipes are Moderne proprietary and must never reach docs.openrewrite.org. The exclusion keys
+        // off the module list rather than the jar manifest, so a mis-stamped License-Url on the (metadata
+        // only) Maven artifact cannot leak a whole ecosystem into the open-source docs.
+        for (artifactId in GoRecipeLoader.GO_RECIPE_MODULES.keys) {
+            val origin = RecipeOrigin("org.openrewrite.recipe", artifactId, "0.5.3", URI.create("file:///$artifactId.jar"))
+                .apply { license = Licenses.Apache2 }
+            assertThat(RecipeMarkdownGenerator.isModerneDocsOnly(origin))
+                .describedAs("Go module %s must be excluded from the OpenRewrite docs", artifactId)
+                .isTrue()
+        }
+    }
+
+    @Test
     fun conflictingRecipesGetEditionSuffix() {
         // When both moderne and openrewrite have the same recipe, they should get edition suffixes
         val recipes = listOf(

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -226,20 +226,19 @@ class RecipeMarkdownWriterModerneDocsTest {
     }
 
     @Test
-    fun openRewriteDocsEmitsGoInstallForGoRecipe(@TempDir dir: Path) {
+    fun openRewriteDocsRefuseToRenderGoRecipe(@TempDir dir: Path) {
+        // Go recipes are Moderne proprietary, so RecipeMarkdownGenerator keeps them out of the OpenRewrite
+        // docs. If that filter ever breaks, fail the build rather than publish an open-source page whose
+        // `jar install` command installs nothing.
         val goOrigin = RecipeOrigin("org.openrewrite.recipe", "recipes-go", "0.5.3", jar)
-        val recipe = descriptor(
-            "org.openrewrite.golang.OrderImports",
-            "Order imports", "Orders Go imports.",
-        )
+            .apply { license = Licenses.Proprietary }
+        val recipe = descriptor("org.openrewrite.golang.OrderImports", "Order imports", "Orders Go imports.")
         val recipeToSource = mapOf(recipe.name to URI.create("go-search://recipes-go/${recipe.name}"))
-        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = false)
-            .writeRecipe(recipe, dir, goOrigin)
-        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+        val writer = RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = false)
 
-        assertThat(out).contains("goPackage=\"github.com/moderneinc/recipes-go\"")
-        assertThat(out).contains("versionKey=\"VERSION_ORG_OPENREWRITE_RECIPE_RECIPES_GO\"")
-        assertThat(out).doesNotContain("jar install")
+        assertThatThrownBy { writer.writeRecipe(recipe, dir, goOrigin) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("go-search")
     }
 
     @Test

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -1,6 +1,7 @@
 package org.openrewrite
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.openrewrite.config.OptionDescriptor
@@ -201,9 +202,62 @@ class RecipeMarkdownWriterModerneDocsTest {
     }
 
     @Test
+    fun moderneDocsEmitsGoInstallForGoRecipe(@TempDir dir: Path) {
+        // Uses `recipes-go` — a real entry in GoRecipeLoader.GO_RECIPE_MODULES — so the Usage section installs
+        // the Go module. The Maven artifact of the same name is a metadata-only stub: a `jar install` of it
+        // succeeds while installing zero recipes, which is exactly what this must not render.
+        val goOrigin = RecipeOrigin("org.openrewrite.recipe", "recipes-go", "0.5.3", jar)
+            .apply { license = Licenses.Proprietary }
+        val recipe = descriptor(
+            "org.openrewrite.golang.OrderImports",
+            "Order imports", "Orders Go imports.",
+        )
+        val recipeToSource = mapOf(recipe.name to URI.create("go-search://recipes-go/${recipe.name}"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, setOf(recipe.name), forModerneDocs = true)
+            .writeRecipe(recipe, dir, goOrigin)
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        assertThat(out).contains("\"goPackage\":\"github.com/moderneinc/recipes-go\"")
+        assertThat(out).contains("\"versionKey\":\"VERSION_ORG_OPENREWRITE_RECIPE_RECIPES_GO\"")
+        assertThat(out).doesNotContain("\"groupId\":")
+        assertThat(out).doesNotContain("\"artifactId\":")
+
+        assertThat(out).contains("artifact={\"github.com/moderneinc/recipes-go\"}")
+    }
+
+    @Test
+    fun openRewriteDocsEmitsGoInstallForGoRecipe(@TempDir dir: Path) {
+        val goOrigin = RecipeOrigin("org.openrewrite.recipe", "recipes-go", "0.5.3", jar)
+        val recipe = descriptor(
+            "org.openrewrite.golang.OrderImports",
+            "Order imports", "Orders Go imports.",
+        )
+        val recipeToSource = mapOf(recipe.name to URI.create("go-search://recipes-go/${recipe.name}"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = false)
+            .writeRecipe(recipe, dir, goOrigin)
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        assertThat(out).contains("goPackage=\"github.com/moderneinc/recipes-go\"")
+        assertThat(out).contains("versionKey=\"VERSION_ORG_OPENREWRITE_RECIPE_RECIPES_GO\"")
+        assertThat(out).doesNotContain("jar install")
+    }
+
+    @Test
+    fun unhandledEcosystemSourceUriFailsRatherThanFallingBackToMavenCoordinates(@TempDir dir: Path) {
+        // A future ecosystem's `*-search://` URI must not silently render Maven coordinates.
+        val recipe = descriptor("org.openrewrite.ruby.OrderRequires", "Order requires", "Orders requires.")
+        val recipeToSource = mapOf(recipe.name to URI.create("ruby-search://recipes-ruby/${recipe.name}"))
+        val writer = RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = true)
+
+        assertThatThrownBy { writer.writeRecipe(recipe, dir, origin()) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("ruby-search")
+    }
+
+    @Test
     fun moderneDocsEmitsMavenArtifactForJavaRecipe(@TempDir dir: Path) {
-        // A Java recipe (no typescript-search:// / python-search:// / csharp-search:// source URI) keeps the
-        // groupId:artifactId chip — this is the default and the previous behaviour for every language.
+        // A Java recipe (no typescript-search:// / python-search:// / csharp-search:// / go-search:// source
+        // URI) keeps the groupId:artifactId chip — the default and previous behaviour for every language.
         val out = generate(singleRecipe(), dir, forModerneDocs = true)
 
         assertThat(out).contains("artifact={\"org.openrewrite.recipe:rewrite-static-analysis\"}")


### PR DESCRIPTION
Fixes the generator half of moderneinc/moderne-docs#901.

Every recipe page under `recipe-catalog/golang/` told readers to run
`mod config recipes jar install org.openrewrite.recipe:recipes-go:<version>`.
That command succeeds and installs **zero** recipes — the Maven artifact is a
1.3 KB metadata-only stub the generator uses purely as a `RecipeOrigin` for the
version key and license. The recipes ship as a Go module.

Go support had been added everywhere (`GoRecipeLoader`, `RecipeOrigin`,
`VersionWriter`, `findOrigin`) except the markdown writer, so Go recipes fell
through the per-ecosystem `when` into the Maven branch.

Go recipes are Moderne proprietary, so this only affects the Moderne recipe
catalog — they are, and stay, excluded from docs.openrewrite.org.

## Changes

- `isGoRecipe` / `getGoModuleName` in `RecipeMarkdownWriter`, mirroring the
  existing JavaScript, Python, and C# pairs and reading `GoRecipeLoader.GO_RECIPE_MODULES`.
- A Go branch in `buildUsageJson` (Moderne docs) emitting `goPackage` plus
  `versionKey`, and in the `RecipeHeader` artifact chip.
- Deliberately **no** Go branch in `writeUsage`, which writes the OpenRewrite
  docs only. `requireHandledEcosystem` fails the generation when a recipe
  carries an unhandled `*-search://` source URI, so a Go recipe reaching that
  path is a build failure rather than a published page whose install command
  installs nothing — and so the next ecosystem added cannot silently repeat the
  original bug.
- Go modules are listed in `MODERNE_DOCS_ONLY_MODULES`, so the exclusion from
  the OpenRewrite docs keys off the module list rather than a `License-Url` on
  a metadata-only jar.
- Tests for the Moderne output, the OpenRewrite-docs refusal, the
  unhandled-scheme guard, and the module-list exclusion.

## Requires a companion change in moderne-docs

`src/components/RunRecipe/index.tsx` needs a `goPackage` branch rendering
`mod config recipes go install <module>@v<version>`. Note the `v` prefix on the
version, which the npm/pip/nuget branches do not have. Until that lands, the
Usage section on Go pages will not render an install command — but it will no
longer render a wrong one.