### PR TITLE
Always show latest versions of rewrite-polyglot and rewrite-templating

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,9 +94,9 @@ dependencies {
     "recipe"("org.openrewrite:rewrite-xml:$rewriteVersion")
     "recipe"("org.openrewrite:rewrite-yaml:$rewriteVersion")
 
-    // Additional core modules (versions only, recipes not yet included)
-//    "recipe"("org.openrewrite:rewrite-polyglot:$rewriteVersion")
-//    "recipe"("org.openrewrite:rewrite-templating:$rewriteVersion")
+    // Additional core modules; versions only, recipes not included (RecipeLoader.VERSION_ONLY_MODULES)
+    "recipe"("org.openrewrite:rewrite-polyglot:$rewriteVersion")
+    "recipe"("org.openrewrite:rewrite-templating:$rewriteVersion")
 
     // Recipe modules (org.openrewrite.recipe)
     "recipe"("org.openrewrite.meta:rewrite-analysis:$rewriteVersion")
@@ -200,13 +200,6 @@ tasks.named<JavaExec>("run").configure {
     val moderneTargetDir = layout.buildDirectory.dir("moderne-docs").get().asFile
 
     val latestVersionsOnly = providers.gradleProperty("latestVersionsOnly").getOrElse("").equals("true")
-    if (latestVersionsOnly) {
-        // Additional modules whose versions we want to show, but not (yet) their recipes
-        dependencies {
-            "recipe"("org.openrewrite:rewrite-polyglot:$rewriteVersion")
-            "recipe"("org.openrewrite:rewrite-templating:$rewriteVersion")
-        }
-    }
 
     // Collect all of the dependencies from recipeConf, then stuff them into a string representation
     val recipeModules = recipeConf.resolvedConfiguration.firstLevelModuleDependencies.flatMap { dep ->

--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -306,6 +306,12 @@ class RecipeLoader {
 
     companion object {
         /**
+         * Modules on the recipe configuration purely so the version table lists them; they ship no
+         * recipes we document, so they are skipped when scanning and left out of install commands.
+         */
+        val VERSION_ONLY_MODULES = setOf("rewrite-polyglot", "rewrite-templating")
+
+        /**
          * Sanitize a category name for use as a URL-safe directory path segment.
          * Replaces special characters that are invalid in URLs/directory names.
          * E.g., "C#" → "csharp", "F#" → "fsharp"
@@ -396,6 +402,7 @@ class RecipeLoader {
     private fun loadEnvironmentDataAsync(): List<EnvironmentData> = runBlocking {
         println("Starting parallel recipe loading...")
         recipeOrigins.entries
+            .filter { it.value.artifactId !in VERSION_ONLY_MODULES }
             .chunked(3)
             .flatMap { batch -> batch.map { recipeOrigin ->
                 async(Dispatchers.IO) {

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -83,6 +83,23 @@ class VersionWriter {
                 recipeOrigins.filterNot { RecipeMarkdownGenerator.isModerneDocsOnly(it) }
             }
             for (origin in modulesToList) {
+                // C# modules have no Maven coordinate, so install them via the `nuget` bundle
+                // variant. `*-*` is the NuGet parallel of Maven `LATEST` (newest published,
+                // prereleases included).
+                val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES[origin.artifactId]
+
+                // Note that these are links to Github releases, not locations on things like Nuget.org or Maven Central currently
+                val repoLink: String
+                if (nugetPackage != null) {
+                    repoLink = "[$nugetPackage](${origin.repositoryUrl})"
+                } else {
+                    repoLink = "[${origin.groupId}:${origin.artifactId}](${origin.repositoryUrl})"
+                }
+                val releaseLink = "[${origin.version}](${origin.releaseUrl(origin.version)})"
+                writeln("| ${repoLink.padEnd(117)} | ${releaseLink.padEnd(90)} | ${origin.license.markdown()} |")
+
+                // Modules listed for their version alone ship no recipes to install.
+                if (origin.artifactId in RecipeLoader.VERSION_ONLY_MODULES) continue
 
                 val versionPlaceholder = "{{${origin.versionPlaceholderKey()}}}"
                 when (origin.artifactId) {
@@ -97,7 +114,6 @@ class VersionWriter {
                         cliInstallNpmLatest += "$npmPackage "
                     }
                     in CSharpRecipeLoader.CSHARP_RECIPE_MODULES -> {
-                        val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES.getValue(origin.artifactId)
                         cliInstallNugetPinned += "$nugetPackage@$versionPlaceholder "
                         cliInstallNugetLatest += "$nugetPackage "
                     }
@@ -113,10 +129,6 @@ class VersionWriter {
                     }
                 }
 
-                // C# modules have no Maven coordinate, so install them via the `nuget` bundle
-                // variant. `*-*` is the NuGet parallel of Maven `LATEST` (newest published,
-                // prereleases included).
-                val nugetPackage = CSharpRecipeLoader.CSHARP_RECIPE_MODULES[origin.artifactId]
                 val loadCommand = "load_" + (nugetPackage ?: "${origin.groupId}_${origin.artifactId}")
                     .replace('-', '_')
                     .replace('.', '_')
@@ -137,16 +149,6 @@ class VersionWriter {
                         id
                       }"""
                 }
-
-                // Note that these are links to Github releases, not locations on things like Nuget.org or Maven Central currently
-                val repoLink: String
-                if (nugetPackage != null) {
-                    repoLink = "[$nugetPackage](${origin.repositoryUrl})"
-                } else {
-                    repoLink = "[${origin.groupId}:${origin.artifactId}](${origin.repositoryUrl})"
-                }
-                val releaseLink = "[${origin.version}](${origin.releaseUrl(origin.version)})"
-                writeln("| ${repoLink.padEnd(117)} | ${releaseLink.padEnd(90)} | ${origin.license.markdown()} |")
             }
 
             val pinnedInstalls = listOf(

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -57,6 +57,7 @@ class RecipeMarkdownGeneratorTest {
             mk("org.openrewrite", "rewrite-javascript", "0.9.0"),
             mk("io.moderne.recipe", "recipes-code-quality", "0.1.0"),
             mk("org.openrewrite.recipe", "recipes-go", "0.4.1"),
+            mk("org.openrewrite", "rewrite-polyglot", "2.10.11"),
         )
         VersionWriter().createLatestVersionsMarkdown(tempDir, origins, "8.x", "2.x", "1.x", "6.x", "5.x", forModerneDocs = true)
         val out = Files.readString(tempDir.resolve("latest-versions-of-every-openrewrite-module.md"))
@@ -88,6 +89,11 @@ class RecipeMarkdownGeneratorTest {
         assertThat(out).doesNotContain("[io.moderne.recipe:recipes-code-quality]")
         assertThat(out).doesNotContain("artifactId: \"recipes-code-quality\"")
         assertThat(out).contains("bundle: { nuget: { packageName: \"OpenRewrite.Recipes.CSharp.CodeQuality\", version: \"*-*\" } }")
+
+        // Version-only modules keep their table row, but have no recipes to install.
+        assertThat(out).contains("[org.openrewrite:rewrite-polyglot]")
+        assertThat(out).doesNotContain("org.openrewrite:rewrite-polyglot:")
+        assertThat(out).doesNotContain("artifactId: \"rewrite-polyglot\"")
     }
 
     @Test


### PR DESCRIPTION
`rewrite-polyglot` and `rewrite-templating` were only added to the recipe configuration when running with `-PlatestVersionsOnly=true`, so a full doc generation left them out of the version table entirely; they are now unconditional dependencies. Since we still don't want to document their recipes, `RecipeLoader.VERSION_ONLY_MODULES` keeps them out of recipe scanning, out of the `mod config recipes` install commands, and out of the Moderne installation GraphQL mutation, while their table row, license, release link, and `{{VERSION_*}}` placeholder are all still generated.

Verified with a local `./gradlew run -PlatestVersionsOnly=true` and a restricted full run: both modules appear exactly once each in `latest-versions-of-every-openrewrite-module.md` (as table rows) and in `latest-versions.js`, with no recipe pages generated from them.