### PR TITLE
Update recipeDescriptors.yml for OpenRewrite 8.88.0

### DIFF
--- a/src/main/resources/recipeDescriptors.yml
+++ b/src/main/resources/recipeDescriptors.yml
@@ -1,6 +1,6 @@
 rewrite-all:
   artifactId: "rewrite-all"
-  version: "1.27.1"
+  version: "1.28.0"
   markdownRecipeDescriptors:
     org.openrewrite.FindCallGraph:
       name: "org.openrewrite.FindCallGraph"
@@ -32,7 +32,7 @@ rewrite-all:
       artifactId: "rewrite-all"
 rewrite-analysis:
   artifactId: "rewrite-analysis"
-  version: "2.36.1"
+  version: "2.37.0"
   markdownRecipeDescriptors:
     org.openrewrite.analysis.controlflow.ControlFlowVisualization:
       name: "org.openrewrite.analysis.controlflow.ControlFlowVisualization"
@@ -95,7 +95,7 @@ rewrite-analysis:
       artifactId: "rewrite-analysis"
 rewrite-apache:
   artifactId: "rewrite-apache"
-  version: "2.28.0"
+  version: "2.29.0"
   markdownRecipeDescriptors:
     org.openrewrite.apache.commons.PreferJavaStandardLibrary:
       name: "org.openrewrite.apache.commons.PreferJavaStandardLibrary"
@@ -1120,7 +1120,7 @@ rewrite-apache:
       artifactId: "rewrite-apache"
 rewrite-cobol:
   artifactId: "rewrite-cobol"
-  version: "2.20.2"
+  version: "2.20.3"
   markdownRecipeDescriptors:
     org.openrewrite.cobol.cleanup.RemoveWithDebuggingMode:
       name: "org.openrewrite.cobol.cleanup.RemoveWithDebuggingMode"
@@ -1203,3533 +1203,9 @@ rewrite-cobol:
         required: true
       isImperative: true
       artifactId: "rewrite-cobol"
-rewrite-codemods:
-  artifactId: "rewrite-codemods"
-  version: "0.27.1"
-  markdownRecipeDescriptors:
-    org.openrewrite.codemods.ApplyCodemod:
-      name: "org.openrewrite.codemods.ApplyCodemod"
-      description: "Applies a codemod represented by an NPM package to all source\
-        \ files."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/applycodemod"
-      options:
-      - name: "codemodArgs"
-        type: "List"
-        required: false
-      - name: "executable"
-        type: "String"
-        required: false
-      - name: "fileFilter"
-        type: "String"
-        required: true
-      - name: "transform"
-        type: "String"
-        required: true
-      isImperative: true
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.Biome:
-      name: "org.openrewrite.codemods.Biome"
-      description: "Run [Biome](https://biomejs.dev/) recommended settings on your\
-        \ projects."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/biome"
-      options: []
-      isImperative: true
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ESLint:
-      name: "org.openrewrite.codemods.ESLint"
-      description: "Run [ESLint](https://eslint.org/) across the code to fix common\
-        \ static analysis issues in the code.\n\nThis requires the code to have an\
-        \ existing ESLint configuration."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/eslint"
-      options:
-      - name: "allowInlineConfig"
-        type: "Boolean"
-        required: false
-      - name: "configFile"
-        type: "String"
-        required: false
-      - name: "envs"
-        type: "List"
-        required: false
-      - name: "extend"
-        type: "List"
-        required: false
-      - name: "fix"
-        type: "Boolean"
-        required: false
-      - name: "globals"
-        type: "List"
-        required: false
-      - name: "parser"
-        type: "String"
-        required: false
-      - name: "parserOptions"
-        type: "List"
-        required: false
-      - name: "patterns"
-        type: "List"
-        required: false
-      - name: "plugins"
-        type: "List"
-        required: false
-      - name: "rules"
-        type: "List"
-        required: false
-      isImperative: true
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.Putout:
-      name: "org.openrewrite.codemods.Putout"
-      description: "Run [Putout](https://github.com/coderaiser/putout) on your projects."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/putout"
-      options:
-      - name: "printer"
-        type: "String"
-        required: false
-      - name: "rules"
-        type: "Set"
-        required: false
-      isImperative: true
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ReactI18Next:
-      name: "org.openrewrite.codemods.ReactI18Next"
-      description: "Automatically internationalizes React applications by extracting\
-        \ hardcoded strings and replacing them with [react-i18next](https://react.i18next.com)\
-        \ translation calls. Handles JSX text, attributes, and template literals with\
-        \ variables. Creates and updates a translation JSON file with extracted strings."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/reacti18next"
-      options:
-      - name: "filePattern"
-        type: "String"
-        required: false
-      - name: "importName"
-        type: "String"
-        required: true
-      - name: "parser"
-        type: "String"
-        required: false
-      - name: "translationFilePath"
-        type: "String"
-        required: false
-      - name: "translationRoot"
-        type: "String"
-        required: false
-      isImperative: true
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.UI5:
-      name: "org.openrewrite.codemods.UI5"
-      description: "Runs the [UI5 Linter](https://github.com/SAP/ui5-linter), a static\
-        \ code analysis tool for UI5 projects. It checks JavaScript, TypeScript, XML,\
-        \ JSON, and other files in your project and reports findings."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ui5"
-      options: []
-      isImperative: true
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.ArrowBodyStyle:
-      name: "org.openrewrite.codemods.cleanup.javascript.ArrowBodyStyle"
-      description: "Require braces around arrow function bodies\nSee [rule details](https://eslint.org/docs/latest/rules/arrow-body-style)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/arrowbodystyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.BetterRegex:
-      name: "org.openrewrite.codemods.cleanup.javascript.BetterRegex"
-      description: "Improve regexes by making them shorter, consistent, and safer.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/better-regex.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/betterregex"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.CapitalizedComments:
-      name: "org.openrewrite.codemods.cleanup.javascript.CapitalizedComments"
-      description: "Enforce or disallow capitalization of the first letter of a comment\
-        \ \nSee [rule details](https://eslint.org/docs/latest/rules/capitalized-comments)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/capitalizedcomments"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.CatchErrorName:
-      name: "org.openrewrite.codemods.cleanup.javascript.CatchErrorName"
-      description: "Enforce a specific parameter name in catch clauses.\nSee [rule\
-        \ details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/catch-error-name.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/catcherrorname"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.ConsistentDestructuring:
-      name: "org.openrewrite.codemods.cleanup.javascript.ConsistentDestructuring"
-      description: "Use destructured variables over properties.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/consistent-destructuring.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/consistentdestructuring"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.ConsistentTypeSpecifierStyle:
-      name: "org.openrewrite.codemods.cleanup.javascript.ConsistentTypeSpecifierStyle"
-      description: "Enforce or ban the use of inline type-only markers for named imports\n\
-        See rule details for [import/consistent-type-specifier-style](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/consistent-type-specifier-style.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/consistenttypespecifierstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.Curly:
-      name: "org.openrewrite.codemods.cleanup.javascript.Curly"
-      description: "Enforce consistent brace style for all control statements \nSee\
-        \ [rule details](https://eslint.org/docs/latest/rules/curly)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/curly"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.CustomErrorDefinition:
-      name: "org.openrewrite.codemods.cleanup.javascript.CustomErrorDefinition"
-      description: "Enforce correct `Error` subclassing.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/custom-error-definition.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/customerrordefinition"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.DotNotation:
-      name: "org.openrewrite.codemods.cleanup.javascript.DotNotation"
-      description: "Enforce dot notation whenever possible \nSee [rule details](https://eslint.org/docs/latest/rules/dot-notation)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/dotnotation"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.EmptyBraceSpaces:
-      name: "org.openrewrite.codemods.cleanup.javascript.EmptyBraceSpaces"
-      description: "Enforce no spaces between braces.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/empty-brace-spaces.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/emptybracespaces"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.Eqeqeq:
-      name: "org.openrewrite.codemods.cleanup.javascript.Eqeqeq"
-      description: "Require the use of `===` and `!==` \nSee [rule details](https://eslint.org/docs/latest/rules/eqeqeq)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/eqeqeq"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.EscapeCase:
-      name: "org.openrewrite.codemods.cleanup.javascript.EscapeCase"
-      description: "Require escape sequences to use uppercase values.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/escape-case.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/escapecase"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.ExplicitLengthCheck:
-      name: "org.openrewrite.codemods.cleanup.javascript.ExplicitLengthCheck"
-      description: "Enforce explicitly comparing the length or size property of a\
-        \ value.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/explicit-length-check.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/explicitlengthcheck"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.First:
-      name: "org.openrewrite.codemods.cleanup.javascript.First"
-      description: "Ensure all imports appear before other statements\nSee rule details\
-        \ for [import/first](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/first.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/first"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.LogicalAssignmentOperators:
-      name: "org.openrewrite.codemods.cleanup.javascript.LogicalAssignmentOperators"
-      description: "Require or disallow logical assignment operator shorthand \nSee\
-        \ [rule details](https://eslint.org/docs/latest/rules/logical-assignment-operators)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/logicalassignmentoperators"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.MultilineCommentStyle:
-      name: "org.openrewrite.codemods.cleanup.javascript.MultilineCommentStyle"
-      description: "Enforce a particular style for multiline comments \nSee [rule\
-        \ details](https://eslint.org/docs/latest/rules/multiline-comment-style)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/multilinecommentstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NewForBuiltins:
-      name: "org.openrewrite.codemods.cleanup.javascript.NewForBuiltins"
-      description: "Enforce the use of `new` for all builtins, except `String`, `Number`,\
-        \ `Boolean`, `Symbol`, and `BigInt`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/new-for-builtins.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/newforbuiltins"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NewlineAfterImport:
-      name: "org.openrewrite.codemods.cleanup.javascript.NewlineAfterImport"
-      description: "Enforce a newline after import statements\nSee rule details for\
-        \ [import/newline-after-import](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/newline-after-import.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/newlineafterimport"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoAbsolutePath:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoAbsolutePath"
-      description: "Forbid import of modules using absolute paths\nSee rule details\
-        \ for [import/no-absolute-path](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-absolute-path.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noabsolutepath"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoArrayForEach:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoArrayForEach"
-      description: "Prefer `for…of` over the `forEach` method.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-for-each.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noarrayforeach"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoArrayMethodThisArgument:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoArrayMethodThisArgument"
-      description: "Disallow using the `this` argument in array methods.\nSee [rule\
-        \ details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-method-this-argument.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noarraymethodthisargument"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoArrayPushPush:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoArrayPushPush"
-      description: "Enforce combining multiple `Array#push()` into one call.\nSee\
-        \ [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-array-push-push.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noarraypushpush"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoAwaitExpressionMember:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoAwaitExpressionMember"
-      description: "Disallow member access from `await` expression.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-await-expression-member.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noawaitexpressionmember"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoConsoleSpaces:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoConsoleSpaces"
-      description: "Do not use leading/trailing space between `console.log` parameters.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-console-spaces.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noconsolespaces"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoDivRegex:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoDivRegex"
-      description: "Disallow equal signs explicitly at the beginning of regular expressions\
-        \ \nSee [rule details](https://eslint.org/docs/latest/rules/no-div-regex)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nodivregex"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoDuplicates:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoDuplicates"
-      description: "Forbid repeated import of the same module in multiple places\n\
-        See rule details for [import/no-duplicates](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-duplicates.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noduplicates"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoElseReturn:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoElseReturn"
-      description: "Disallow else blocks after return statements in if statements\
-        \ \nSee [rule details](https://eslint.org/docs/latest/rules/no-else-return)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noelsereturn"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoEmptyNamedBlocks:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoEmptyNamedBlocks"
-      description: "Forbid empty named import\nSee rule details for [import/no-empty-named-blocks](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-empty-named-blocks.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noemptynamedblocks"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoExtraBind:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoExtraBind"
-      description: "Disallow unnecessary calls to `.bind()` \nSee [rule details](https://eslint.org/docs/latest/rules/no-extra-bind)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noextrabind"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoExtraLabel:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoExtraLabel"
-      description: "Disallow unnecessary labels \nSee [rule details](https://eslint.org/docs/latest/rules/no-extra-label)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noextralabel"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoForLoop:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoForLoop"
-      description: "Do not use a `for` loop that can be replaced with a `for-of` loop.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-for-loop.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noforloop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoHexEscape:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoHexEscape"
-      description: "Enforce the use of Unicode escapes instead of hexadecimal escapes.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-hex-escape.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nohexescape"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoImplicitCoercion:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoImplicitCoercion"
-      description: "Disallow shorthand type conversions \nSee [rule details](https://eslint.org/docs/latest/rules/no-implicit-coercion)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noimplicitcoercion"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoImportModuleExports:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoImportModuleExports"
-      description: "Forbid import statements with CommonJS module.exports\nSee rule\
-        \ details for [import/no-import-module-exports](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-import-module-exports.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noimportmoduleexports"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoInstanceofArray:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoInstanceofArray"
-      description: "Require `Array.isArray()` instead of `instanceof Array`.\nSee\
-        \ [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-instanceof-array.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noinstanceofarray"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoLonelyIf:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoLonelyIf"
-      description: "Disallow if statements as the only statement in else blocks \n\
-        See [rule details](https://eslint.org/docs/latest/rules/no-lonely-if)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nolonelyif"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoNamespace:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoNamespace"
-      description: "Forbid namespace (a.k.a. \"wildcard\" `*`) imports.\nSee rule\
-        \ details for [import/no-namespace](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-namespace.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nonamespace"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoNegatedCondition:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoNegatedCondition"
-      description: "Disallow negated conditions.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-negated-condition.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nonegatedcondition"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoNestedTernary:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoNestedTernary"
-      description: "Disallow nested ternary expressions.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-nested-ternary.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nonestedternary"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoNewArray:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoNewArray"
-      description: "Disallow `new Array()`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-array.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nonewarray"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoNewBuffer:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoNewBuffer"
-      description: "Enforce the use of `Buffer.from()` and `Buffer.alloc()` instead\
-        \ of the deprecated `new Buffer()`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-new-buffer.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nonewbuffer"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoNull:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoNull"
-      description: "Disallow the use of the `null` literal.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-null.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nonull"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoRelativePackages:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoRelativePackages"
-      description: "Forbid importing packages through relative paths\nSee rule details\
-        \ for [import/no-relative-packages](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-relative-packages.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/norelativepackages"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoStaticOnlyClass:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoStaticOnlyClass"
-      description: "Disallow classes that only have static members.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-static-only-class.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nostaticonlyclass"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoTypeofUndefined:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoTypeofUndefined"
-      description: "Disallow comparing `undefined` using `typeof`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-typeof-undefined.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/notypeofundefined"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUndefInit:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUndefInit"
-      description: "Disallow initializing variables to undefined \nSee [rule details](https://eslint.org/docs/latest/rules/no-undef-init)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/noundefinit"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUnnecessaryAwait:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUnnecessaryAwait"
-      description: "Disallow awaiting non-promise values.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unnecessary-await.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nounnecessaryawait"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUnneededTernary:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUnneededTernary"
-      description: "Disallow ternary operators when simpler alternatives exist \n\
-        See [rule details](https://eslint.org/docs/latest/rules/no-unneeded-ternary)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nounneededternary"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUnreadableArrayDestructuring:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUnreadableArrayDestructuring"
-      description: "Disallow unreadable array destructuring.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unreadable-array-destructuring.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nounreadablearraydestructuring"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessComputedKey:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessComputedKey"
-      description: "Disallow unnecessary computed property keys in objects and classes\
-        \ \nSee [rule details](https://eslint.org/docs/latest/rules/no-useless-computed-key)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselesscomputedkey"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessFallbackInSpread:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessFallbackInSpread"
-      description: "Disallow useless fallback when spreading in object literals.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-fallback-in-spread.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselessfallbackinspread"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessLengthCheck:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessLengthCheck"
-      description: "Disallow useless array `length` check.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-length-check.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselesslengthcheck"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessPathSegments:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessPathSegments"
-      description: "Forbid unnecessary path segments in import and require statements\n\
-        See rule details for [import/no-useless-path-segments](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/no-useless-path-segments.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselesspathsegments"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessPromiseResolveReject:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessPromiseResolveReject"
-      description: "Disallow returning/yielding `Promise.resolve()`/`reject()` in\
-        \ `async` functions or promise callbacks.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-promise-resolve-reject.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselesspromiseresolvereject"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessRename:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessRename"
-      description: "Disallow renaming import, export, and destructured assignments\
-        \ to the same name\nSee [rule details](https://eslint.org/docs/latest/rules/no-useless-rename)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselessrename"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessReturn:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessReturn"
-      description: "Disallow redundant return statements \nSee [rule details](https://eslint.org/docs/latest/rules/no-useless-return)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselessreturn"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessSpread:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessSpread"
-      description: "Disallow unnecessary spread.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-spread.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselessspread"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoUselessUndefined:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoUselessUndefined"
-      description: "Disallow useless `undefined`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-undefined.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nouselessundefined"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoVar:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoVar"
-      description: "Require `let` or `const` instead of `var` \nSee [rule details](https://eslint.org/docs/latest/rules/no-var)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/novar"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NoZeroFractions:
-      name: "org.openrewrite.codemods.cleanup.javascript.NoZeroFractions"
-      description: "Disallow number literals with zero fractions or dangling dots.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-zero-fractions.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/nozerofractions"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NumberLiteralCase:
-      name: "org.openrewrite.codemods.cleanup.javascript.NumberLiteralCase"
-      description: "Enforce proper case for numeric literals.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/number-literal-case.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/numberliteralcase"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.NumericSeparatorsStyle:
-      name: "org.openrewrite.codemods.cleanup.javascript.NumericSeparatorsStyle"
-      description: "Enforce the style of numeric separators by correctly grouping\
-        \ digits.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/numeric-separators-style.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/numericseparatorsstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.ObjectShorthand:
-      name: "org.openrewrite.codemods.cleanup.javascript.ObjectShorthand"
-      description: "Require or disallow method and property shorthand syntax for object\
-        \ literals \nSee [rule details](https://eslint.org/docs/latest/rules/object-shorthand)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/objectshorthand"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.OneVar:
-      name: "org.openrewrite.codemods.cleanup.javascript.OneVar"
-      description: "Enforce variables to be declared either together or separately\
-        \ in functions \nSee [rule details](https://eslint.org/docs/latest/rules/one-var)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/onevar"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.OperatorAssignment:
-      name: "org.openrewrite.codemods.cleanup.javascript.OperatorAssignment"
-      description: "Require or disallow assignment operator shorthand where possible\
-        \ \nSee [rule details](https://eslint.org/docs/latest/rules/operator-assignment)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/operatorassignment"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.Order:
-      name: "org.openrewrite.codemods.cleanup.javascript.Order"
-      description: "Enforce a convention in module import order\nSee rule details\
-        \ for [import/order](https://github.com/import-js/eslint-plugin-import/blob/HEAD/docs/rules/order.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/order"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferAddEventListener:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferAddEventListener"
-      description: "Prefer `.addEventListener()` and `.removeEventListener()` over\
-        \ on-functions.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-add-event-listener.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferaddeventlistener"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferArrayFind:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferArrayFind"
-      description: "Prefer `.find()` and `.findLast()` over the first or last element\
-        \ from `.filter()`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-find.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferarrayfind"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferArrayFlat:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferArrayFlat"
-      description: "Prefer `Array#flat()` over legacy techniques to flatten arrays.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferarrayflat"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferArrayFlatMap:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferArrayFlatMap"
-      description: "Prefer `.flatMap()` over `.map().flat()`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-flat-map.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferarrayflatmap"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferArrayIndexOf:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferArrayIndexOf"
-      description: "Prefer `Array#{indexOf,lastIndexOf}()` over `Array#{findIndex,findLastIndex}()`\
-        \ when looking for the index of an item.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-index-of.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferarrayindexof"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferArraySome:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferArraySome"
-      description: "Prefer `.some()` over `.filter().length` check and `.{find,findLast}()`.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-some.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferarraysome"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferArrowCallback:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferArrowCallback"
-      description: "Require using arrow functions for callbacks \nSee [rule details](https://eslint.org/docs/latest/rules/prefer-arrow-callback)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferarrowcallback"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferAt:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferAt"
-      description: "Prefer `.at()` method for index access and `String#charAt()`.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-at.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferat"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferConst:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferConst"
-      description: "Require const declarations for variables that are never reassigned\
-        \ after declared \nSee [rule details](https://eslint.org/docs/latest/rules/prefer-const)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferconst"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferDateNow:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferDateNow"
-      description: "Prefer `Date.now()` to get the number of milliseconds since the\
-        \ Unix Epoch.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-date-now.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferdatenow"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferDefaultParameters:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferDefaultParameters"
-      description: "Prefer default parameters over reassignment.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-default-parameters.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferdefaultparameters"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferDestructuring:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferDestructuring"
-      description: "Require destructuring from arrays and/or objects \nSee [rule details](https://eslint.org/docs/latest/rules/prefer-destructuring)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferdestructuring"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferDomNodeAppend:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferDomNodeAppend"
-      description: "Prefer `Node#append()` over `Node#appendChild()`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-append.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferdomnodeappend"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferDomNodeDataset:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferDomNodeDataset"
-      description: "Prefer using `.dataset` on DOM elements over calling attribute\
-        \ methods.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-dataset.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferdomnodedataset"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferDomNodeRemove:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferDomNodeRemove"
-      description: "Prefer `childNode.remove()` over `parentNode.removeChild(childNode)`.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-dom-node-remove.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferdomnoderemove"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferExponentiationOperator:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferExponentiationOperator"
-      description: "Disallow the use of `Math.pow` in favor of the ** operator \n\
-        See [rule details](https://eslint.org/docs/latest/rules/prefer-exponentiation-operator)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferexponentiationoperator"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferExportFrom:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferExportFrom"
-      description: "Prefer `export…from` when re-exporting.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-export-from.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferexportfrom"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferIncludes:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferIncludes"
-      description: "Prefer `.includes()` over `.indexOf()` and `Array#some()` when\
-        \ checking for existence or non-existence.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-includes.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferincludes"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferJsonParseBuffer:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferJsonParseBuffer"
-      description: "Prefer reading a JSON file as a buffer.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-json-parse-buffer.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferjsonparsebuffer"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferKeyboardEventKey:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferKeyboardEventKey"
-      description: "Prefer `KeyboardEvent#key` over `KeyboardEvent#keyCode`.\nSee\
-        \ [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-keyboard-event-key.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferkeyboardeventkey"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferMathTrunc:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferMathTrunc"
-      description: "Enforce the use of `Math.trunc()` instead of bitwise operators.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-math-trunc.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefermathtrunc"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferModernDomApis:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferModernDomApis"
-      description: "Prefer `.before()` over `.insertBefore()`, `.replaceWith()` over\
-        \ `.replaceChild()`, prefer one of `.before()`, `.after()`, `.append()` or\
-        \ `.prepend()` over `insertAdjacentText()` and `insertAdjacentElement()`.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-dom-apis.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefermoderndomapis"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferModernMathApis:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferModernMathApis"
-      description: "Prefer modern Math APIs over legacy patterns.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-modern-math-apis.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefermodernmathapis"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferModule:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferModule"
-      description: "Prefer JavaScript modules (ESM) over CommonJS.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-module.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefermodule"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferNativeCoercionFunctions:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferNativeCoercionFunctions"
-      description: "Prefer using `String`, `Number`, `BigInt`, `Boolean`, and `Symbol`\
-        \ directly.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-native-coercion-functions.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefernativecoercionfunctions"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferNegativeIndex:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferNegativeIndex"
-      description: "Prefer negative index over `.length - index` when possible.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-negative-index.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefernegativeindex"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferNodeProtocol:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferNodeProtocol"
-      description: "Prefer using the `node:` protocol when importing Node.js builtin\
-        \ modules.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefernodeprotocol"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferNumberProperties:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferNumberProperties"
-      description: "Prefer `Number` static properties over global ones.\nSee [rule\
-        \ details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-number-properties.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefernumberproperties"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferNumericLiterals:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferNumericLiterals"
-      description: "Disallow `parseInt()` and `Number.parseInt()` in favor of binary,\
-        \ octal, and hexadecimal literals \nSee [rule details](https://eslint.org/docs/latest/rules/prefer-numeric-literals)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefernumericliterals"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferObjectFromEntries:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferObjectFromEntries"
-      description: "Prefer using `Object.fromEntries()` to transform a list of key-value\
-        \ pairs into an object.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-object-from-entries.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferobjectfromentries"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferObjectHasOwn:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferObjectHasOwn"
-      description: "Disallow use of `Object.prototype.hasOwnProperty.call()` and prefer\
-        \ use of `Object.hasOwn(`) \nSee [rule details](https://eslint.org/docs/latest/rules/prefer-object-has-own)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferobjecthasown"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferObjectSpread:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferObjectSpread"
-      description: "Disallow using `Object.assign` with an object literal as the first\
-        \ argument and prefer the use of object spread instead \nSee [rule details](https://eslint.org/docs/latest/rules/prefer-object-spread)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferobjectspread"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferOptionalCatchBinding:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferOptionalCatchBinding"
-      description: "Prefer omitting the catch binding parameter.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-optional-catch-binding.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferoptionalcatchbinding"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferPrototypeMethods:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferPrototypeMethods"
-      description: "Prefer borrowing methods from the prototype instead of the instance.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-prototype-methods.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferprototypemethods"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferQuerySelector:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferQuerySelector"
-      description: "Prefer `.querySelector()` over `.getElementById()`, `.querySelectorAll()`\
-        \ over `.getElementsByClassName()` and `.getElementsByTagName()`.\nSee [rule\
-        \ details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-query-selector.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferqueryselector"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferReflectApply:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferReflectApply"
-      description: "Prefer `Reflect.apply()` over `Function#apply()`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-reflect-apply.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferreflectapply"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferRegexpTest:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferRegexpTest"
-      description: "Prefer `RegExp#test()` over `String#match()` and `RegExp#exec()`.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-regexp-test.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferregexptest"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferSetHas:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferSetHas"
-      description: "Prefer `Set#has()` over `Array#includes()` when checking for existence\
-        \ or non-existence.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-set-has.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefersethas"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferSetSize:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferSetSize"
-      description: "Prefer using `Set#size` instead of `Array#length`.\nSee [rule\
-        \ details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-set-size.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefersetsize"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferSpread:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferSpread"
-      description: "Prefer the spread operator over `Array.from()`, `Array#concat()`,\
-        \ `Array#{slice,toSpliced}()` and `String#split('')`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-spread.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferspread"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferStringReplaceAll:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferStringReplaceAll"
-      description: "Prefer `String#replaceAll()` over regex searches with the global\
-        \ flag.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-replace-all.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferstringreplaceall"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferStringSlice:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferStringSlice"
-      description: "Prefer `String#slice()` over `String#substr()` and `String#substring()`.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-slice.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferstringslice"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferStringStartsEndsWith:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferStringStartsEndsWith"
-      description: "Prefer `String#startsWith()` & `String#endsWith()` over `RegExp#test()`.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-starts-ends-with.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferstringstartsendswith"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferStringTrimStartEnd:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferStringTrimStartEnd"
-      description: "Prefer `String#trimStart()` / `String#trimEnd()` over `String#trimLeft()`\
-        \ / `String#trimRight()`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-string-trim-start-end.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferstringtrimstartend"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferSwitch:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferSwitch"
-      description: "Prefer `switch` over multiple `else-if`.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-switch.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferswitch"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferTemplate:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferTemplate"
-      description: "Require template literals instead of string concatenation \nSee\
-        \ [rule details](https://eslint.org/docs/latest/rules/prefer-template)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefertemplate"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferTernary:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferTernary"
-      description: "Prefer ternary expressions over simple `if-else` statements.\n\
-        See [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-ternary.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preferternary"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreferTypeError:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreferTypeError"
-      description: "Enforce throwing `TypeError` in type checking conditions.\nSee\
-        \ [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-type-error.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/prefertypeerror"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.PreventAbbreviations:
-      name: "org.openrewrite.codemods.cleanup.javascript.PreventAbbreviations"
-      description: "Prevent abbreviations.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prevent-abbreviations.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/preventabbreviations"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.RelativeUrlStyle:
-      name: "org.openrewrite.codemods.cleanup.javascript.RelativeUrlStyle"
-      description: "Enforce consistent relative URL style.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/relative-url-style.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/relativeurlstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.RequireArrayJoinSeparator:
-      name: "org.openrewrite.codemods.cleanup.javascript.RequireArrayJoinSeparator"
-      description: "Enforce using the separator argument with `Array#join()`.\nSee\
-        \ [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/require-array-join-separator.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/requirearrayjoinseparator"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.RequireNumberToFixedDigitsArgument:
-      name: "org.openrewrite.codemods.cleanup.javascript.RequireNumberToFixedDigitsArgument"
-      description: "Enforce using the digits argument with `Number#toFixed()`.\nSee\
-        \ [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/require-number-to-fixed-digits-argument.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/requirenumbertofixeddigitsargument"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.SortImports:
-      name: "org.openrewrite.codemods.cleanup.javascript.SortImports"
-      description: "Enforce sorted import declarations within modules \nSee [rule\
-        \ details](https://eslint.org/docs/latest/rules/sort-imports)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/sortimports"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.SortVars:
-      name: "org.openrewrite.codemods.cleanup.javascript.SortVars"
-      description: "Require variables within the same declaration block to be sorted\
-        \ \nSee [rule details](https://eslint.org/docs/latest/rules/sort-vars)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/sortvars"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.Strict:
-      name: "org.openrewrite.codemods.cleanup.javascript.Strict"
-      description: "Require or disallow strict mode directives \nSee [rule details](https://eslint.org/docs/latest/rules/strict)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/strict"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.StringContent:
-      name: "org.openrewrite.codemods.cleanup.javascript.StringContent"
-      description: "Enforce better string content.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/string-content.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/stringcontent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.SwitchCaseBraces:
-      name: "org.openrewrite.codemods.cleanup.javascript.SwitchCaseBraces"
-      description: "Enforce consistent brace style for case clauses.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/switch-case-braces.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/switchcasebraces"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.TemplateIndent:
-      name: "org.openrewrite.codemods.cleanup.javascript.TemplateIndent"
-      description: "Fix whitespace-insensitive template indentation.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/template-indent.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/templateindent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.TextEncodingIdentifierCase:
-      name: "org.openrewrite.codemods.cleanup.javascript.TextEncodingIdentifierCase"
-      description: "Enforce consistent case for text encoding identifiers.\nSee [rule\
-        \ details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/text-encoding-identifier-case.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/textencodingidentifiercase"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.ThrowNewError:
-      name: "org.openrewrite.codemods.cleanup.javascript.ThrowNewError"
-      description: "Require `new` when throwing an error.\nSee [rule details](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/throw-new-error.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/thrownewerror"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.UnicodeBom:
-      name: "org.openrewrite.codemods.cleanup.javascript.UnicodeBom"
-      description: "Require or disallow Unicode byte order mark (BOM) \nSee [rule\
-        \ details](https://eslint.org/docs/latest/rules/unicode-bom)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/unicodebom"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.javascript.Yoda:
-      name: "org.openrewrite.codemods.cleanup.javascript.Yoda"
-      description: "Require or disallow \"Yoda\" conditions\nSee [rule details](https://eslint.org/docs/latest/rules/yoda)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/javascript/yoda"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.ConsistentTestIt:
-      name: "org.openrewrite.codemods.cleanup.jest.ConsistentTestIt"
-      description: "Enforce test and it usage conventions\nSee rule details for [jest/consistent-test-it](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/consistent-test-it.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/consistenttestit"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.NoAliasMethods:
-      name: "org.openrewrite.codemods.cleanup.jest.NoAliasMethods"
-      description: "Disallow alias methods\nSee rule details for [jest/no-alias-methods](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-alias-methods.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/noaliasmethods"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.NoDeprecatedFunctions27:
-      name: "org.openrewrite.codemods.cleanup.jest.NoDeprecatedFunctions27"
-      description: "Disallow use of deprecated functions from before version 27\n\
-        See rule details for [jest/no-deprecated-functions](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-deprecated-functions.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/nodeprecatedfunctions27"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.NoJasmineGlobals:
-      name: "org.openrewrite.codemods.cleanup.jest.NoJasmineGlobals"
-      description: "Disallow Jasmine globals\nSee rule details for [jest/no-jasmine-globals](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-jasmine-globals.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/nojasmineglobals"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.NoTestPrefixes:
-      name: "org.openrewrite.codemods.cleanup.jest.NoTestPrefixes"
-      description: "Require using .only and .skip over f and x\nSee rule details for\
-        \ [jest/no-test-prefixes](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-test-prefixes.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/notestprefixes"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.NoUntypedMockFactory:
-      name: "org.openrewrite.codemods.cleanup.jest.NoUntypedMockFactory"
-      description: "Disallow using jest.mock() factories without an explicit type\
-        \ parameter\nSee rule details for [jest/no-untyped-mock-factory](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/no-untyped-mock-factory.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/nountypedmockfactory"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferComparisonMatcher:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferComparisonMatcher"
-      description: "Suggest using the built-in comparison matchers\nSee rule details\
-        \ for [jest/prefer-comparison-matcher](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-comparison-matcher.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/prefercomparisonmatcher"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferExpectResolves:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferExpectResolves"
-      description: "Prefer await expect(...).resolves over expect(await ...) syntax\n\
-        See rule details for [jest/prefer-expect-resolves](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-expect-resolves.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/preferexpectresolves"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferLowercaseTitle:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferLowercaseTitle"
-      description: "Enforce lowercase test names\nSee rule details for [jest/prefer-lowercase-title](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-lowercase-title.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/preferlowercasetitle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferMockPromiseShorthand:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferMockPromiseShorthand"
-      description: "Prefer mock resolved/rejected shorthands for promises\nSee rule\
-        \ details for [jest/prefer-mock-promise-shorthand](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-mock-promise-shorthand.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/prefermockpromiseshorthand"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferSpyOn:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferSpyOn"
-      description: "Suggest using jest.spyOn()\nSee rule details for [jest/prefer-spy-on](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-spy-on.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/preferspyon"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferToBe:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferToBe"
-      description: "Suggest using toBe() for primitive literals\nSee rule details\
-        \ for [jest/prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-to-be.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/prefertobe"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferToContain:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferToContain"
-      description: "Suggest using toContain()\nSee rule details for [jest/prefer-to-contain](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-to-contain.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/prefertocontain"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferToHaveLength:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferToHaveLength"
-      description: "Suggest using toHaveLength()\nSee rule details for [jest/prefer-to-have-length](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-to-have-length.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/prefertohavelength"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.PreferTodo:
-      name: "org.openrewrite.codemods.cleanup.jest.PreferTodo"
-      description: "Suggest using test.todo\nSee rule details for [jest/prefer-todo](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-todo.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/prefertodo"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.RecommendedJestCodeCleanup:
-      name: "org.openrewrite.codemods.cleanup.jest.RecommendedJestCodeCleanup"
-      description: "Collection of cleanup ESLint rules that are recommended by [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/recommendedjestcodecleanup"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.jest.ValidTitle:
-      name: "org.openrewrite.codemods.cleanup.jest.ValidTitle"
-      description: "Enforce valid titles\nSee rule details for [jest/valid-title](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/valid-title.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/jest/validtitle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.DestructuringAssignment:
-      name: "org.openrewrite.codemods.cleanup.react.DestructuringAssignment"
-      description: "Enforce consistent usage of destructuring assignment of props,\
-        \ state, and context\nSee rule details for [react/destructuring-assignment](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/destructuring-assignment.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/destructuringassignment"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.FunctionComponentDefinition:
-      name: "org.openrewrite.codemods.cleanup.react.FunctionComponentDefinition"
-      description: "Enforce a specific function type for function components\nSee\
-        \ rule details for [react/function-component-definition](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/function-component-definition.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/functioncomponentdefinition"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxBooleanValue:
-      name: "org.openrewrite.codemods.cleanup.react.JsxBooleanValue"
-      description: "Enforce boolean attributes notation in JSX\nSee rule details for\
-        \ [react/jsx-boolean-value](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-boolean-value.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxbooleanvalue"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxClosingBracketLocation:
-      name: "org.openrewrite.codemods.cleanup.react.JsxClosingBracketLocation"
-      description: "Enforce closing bracket location in JSX\nSee rule details for\
-        \ [react/jsx-closing-bracket-location](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-closing-bracket-location.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxclosingbracketlocation"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxClosingTagLocation:
-      name: "org.openrewrite.codemods.cleanup.react.JsxClosingTagLocation"
-      description: "Enforce closing tag location for multiline JSX\nSee rule details\
-        \ for [react/jsx-closing-tag-location](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-closing-tag-location.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxclosingtaglocation"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxCurlyBracePresence:
-      name: "org.openrewrite.codemods.cleanup.react.JsxCurlyBracePresence"
-      description: "Disallow unnecessary JSX expressions when literals alone are sufficient\
-        \ or enforce JSX expressions on literals in JSX children or attributes\nSee\
-        \ rule details for [react/jsx-curly-brace-presence](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-curly-brace-presence.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxcurlybracepresence"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxCurlyNewline:
-      name: "org.openrewrite.codemods.cleanup.react.JsxCurlyNewline"
-      description: "Enforce consistent linebreaks in curly braces in JSX attributes\
-        \ and expressions\nSee rule details for [react/jsx-curly-newline](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-curly-newline.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxcurlynewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxCurlySpacing:
-      name: "org.openrewrite.codemods.cleanup.react.JsxCurlySpacing"
-      description: "Enforce or disallow spaces inside of curly braces in JSX attributes\
-        \ and expressions\nSee rule details for [react/jsx-curly-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-curly-spacing.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxcurlyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxEqualsSpacing:
-      name: "org.openrewrite.codemods.cleanup.react.JsxEqualsSpacing"
-      description: "Enforce or disallow spaces around equal signs in JSX attributes\n\
-        See rule details for [react/jsx-equals-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-equals-spacing.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxequalsspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxFirstPropNewLine:
-      name: "org.openrewrite.codemods.cleanup.react.JsxFirstPropNewLine"
-      description: "Enforce proper position of the first property in JSX\nSee rule\
-        \ details for [react/jsx-first-prop-new-line](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-first-prop-new-line.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxfirstpropnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxFragments:
-      name: "org.openrewrite.codemods.cleanup.react.JsxFragments"
-      description: "Enforce shorthand or standard form for React fragments\nSee rule\
-        \ details for [react/jsx-fragments](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-fragments.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxfragments"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxIndent:
-      name: "org.openrewrite.codemods.cleanup.react.JsxIndent"
-      description: "Enforce JSX indentation\nSee rule details for [react/jsx-indent](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-indent.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxindent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxIndentProps:
-      name: "org.openrewrite.codemods.cleanup.react.JsxIndentProps"
-      description: "Enforce props indentation in JSX\nSee rule details for [react/jsx-indent-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-indent-props.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxindentprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxMaxPropsPerLine:
-      name: "org.openrewrite.codemods.cleanup.react.JsxMaxPropsPerLine"
-      description: "Enforce maximum of props on a single line in JSX\nSee rule details\
-        \ for [react/jsx-max-props-per-line](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-max-props-per-line.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxmaxpropsperline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxNewline:
-      name: "org.openrewrite.codemods.cleanup.react.JsxNewline"
-      description: "Require or prevent a new line after jsx elements and expressions\n\
-        See rule details for [react/jsx-newline](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-newline.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxNoLeakedRender:
-      name: "org.openrewrite.codemods.cleanup.react.JsxNoLeakedRender"
-      description: "Disallow problematic leaked values from being rendered\nSee rule\
-        \ details for [react/jsx-no-leaked-render](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-no-leaked-render.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxnoleakedrender"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxNoTargetBlank:
-      name: "org.openrewrite.codemods.cleanup.react.JsxNoTargetBlank"
-      description: "Disallow target=\"_blank\" attribute without rel=\"noreferrer\"\
-        \nSee rule details for [react/jsx-no-target-blank](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-no-target-blank.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxnotargetblank"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxNoUselessFragment:
-      name: "org.openrewrite.codemods.cleanup.react.JsxNoUselessFragment"
-      description: "Disallow unnecessary fragments\nSee rule details for [react/jsx-no-useless-fragment](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-no-useless-fragment.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxnouselessfragment"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxOneExpressionPerLine:
-      name: "org.openrewrite.codemods.cleanup.react.JsxOneExpressionPerLine"
-      description: "Require one JSX element per line\nSee rule details for [react/jsx-one-expression-per-line](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-one-expression-per-line.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxoneexpressionperline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxPropsNoMultiSpaces:
-      name: "org.openrewrite.codemods.cleanup.react.JsxPropsNoMultiSpaces"
-      description: "Disallow multiple spaces between inline JSX props\nSee rule details\
-        \ for [react/jsx-props-no-multi-spaces](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-props-no-multi-spaces.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxpropsnomultispaces"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxSortProps:
-      name: "org.openrewrite.codemods.cleanup.react.JsxSortProps"
-      description: "Enforce props alphabetical sorting\nSee rule details for [react/jsx-sort-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-sort-props.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxsortprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxSpaceBeforeClosing:
-      name: "org.openrewrite.codemods.cleanup.react.JsxSpaceBeforeClosing"
-      description: "Enforce spacing before closing bracket in JSX\nSee rule details\
-        \ for [react/jsx-space-before-closing](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-space-before-closing.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxspacebeforeclosing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxTagSpacing:
-      name: "org.openrewrite.codemods.cleanup.react.JsxTagSpacing"
-      description: "Enforce whitespace in and around the JSX opening and closing brackets\n\
-        See rule details for [react/jsx-tag-spacing](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-tag-spacing.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxtagspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.JsxWrapMultilines:
-      name: "org.openrewrite.codemods.cleanup.react.JsxWrapMultilines"
-      description: "Disallow missing parentheses around multiline JSX\nSee rule details\
-        \ for [react/jsx-wrap-multilines](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/jsx-wrap-multilines.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/jsxwrapmultilines"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.NoArrowFunctionLifecycle:
-      name: "org.openrewrite.codemods.cleanup.react.NoArrowFunctionLifecycle"
-      description: "Lifecycle methods should be methods on the prototype, not class\
-        \ fields\nSee rule details for [react/no-arrow-function-lifecycle](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/no-arrow-function-lifecycle.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/noarrowfunctionlifecycle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.NoUnknownProperty:
-      name: "org.openrewrite.codemods.cleanup.react.NoUnknownProperty"
-      description: "Disallow usage of unknown DOM property\nSee rule details for [react/no-unknown-property](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/no-unknown-property.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/nounknownproperty"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.PreferReadOnlyProps:
-      name: "org.openrewrite.codemods.cleanup.react.PreferReadOnlyProps"
-      description: "Enforce that props are read-only\nSee rule details for [react/prefer-read-only-props](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/prefer-read-only-props.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/preferreadonlyprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.SelfClosingComp:
-      name: "org.openrewrite.codemods.cleanup.react.SelfClosingComp"
-      description: "Disallow extra closing tags for components without children\n\
-        See rule details for [react/self-closing-comp](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/self-closing-comp.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/selfclosingcomp"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.react.SortPropTypes:
-      name: "org.openrewrite.codemods.cleanup.react.SortPropTypes"
-      description: "Enforce propTypes declarations alphabetical sorting\nSee rule\
-        \ details for [react/sort-prop-types](https://github.com/jsx-eslint/eslint-plugin-react/blob/HEAD/docs/rules/sort-prop-types.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/react/sortproptypes"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.AwaitInteractions:
-      name: "org.openrewrite.codemods.cleanup.storybook.AwaitInteractions"
-      description: "Interactions should be awaited\nSee rule details for [storybook/await-interactions](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/await-interactions.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/awaitinteractions"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.DefaultExports:
-      name: "org.openrewrite.codemods.cleanup.storybook.DefaultExports"
-      description: "Story files should have a default export\nSee rule details for\
-        \ [storybook/default-exports](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/default-exports.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/defaultexports"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.HierarchySeparator:
-      name: "org.openrewrite.codemods.cleanup.storybook.HierarchySeparator"
-      description: "Deprecated hierarchy separator in title property\nSee rule details\
-        \ for [storybook/hierarchy-separator](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/hierarchy-separator.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/hierarchyseparator"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.NoRedundantStoryName:
-      name: "org.openrewrite.codemods.cleanup.storybook.NoRedundantStoryName"
-      description: "A story should not have a redundant name property\nSee rule details\
-        \ for [storybook/no-redundant-story-name](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/no-redundant-story-name.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/noredundantstoryname"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.NoTitlePropertyInMeta:
-      name: "org.openrewrite.codemods.cleanup.storybook.NoTitlePropertyInMeta"
-      description: "Do not define a title in meta\nSee rule details for [storybook/no-title-property-in-meta](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/no-title-property-in-meta.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/notitlepropertyinmeta"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.PreferPascalCase:
-      name: "org.openrewrite.codemods.cleanup.storybook.PreferPascalCase"
-      description: "Stories should use PascalCase\nSee rule details for [storybook/prefer-pascal-case](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/prefer-pascal-case.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/preferpascalcase"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.RecommendedStorybookCodeCleanup:
-      name: "org.openrewrite.codemods.cleanup.storybook.RecommendedStorybookCodeCleanup"
-      description: "Collection of cleanup ESLint rules from [eslint-plugin-storybook](https://github.com/storybookjs/eslint-plugin-storybook#readme)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/recommendedstorybookcodecleanup"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.UseStorybookExpect:
-      name: "org.openrewrite.codemods.cleanup.storybook.UseStorybookExpect"
-      description: "Use expect from @storybook/jest\nSee rule details for [storybook/use-storybook-expect](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/use-storybook-expect.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/usestorybookexpect"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.storybook.UseStorybookTestingLibrary:
-      name: "org.openrewrite.codemods.cleanup.storybook.UseStorybookTestingLibrary"
-      description: "Do not use testing-library directly on stories\nSee rule details\
-        \ for [storybook/use-storybook-testing-library](https://github.com/storybookjs/eslint-plugin-storybook/blob/main/docs/rules/use-storybook-testing-library.md)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/storybook/usestorybooktestinglibrary"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.FirstAttributeLinebreak:
-      name: "org.openrewrite.codemods.cleanup.svelte.FirstAttributeLinebreak"
-      description: "Enforce the location of first attribute\nSee rule details for\
-        \ [svelte/first-attribute-linebreak](https://sveltejs.github.io/eslint-plugin-svelte/rules/first-attribute-linebreak/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/firstattributelinebreak"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.HtmlClosingBracketSpacing:
-      name: "org.openrewrite.codemods.cleanup.svelte.HtmlClosingBracketSpacing"
-      description: "Require or disallow a space before tag's closing brackets\nSee\
-        \ rule details for [svelte/html-closing-bracket-spacing](https://sveltejs.github.io/eslint-plugin-svelte/rules/html-closing-bracket-spacing/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/htmlclosingbracketspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.HtmlQuotes:
-      name: "org.openrewrite.codemods.cleanup.svelte.HtmlQuotes"
-      description: "Enforce quotes style of HTML attributes\nSee rule details for\
-        \ [svelte/html-quotes](https://sveltejs.github.io/eslint-plugin-svelte/rules/html-quotes/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/htmlquotes"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.HtmlSelfClosing:
-      name: "org.openrewrite.codemods.cleanup.svelte.HtmlSelfClosing"
-      description: "Enforce self-closing style\nSee rule details for [svelte/html-self-closing](https://sveltejs.github.io/eslint-plugin-svelte/rules/html-self-closing/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/htmlselfclosing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.Indent:
-      name: "org.openrewrite.codemods.cleanup.svelte.Indent"
-      description: "Enforce consistent indentation\nSee rule details for [svelte/indent](https://sveltejs.github.io/eslint-plugin-svelte/rules/indent/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/indent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.MaxAttributesPerLine:
-      name: "org.openrewrite.codemods.cleanup.svelte.MaxAttributesPerLine"
-      description: "Enforce the maximum number of attributes per line\nSee rule details\
-        \ for [svelte/max-attributes-per-line](https://sveltejs.github.io/eslint-plugin-svelte/rules/max-attributes-per-line/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/maxattributesperline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.MustacheSpacing:
-      name: "org.openrewrite.codemods.cleanup.svelte.MustacheSpacing"
-      description: "Enforce unified spacing in mustache\nSee rule details for [svelte/mustache-spacing](https://sveltejs.github.io/eslint-plugin-svelte/rules/mustache-spacing/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/mustachespacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.NoDynamicSlotName:
-      name: "org.openrewrite.codemods.cleanup.svelte.NoDynamicSlotName"
-      description: "Disallow dynamic slot name\nSee rule details for [svelte/no-dynamic-slot-name](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-dynamic-slot-name/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/nodynamicslotname"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.NoSpacesAroundEqualSignsInAttribute:
-      name: "org.openrewrite.codemods.cleanup.svelte.NoSpacesAroundEqualSignsInAttribute"
-      description: "Disallow spaces around equal signs in attribute\nSee rule details\
-        \ for [svelte/no-spaces-around-equal-signs-in-attribute](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-spaces-around-equal-signs-in-attribute/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/nospacesaroundequalsignsinattribute"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.NoUselessMustaches:
-      name: "org.openrewrite.codemods.cleanup.svelte.NoUselessMustaches"
-      description: "Disallow unnecessary mustache interpolations\nSee rule details\
-        \ for [svelte/no-useless-mustaches](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-useless-mustaches/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/nouselessmustaches"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.PreferClassDirective:
-      name: "org.openrewrite.codemods.cleanup.svelte.PreferClassDirective"
-      description: "Require class directives instead of ternary expressions\nSee rule\
-        \ details for [svelte/prefer-class-directive](https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-class-directive/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/preferclassdirective"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.PreferStyleDirective:
-      name: "org.openrewrite.codemods.cleanup.svelte.PreferStyleDirective"
-      description: "Require style directives instead of style attribute\nSee rule\
-        \ details for [svelte/prefer-style-directive](https://sveltejs.github.io/eslint-plugin-svelte/rules/prefer-style-directive/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/preferstyledirective"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.RecommendedsvelteCodeCleanup:
-      name: "org.openrewrite.codemods.cleanup.svelte.RecommendedsvelteCodeCleanup"
-      description: "Collection of cleanup ESLint rules from [eslint-plugin-svelte](https://github.com/sveltejs/eslint-plugin-svelte)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/recommendedsveltecodecleanup"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.RequireStoreReactiveAccess:
-      name: "org.openrewrite.codemods.cleanup.svelte.RequireStoreReactiveAccess"
-      description: "Disallow to use of the store itself as an operand. Need to use\
-        \ $ prefix or get function.\nSee rule details for [svelte/require-store-reactive-access](https://sveltejs.github.io/eslint-plugin-svelte/rules/require-store-reactive-access/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/requirestorereactiveaccess"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.ShorthandAttribute:
-      name: "org.openrewrite.codemods.cleanup.svelte.ShorthandAttribute"
-      description: "Enforce use of shorthand syntax in attribute\nSee rule details\
-        \ for [svelte/shorthand-attribute](https://sveltejs.github.io/eslint-plugin-svelte/rules/shorthand-attribute/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/shorthandattribute"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.ShorthandDirective:
-      name: "org.openrewrite.codemods.cleanup.svelte.ShorthandDirective"
-      description: "Enforce use of shorthand syntax in directives\nSee rule details\
-        \ for [svelte/shorthand-directive](https://sveltejs.github.io/eslint-plugin-svelte/rules/shorthand-directive/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/shorthanddirective"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.SortAttributes:
-      name: "org.openrewrite.codemods.cleanup.svelte.SortAttributes"
-      description: "Enforce order of attributes\nSee rule details for [svelte/sort-attributes](https://sveltejs.github.io/eslint-plugin-svelte/rules/sort-attributes/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/sortattributes"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.svelte.SpacedHtmlComment:
-      name: "org.openrewrite.codemods.cleanup.svelte.SpacedHtmlComment"
-      description: "Enforce consistent spacing after the <!-- and before the --> in\
-        \ a HTML comment\nSee rule details for [svelte/spaced-html-comment](https://sveltejs.github.io/eslint-plugin-svelte/rules/spaced-html-comment/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/svelte/spacedhtmlcomment"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ArrayBracketNewline:
-      name: "org.openrewrite.codemods.cleanup.vue.ArrayBracketNewline"
-      description: "Enforce linebreaks after opening and before closing array brackets\
-        \ in `<template>`\nSee rule details for [vue/array-bracket-newline](https://eslint.vuejs.org/rules/array-bracket-newline.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/arraybracketnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ArrayBracketSpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.ArrayBracketSpacing"
-      description: "Enforce consistent spacing inside array brackets in `<template>`\n\
-        See rule details for [vue/array-bracket-spacing](https://eslint.vuejs.org/rules/array-bracket-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/arraybracketspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ArrayElementNewline:
-      name: "org.openrewrite.codemods.cleanup.vue.ArrayElementNewline"
-      description: "Enforce line breaks after each array element in `<template>`\n\
-        See rule details for [vue/array-element-newline](https://eslint.vuejs.org/rules/array-element-newline.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/arrayelementnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ArrowSpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.ArrowSpacing"
-      description: "Enforce consistent spacing before and after the arrow in arrow\
-        \ functions in `<template>`\nSee rule details for [vue/arrow-spacing](https://eslint.vuejs.org/rules/arrow-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/arrowspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.AttributesOrder:
-      name: "org.openrewrite.codemods.cleanup.vue.AttributesOrder"
-      description: "Enforce order of attributes\nSee rule details for [vue/attributes-order](https://eslint.vuejs.org/rules/attributes-order.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/attributesorder"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.BlockOrder:
-      name: "org.openrewrite.codemods.cleanup.vue.BlockOrder"
-      description: "Enforce order of component top-level elements\nSee rule details\
-        \ for [vue/block-order](https://eslint.vuejs.org/rules/block-order.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/blockorder"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.BlockSpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.BlockSpacing"
-      description: "Disallow or enforce spaces inside of blocks after opening block\
-        \ and before closing block in `<template>`\nSee rule details for [vue/block-spacing](https://eslint.vuejs.org/rules/block-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/blockspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.BlockTagNewline:
-      name: "org.openrewrite.codemods.cleanup.vue.BlockTagNewline"
-      description: "Enforce line breaks after opening and before closing block-level\
-        \ tags\nSee rule details for [vue/block-tag-newline](https://eslint.vuejs.org/rules/block-tag-newline.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/blocktagnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.BraceStyle:
-      name: "org.openrewrite.codemods.cleanup.vue.BraceStyle"
-      description: "Enforce consistent brace style for blocks in `<template>`\nSee\
-        \ rule details for [vue/brace-style](https://eslint.vuejs.org/rules/brace-style.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/bracestyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.CommaDangle:
-      name: "org.openrewrite.codemods.cleanup.vue.CommaDangle"
-      description: "Require or disallow trailing commas in `<template>`\nSee rule\
-        \ details for [vue/comma-dangle](https://eslint.vuejs.org/rules/comma-dangle.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/commadangle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.CommaSpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.CommaSpacing"
-      description: "Enforce consistent spacing before and after commas in `<template>`\n\
-        See rule details for [vue/comma-spacing](https://eslint.vuejs.org/rules/comma-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/commaspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.CommaStyle:
-      name: "org.openrewrite.codemods.cleanup.vue.CommaStyle"
-      description: "Enforce consistent comma style in `<template>`\nSee rule details\
-        \ for [vue/comma-style](https://eslint.vuejs.org/rules/comma-style.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/commastyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ComponentNameInTemplateCasing:
-      name: "org.openrewrite.codemods.cleanup.vue.ComponentNameInTemplateCasing"
-      description: "Enforce specific casing for the component naming style in template\n\
-        See rule details for [vue/component-name-in-template-casing](https://eslint.vuejs.org/rules/component-name-in-template-casing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/componentnameintemplatecasing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ComponentOptionsNameCasing:
-      name: "org.openrewrite.codemods.cleanup.vue.ComponentOptionsNameCasing"
-      description: "Enforce the casing of component name in components options\nSee\
-        \ rule details for [vue/component-options-name-casing](https://eslint.vuejs.org/rules/component-options-name-casing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/componentoptionsnamecasing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ComponentTagsOrder:
-      name: "org.openrewrite.codemods.cleanup.vue.ComponentTagsOrder"
-      description: "Enforce order of component top-level elements\nSee rule details\
-        \ for [vue/component-tags-order](https://eslint.vuejs.org/rules/component-tags-order.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/componenttagsorder"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.DefineMacrosOrder:
-      name: "org.openrewrite.codemods.cleanup.vue.DefineMacrosOrder"
-      description: "Enforce order of defineEmits and defineProps compiler macros\n\
-        See rule details for [vue/define-macros-order](https://eslint.vuejs.org/rules/define-macros-order.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/definemacrosorder"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.DotLocation:
-      name: "org.openrewrite.codemods.cleanup.vue.DotLocation"
-      description: "Enforce consistent newlines before and after dots in `<template>`\n\
-        See rule details for [vue/dot-location](https://eslint.vuejs.org/rules/dot-location.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/dotlocation"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.DotNotation:
-      name: "org.openrewrite.codemods.cleanup.vue.DotNotation"
-      description: "Enforce dot notation whenever possible in `<template>`\nSee rule\
-        \ details for [vue/dot-notation](https://eslint.vuejs.org/rules/dot-notation.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/dotnotation"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.Eqeqeq:
-      name: "org.openrewrite.codemods.cleanup.vue.Eqeqeq"
-      description: "Require the use of === and !== in `<template>`\nSee rule details\
-        \ for [vue/eqeqeq](https://eslint.vuejs.org/rules/eqeqeq.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/eqeqeq"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.FuncCallSpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.FuncCallSpacing"
-      description: "Require or disallow spacing between function identifiers and their\
-        \ invocations in `<template>`\nSee rule details for [vue/func-call-spacing](https://eslint.vuejs.org/rules/func-call-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/funccallspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.HtmlCommentContentNewline:
-      name: "org.openrewrite.codemods.cleanup.vue.HtmlCommentContentNewline"
-      description: "Enforce unified line brake in HTML comments\nSee rule details\
-        \ for [vue/html-comment-content-newline](https://eslint.vuejs.org/rules/html-comment-content-newline.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/htmlcommentcontentnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.HtmlCommentContentSpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.HtmlCommentContentSpacing"
-      description: "Enforce unified spacing in HTML comments\nSee rule details for\
-        \ [vue/html-comment-content-spacing](https://eslint.vuejs.org/rules/html-comment-content-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/htmlcommentcontentspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.HtmlCommentIndent:
-      name: "org.openrewrite.codemods.cleanup.vue.HtmlCommentIndent"
-      description: "Enforce consistent indentation in HTML comments\nSee rule details\
-        \ for [vue/html-comment-indent](https://eslint.vuejs.org/rules/html-comment-indent.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/htmlcommentindent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.KeySpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.KeySpacing"
-      description: "Enforce consistent spacing between keys and values in object literal\
-        \ properties in `<template>`\nSee rule details for [vue/key-spacing](https://eslint.vuejs.org/rules/key-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/keyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.KeywordSpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.KeywordSpacing"
-      description: "Enforce consistent spacing before and after keywords in `<template>`\n\
-        See rule details for [vue/keyword-spacing](https://eslint.vuejs.org/rules/keyword-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/keywordspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.MultilineTernary:
-      name: "org.openrewrite.codemods.cleanup.vue.MultilineTernary"
-      description: "Enforce newlines between operands of ternary expressions in `<template>`\n\
-        See rule details for [vue/multiline-ternary](https://eslint.vuejs.org/rules/multiline-ternary.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/multilineternary"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.NewLineBetweenMultiLineProperty:
-      name: "org.openrewrite.codemods.cleanup.vue.NewLineBetweenMultiLineProperty"
-      description: "Enforce new lines between multi-line properties in Vue components\n\
-        See rule details for [vue/new-line-between-multi-line-property](https://eslint.vuejs.org/rules/new-line-between-multi-line-property.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/newlinebetweenmultilineproperty"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.NextTickStyle:
-      name: "org.openrewrite.codemods.cleanup.vue.NextTickStyle"
-      description: "Enforce Promise or callback style in nextTick\nSee rule details\
-        \ for [vue/next-tick-style](https://eslint.vuejs.org/rules/next-tick-style.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/nexttickstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.NoExtraParens:
-      name: "org.openrewrite.codemods.cleanup.vue.NoExtraParens"
-      description: "Disallow unnecessary parentheses in `<template>`\nSee rule details\
-        \ for [vue/no-extra-parens](https://eslint.vuejs.org/rules/no-extra-parens.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/noextraparens"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.NoRequiredPropWithDefault:
-      name: "org.openrewrite.codemods.cleanup.vue.NoRequiredPropWithDefault"
-      description: "Enforce props with default values to be optional\nSee rule details\
-        \ for [vue/no-required-prop-with-default](https://eslint.vuejs.org/rules/no-required-prop-with-default.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/norequiredpropwithdefault"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.NoUnsupportedFeatures:
-      name: "org.openrewrite.codemods.cleanup.vue.NoUnsupportedFeatures"
-      description: "Disallow unsupported Vue.js syntax on the specified version\n\
-        See rule details for [vue/no-unsupported-features](https://eslint.vuejs.org/rules/no-unsupported-features.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/nounsupportedfeatures"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.NoUselessMustaches:
-      name: "org.openrewrite.codemods.cleanup.vue.NoUselessMustaches"
-      description: "Disallow unnecessary mustache interpolations\nSee rule details\
-        \ for [vue/no-useless-mustaches](https://eslint.vuejs.org/rules/no-useless-mustaches.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/nouselessmustaches"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.NoUselessVBind:
-      name: "org.openrewrite.codemods.cleanup.vue.NoUselessVBind"
-      description: "Disallow unnecessary v-bind directives\nSee rule details for [vue/no-useless-v-bind](https://eslint.vuejs.org/rules/no-useless-v-bind.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/nouselessvbind"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ObjectCurlyNewline:
-      name: "org.openrewrite.codemods.cleanup.vue.ObjectCurlyNewline"
-      description: "Enforce consistent line breaks after opening and before closing\
-        \ braces in `<template>`\nSee rule details for [vue/object-curly-newline](https://eslint.vuejs.org/rules/object-curly-newline.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/objectcurlynewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ObjectCurlySpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.ObjectCurlySpacing"
-      description: "Enforce consistent spacing inside braces in `<template>`\nSee\
-        \ rule details for [vue/object-curly-spacing](https://eslint.vuejs.org/rules/object-curly-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/objectcurlyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ObjectPropertyNewline:
-      name: "org.openrewrite.codemods.cleanup.vue.ObjectPropertyNewline"
-      description: "Enforce placing object properties on separate lines in `<template>`\n\
-        See rule details for [vue/object-property-newline](https://eslint.vuejs.org/rules/object-property-newline.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/objectpropertynewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ObjectShorthand:
-      name: "org.openrewrite.codemods.cleanup.vue.ObjectShorthand"
-      description: "Require or disallow method and property shorthand syntax for object\
-        \ literals in `<template>`\nSee rule details for [vue/object-shorthand](https://eslint.vuejs.org/rules/object-shorthand.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/objectshorthand"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.OperatorLinebreak:
-      name: "org.openrewrite.codemods.cleanup.vue.OperatorLinebreak"
-      description: "Enforce consistent linebreak style for operators in `<template>`\n\
-        See rule details for [vue/operator-linebreak](https://eslint.vuejs.org/rules/operator-linebreak.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/operatorlinebreak"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.OrderInComponents:
-      name: "org.openrewrite.codemods.cleanup.vue.OrderInComponents"
-      description: "Enforce order of properties in components\nSee rule details for\
-        \ [vue/order-in-components](https://eslint.vuejs.org/rules/order-in-components.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/orderincomponents"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.PaddingLineBetweenBlocks:
-      name: "org.openrewrite.codemods.cleanup.vue.PaddingLineBetweenBlocks"
-      description: "Require or disallow padding lines between blocks\nSee rule details\
-        \ for [vue/padding-line-between-blocks](https://eslint.vuejs.org/rules/padding-line-between-blocks.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/paddinglinebetweenblocks"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.PaddingLineBetweenTags:
-      name: "org.openrewrite.codemods.cleanup.vue.PaddingLineBetweenTags"
-      description: "Require or disallow newlines between sibling tags in template\n\
-        See rule details for [vue/padding-line-between-tags](https://eslint.vuejs.org/rules/padding-line-between-tags.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/paddinglinebetweentags"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.PaddingLinesInComponentDefinition:
-      name: "org.openrewrite.codemods.cleanup.vue.PaddingLinesInComponentDefinition"
-      description: "Require or disallow padding lines in component definition\nSee\
-        \ rule details for [vue/padding-lines-in-component-definition](https://eslint.vuejs.org/rules/padding-lines-in-component-definition.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/paddinglinesincomponentdefinition"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.PreferDefineOptions:
-      name: "org.openrewrite.codemods.cleanup.vue.PreferDefineOptions"
-      description: "Enforce use of defineOptions instead of default export.\nSee rule\
-        \ details for [vue/prefer-define-options](https://eslint.vuejs.org/rules/prefer-define-options.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/preferdefineoptions"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.PreferSeparateStaticClass:
-      name: "org.openrewrite.codemods.cleanup.vue.PreferSeparateStaticClass"
-      description: "Require static class names in template to be in a separate class\
-        \ attribute\nSee rule details for [vue/prefer-separate-static-class](https://eslint.vuejs.org/rules/prefer-separate-static-class.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/preferseparatestaticclass"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.PreferTemplate:
-      name: "org.openrewrite.codemods.cleanup.vue.PreferTemplate"
-      description: "Require template literals instead of string concatenation in `<template>`\n\
-        See rule details for [vue/prefer-template](https://eslint.vuejs.org/rules/prefer-template.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/prefertemplate"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.QuoteProps:
-      name: "org.openrewrite.codemods.cleanup.vue.QuoteProps"
-      description: "Require quotes around object literal property names in `<template>`\n\
-        See rule details for [vue/quote-props](https://eslint.vuejs.org/rules/quote-props.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/quoteprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.RecommendedVueCodeCleanup:
-      name: "org.openrewrite.codemods.cleanup.vue.RecommendedVueCodeCleanup"
-      description: "Collection of cleanup ESLint rules from [eslint-plugin-vue](https://eslint.vuejs.org/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/recommendedvuecodecleanup"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ScriptIndent:
-      name: "org.openrewrite.codemods.cleanup.vue.ScriptIndent"
-      description: "Enforce consistent indentation in `<script>`\nSee rule details\
-        \ for [vue/script-indent](https://eslint.vuejs.org/rules/script-indent.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/scriptindent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.SpaceInParens:
-      name: "org.openrewrite.codemods.cleanup.vue.SpaceInParens"
-      description: "Enforce consistent spacing inside parentheses in `<template>`\n\
-        See rule details for [vue/space-in-parens](https://eslint.vuejs.org/rules/space-in-parens.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/spaceinparens"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.SpaceInfixOps:
-      name: "org.openrewrite.codemods.cleanup.vue.SpaceInfixOps"
-      description: "Require spacing around infix operators in `<template>`\nSee rule\
-        \ details for [vue/space-infix-ops](https://eslint.vuejs.org/rules/space-infix-ops.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/spaceinfixops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.SpaceUnaryOps:
-      name: "org.openrewrite.codemods.cleanup.vue.SpaceUnaryOps"
-      description: "Enforce consistent spacing before or after unary operators in\
-        \ `<template>`\nSee rule details for [vue/space-unary-ops](https://eslint.vuejs.org/rules/space-unary-ops.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/spaceunaryops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.StaticClassNamesOrder:
-      name: "org.openrewrite.codemods.cleanup.vue.StaticClassNamesOrder"
-      description: "Enforce static class names order\nSee rule details for [vue/static-class-names-order](https://eslint.vuejs.org/rules/static-class-names-order.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/staticclassnamesorder"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.TemplateCurlySpacing:
-      name: "org.openrewrite.codemods.cleanup.vue.TemplateCurlySpacing"
-      description: "Require or disallow spacing around embedded expressions of template\
-        \ strings in `<template>`\nSee rule details for [vue/template-curly-spacing](https://eslint.vuejs.org/rules/template-curly-spacing.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/templatecurlyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.ThisInTemplate:
-      name: "org.openrewrite.codemods.cleanup.vue.ThisInTemplate"
-      description: "Disallow usage of this in template\nSee rule details for [vue/this-in-template](https://eslint.vuejs.org/rules/this-in-template.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/thisintemplate"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.VForDelimiterStyle:
-      name: "org.openrewrite.codemods.cleanup.vue.VForDelimiterStyle"
-      description: "Enforce v-for directive's delimiter style\nSee rule details for\
-        \ [vue/v-for-delimiter-style](https://eslint.vuejs.org/rules/v-for-delimiter-style.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/vfordelimiterstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.VIfElseKey:
-      name: "org.openrewrite.codemods.cleanup.vue.VIfElseKey"
-      description: "Require key attribute for conditionally rendered repeated components\n\
-        See rule details for [vue/v-if-else-key](https://eslint.vuejs.org/rules/v-if-else-key.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/vifelsekey"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.cleanup.vue.VOnHandlerStyle:
-      name: "org.openrewrite.codemods.cleanup.vue.VOnHandlerStyle"
-      description: "Enforce writing style for handlers in v-on directives\nSee rule\
-        \ details for [vue/v-on-handler-style](https://eslint.vuejs.org/rules/v-on-handler-style.html)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/cleanup/vue/vonhandlerstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.5to6.ECMAScript6BestPractices:
-      name: "org.openrewrite.codemods.ecmascript.5to6.ECMAScript6BestPractices"
-      description: "A collection of common ECMAScript 5 to ECMAScript 6 updates."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/5to6/ecmascript6bestpractices"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.5to6.amdToEsm:
-      name: "org.openrewrite.codemods.ecmascript.5to6.amdToEsm"
-      description: "Transform AMD style `define()` calls to ES6 `import` statements."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/5to6/amdtoesm"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.5to6.cjsToEsm:
-      name: "org.openrewrite.codemods.ecmascript.5to6.cjsToEsm"
-      description: "Transform CommonJS style `require()` calls to ES6 `import` statements."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/5to6/cjstoesm"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.5to6.namedExportGeneration:
-      name: "org.openrewrite.codemods.ecmascript.5to6.namedExportGeneration"
-      description: "Generate named exports from CommonJS modules."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/5to6/namedexportgeneration"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.5to6.noStrict:
-      name: "org.openrewrite.codemods.ecmascript.5to6.noStrict"
-      description: "Remove \"use strict\" directives."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/5to6/nostrict"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.5to6.simpleArrow:
-      name: "org.openrewrite.codemods.ecmascript.5to6.simpleArrow"
-      description: "Replace all function expressions with only `return` statement\
-        \ with simple arrow function."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/5to6/simplearrow"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.5to6.varToLet:
-      name: "org.openrewrite.codemods.ecmascript.5to6.varToLet"
-      description: "Convert `var` to `let`."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/5to6/vartolet"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.ESLintTypeScriptDefaults:
-      name: "org.openrewrite.codemods.ecmascript.ESLintTypeScriptDefaults"
-      description: "The default config includes the `@typescript-eslint` plugin and\
-        \ the corresponding `plugin:@typescript-eslint/recommended` extend."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/eslinttypescriptdefaults"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.ecmascript.ESLintTypeScriptPrettier:
-      name: "org.openrewrite.codemods.ecmascript.ESLintTypeScriptPrettier"
-      description: "Formats all TypeScript source code using the ESLint Prettier plugin."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/ecmascript/eslinttypescriptprettier"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ArrayBracketNewline:
-      name: "org.openrewrite.codemods.format.ArrayBracketNewline"
-      description: "Enforce linebreaks after opening and before closing array brackets\n\
-        \nSee [rule details](https://eslint.style/rules/default/array-bracket-newline)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/arraybracketnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ArrayBracketSpacing:
-      name: "org.openrewrite.codemods.format.ArrayBracketSpacing"
-      description: "Enforce consistent spacing inside array brackets\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/array-bracket-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/arraybracketspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ArrayElementNewline:
-      name: "org.openrewrite.codemods.format.ArrayElementNewline"
-      description: "Enforce line breaks after each array element\n\nSee [rule details](https://eslint.style/rules/default/array-element-newline)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/arrayelementnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ArrowParens:
-      name: "org.openrewrite.codemods.format.ArrowParens"
-      description: "Require parentheses around arrow function arguments\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/arrow-parens)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/arrowparens"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ArrowSpacing:
-      name: "org.openrewrite.codemods.format.ArrowSpacing"
-      description: "Enforce consistent spacing before and after the arrow in arrow\
-        \ functions\n\nSee [rule details](https://eslint.style/rules/default/arrow-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/arrowspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.BlockSpacing:
-      name: "org.openrewrite.codemods.format.BlockSpacing"
-      description: "Disallow or enforce spaces inside of blocks after opening block\
-        \ and before closing block\n\nSee [rule details](https://eslint.style/rules/default/block-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/blockspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.BraceStyle:
-      name: "org.openrewrite.codemods.format.BraceStyle"
-      description: "Enforce consistent brace style for blocks\n\nSee [rule details](https://eslint.style/rules/default/brace-style)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/bracestyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.CommaDangle:
-      name: "org.openrewrite.codemods.format.CommaDangle"
-      description: "Require or disallow trailing commas\n\nSee [rule details](https://eslint.style/rules/default/comma-dangle)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/commadangle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.CommaSpacing:
-      name: "org.openrewrite.codemods.format.CommaSpacing"
-      description: "Enforce consistent spacing before and after commas\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/comma-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/commaspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.CommaStyle:
-      name: "org.openrewrite.codemods.format.CommaStyle"
-      description: "Enforce consistent comma style\n\nSee [rule details](https://eslint.style/rules/default/comma-style)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/commastyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ComputedPropertySpacing:
-      name: "org.openrewrite.codemods.format.ComputedPropertySpacing"
-      description: "Enforce consistent spacing inside computed property brackets\n\
-        \nSee [rule details](https://eslint.style/rules/default/computed-property-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/computedpropertyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.DotLocation:
-      name: "org.openrewrite.codemods.format.DotLocation"
-      description: "Enforce consistent newlines before and after dots\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/dot-location)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/dotlocation"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.EolLast:
-      name: "org.openrewrite.codemods.format.EolLast"
-      description: "Require or disallow newline at the end of files\n\nSee [rule details](https://eslint.style/rules/default/eol-last)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/eollast"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.FuncCallSpacing:
-      name: "org.openrewrite.codemods.format.FuncCallSpacing"
-      description: "Require or disallow spacing between function identifiers and their\
-        \ invocations. Alias of &#x60;function-call-spacing&#x60;.\n\nSee [rule details](https://eslint.style/rules/default/func-call-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/funccallspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.FunctionCallArgumentNewline:
-      name: "org.openrewrite.codemods.format.FunctionCallArgumentNewline"
-      description: "Enforce line breaks between arguments of a function call\n\nSee\
-        \ [rule details](https://eslint.style/rules/default/function-call-argument-newline)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/functioncallargumentnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.FunctionCallSpacing:
-      name: "org.openrewrite.codemods.format.FunctionCallSpacing"
-      description: "Require or disallow spacing between function identifiers and their\
-        \ invocations\n\nSee [rule details](https://eslint.style/rules/default/function-call-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/functioncallspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.FunctionParenNewline:
-      name: "org.openrewrite.codemods.format.FunctionParenNewline"
-      description: "Enforce consistent line breaks inside function parentheses\n\n\
-        See [rule details](https://eslint.style/rules/default/function-paren-newline)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/functionparennewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.GeneratorStarSpacing:
-      name: "org.openrewrite.codemods.format.GeneratorStarSpacing"
-      description: "Enforce consistent spacing around &#x60;*&#x60; operators in generator\
-        \ functions\n\nSee [rule details](https://eslint.style/rules/default/generator-star-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/generatorstarspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ImplicitArrowLinebreak:
-      name: "org.openrewrite.codemods.format.ImplicitArrowLinebreak"
-      description: "Enforce the location of arrow function bodies\n\nSee [rule details](https://eslint.style/rules/default/implicit-arrow-linebreak)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/implicitarrowlinebreak"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.Indent:
-      name: "org.openrewrite.codemods.format.Indent"
-      description: "Enforce consistent indentation\n\nSee [rule details](https://eslint.style/rules/default/indent)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/indent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.IndentBinaryOps:
-      name: "org.openrewrite.codemods.format.IndentBinaryOps"
-      description: "Indentation for binary operators\n\nSee [rule details](https://eslint.style/rules/default/indent-binary-ops)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/indentbinaryops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxClosingBracketLocation:
-      name: "org.openrewrite.codemods.format.JsxClosingBracketLocation"
-      description: "Enforce closing bracket location in JSX\n\nSee [rule details](https://eslint.style/rules/default/jsx-closing-bracket-location)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxclosingbracketlocation"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxClosingTagLocation:
-      name: "org.openrewrite.codemods.format.JsxClosingTagLocation"
-      description: "Enforce closing tag location for multiline JSX\n\nSee [rule details](https://eslint.style/rules/default/jsx-closing-tag-location)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxclosingtaglocation"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxCurlyBracePresence:
-      name: "org.openrewrite.codemods.format.JsxCurlyBracePresence"
-      description: "Disallow unnecessary JSX expressions when literals alone are sufficient\
-        \ or enforce JSX expressions on literals in JSX children or attributes\n\n\
-        See [rule details](https://eslint.style/rules/default/jsx-curly-brace-presence)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxcurlybracepresence"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxCurlyNewline:
-      name: "org.openrewrite.codemods.format.JsxCurlyNewline"
-      description: "Enforce consistent linebreaks in curly braces in JSX attributes\
-        \ and expressions\n\nSee [rule details](https://eslint.style/rules/default/jsx-curly-newline)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxcurlynewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxCurlySpacing:
-      name: "org.openrewrite.codemods.format.JsxCurlySpacing"
-      description: "Enforce or disallow spaces inside of curly braces in JSX attributes\
-        \ and expressions\n\nSee [rule details](https://eslint.style/rules/default/jsx-curly-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxcurlyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxEqualsSpacing:
-      name: "org.openrewrite.codemods.format.JsxEqualsSpacing"
-      description: "Enforce or disallow spaces around equal signs in JSX attributes\n\
-        \nSee [rule details](https://eslint.style/rules/default/jsx-equals-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxequalsspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxFirstPropNewLine:
-      name: "org.openrewrite.codemods.format.JsxFirstPropNewLine"
-      description: "Enforce proper position of the first property in JSX\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/jsx-first-prop-new-line)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxfirstpropnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxIndent:
-      name: "org.openrewrite.codemods.format.JsxIndent"
-      description: "Enforce JSX indentation\n\nSee [rule details](https://eslint.style/rules/default/jsx-indent)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxindent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxIndentProps:
-      name: "org.openrewrite.codemods.format.JsxIndentProps"
-      description: "Enforce props indentation in JSX\n\nSee [rule details](https://eslint.style/rules/default/jsx-indent-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxindentprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxMaxPropsPerLine:
-      name: "org.openrewrite.codemods.format.JsxMaxPropsPerLine"
-      description: "Enforce maximum of props on a single line in JSX\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/jsx-max-props-per-line)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxmaxpropsperline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxNewline:
-      name: "org.openrewrite.codemods.format.JsxNewline"
-      description: "Require or prevent a new line after jsx elements and expressions.\n\
-        \nSee [rule details](https://eslint.style/rules/default/jsx-newline)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxnewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxOneExpressionPerLine:
-      name: "org.openrewrite.codemods.format.JsxOneExpressionPerLine"
-      description: "Require one JSX element per line\n\nSee [rule details](https://eslint.style/rules/default/jsx-one-expression-per-line)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxoneexpressionperline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxPascalCase:
-      name: "org.openrewrite.codemods.format.JsxPascalCase"
-      description: "Enforce PascalCase for user-defined JSX components\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/jsx-pascal-case)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxpascalcase"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxPropsNoMultiSpaces:
-      name: "org.openrewrite.codemods.format.JsxPropsNoMultiSpaces"
-      description: "Disallow multiple spaces between inline JSX props\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/jsx-props-no-multi-spaces)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxpropsnomultispaces"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxQuotes:
-      name: "org.openrewrite.codemods.format.JsxQuotes"
-      description: "Enforce the consistent use of either double or single quotes in\
-        \ JSX attributes\n\nSee [rule details](https://eslint.style/rules/default/jsx-quotes)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxquotes"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxSelfClosingComp:
-      name: "org.openrewrite.codemods.format.JsxSelfClosingComp"
-      description: "Disallow extra closing tags for components without children\n\n\
-        See [rule details](https://eslint.style/rules/default/jsx-self-closing-comp)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxselfclosingcomp"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxSortProps:
-      name: "org.openrewrite.codemods.format.JsxSortProps"
-      description: "Enforce props alphabetical sorting\n\nSee [rule details](https://eslint.style/rules/default/jsx-sort-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxsortprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxTagSpacing:
-      name: "org.openrewrite.codemods.format.JsxTagSpacing"
-      description: "Enforce whitespace in and around the JSX opening and closing brackets\n\
-        \nSee [rule details](https://eslint.style/rules/default/jsx-tag-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxtagspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.JsxWrapMultilines:
-      name: "org.openrewrite.codemods.format.JsxWrapMultilines"
-      description: "Disallow missing parentheses around multiline JSX\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/jsx-wrap-multilines)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/jsxwrapmultilines"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.KeySpacing:
-      name: "org.openrewrite.codemods.format.KeySpacing"
-      description: "Enforce consistent spacing between keys and values in object literal\
-        \ properties\n\nSee [rule details](https://eslint.style/rules/default/key-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/keyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.KeywordSpacing:
-      name: "org.openrewrite.codemods.format.KeywordSpacing"
-      description: "Enforce consistent spacing before and after keywords\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/keyword-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/keywordspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.LinebreakStyle:
-      name: "org.openrewrite.codemods.format.LinebreakStyle"
-      description: "Enforce consistent linebreak style\n\nSee [rule details](https://eslint.style/rules/default/linebreak-style)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/linebreakstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.LinesAroundComment:
-      name: "org.openrewrite.codemods.format.LinesAroundComment"
-      description: "Require empty lines around comments\n\nSee [rule details](https://eslint.style/rules/default/lines-around-comment)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/linesaroundcomment"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.LinesBetweenClassMembers:
-      name: "org.openrewrite.codemods.format.LinesBetweenClassMembers"
-      description: "Require or disallow an empty line between class members\n\nSee\
-        \ [rule details](https://eslint.style/rules/default/lines-between-class-members)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/linesbetweenclassmembers"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.MemberDelimiterStyle:
-      name: "org.openrewrite.codemods.format.MemberDelimiterStyle"
-      description: "Require a specific member delimiter style for interfaces and type\
-        \ literals\n\nSee [rule details](https://eslint.style/rules/default/member-delimiter-style)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/memberdelimiterstyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.MultilineTernary:
-      name: "org.openrewrite.codemods.format.MultilineTernary"
-      description: "Enforce newlines between operands of ternary expressions\n\nSee\
-        \ [rule details](https://eslint.style/rules/default/multiline-ternary)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/multilineternary"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NewParens:
-      name: "org.openrewrite.codemods.format.NewParens"
-      description: "Enforce or disallow parentheses when invoking a constructor with\
-        \ no arguments\n\nSee [rule details](https://eslint.style/rules/default/new-parens)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/newparens"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NewlinePerChainedCall:
-      name: "org.openrewrite.codemods.format.NewlinePerChainedCall"
-      description: "Require a newline after each call in a method chain\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/newline-per-chained-call)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/newlineperchainedcall"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NoConfusingArrow:
-      name: "org.openrewrite.codemods.format.NoConfusingArrow"
-      description: "Disallow arrow functions where they could be confused with comparisons\n\
-        \nSee [rule details](https://eslint.style/rules/default/no-confusing-arrow)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/noconfusingarrow"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NoExtraParens:
-      name: "org.openrewrite.codemods.format.NoExtraParens"
-      description: "Disallow unnecessary parentheses\n\nSee [rule details](https://eslint.style/rules/default/no-extra-parens)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/noextraparens"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NoExtraSemi:
-      name: "org.openrewrite.codemods.format.NoExtraSemi"
-      description: "Disallow unnecessary semicolons\n\nSee [rule details](https://eslint.style/rules/default/no-extra-semi)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/noextrasemi"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NoFloatingDecimal:
-      name: "org.openrewrite.codemods.format.NoFloatingDecimal"
-      description: "Disallow leading or trailing decimal points in numeric literals\n\
-        \nSee [rule details](https://eslint.style/rules/default/no-floating-decimal)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/nofloatingdecimal"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NoMultiSpaces:
-      name: "org.openrewrite.codemods.format.NoMultiSpaces"
-      description: "Disallow multiple spaces\n\nSee [rule details](https://eslint.style/rules/default/no-multi-spaces)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/nomultispaces"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NoMultipleEmptyLines:
-      name: "org.openrewrite.codemods.format.NoMultipleEmptyLines"
-      description: "Disallow multiple empty lines\n\nSee [rule details](https://eslint.style/rules/default/no-multiple-empty-lines)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/nomultipleemptylines"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NoTrailingSpaces:
-      name: "org.openrewrite.codemods.format.NoTrailingSpaces"
-      description: "Disallow trailing whitespace at the end of lines\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/no-trailing-spaces)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/notrailingspaces"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NoWhitespaceBeforeProperty:
-      name: "org.openrewrite.codemods.format.NoWhitespaceBeforeProperty"
-      description: "Disallow whitespace before properties\n\nSee [rule details](https://eslint.style/rules/default/no-whitespace-before-property)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/nowhitespacebeforeproperty"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.NonblockStatementBodyPosition:
-      name: "org.openrewrite.codemods.format.NonblockStatementBodyPosition"
-      description: "Enforce the location of single-line statements\n\nSee [rule details](https://eslint.style/rules/default/nonblock-statement-body-position)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/nonblockstatementbodyposition"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ObjectCurlyNewline:
-      name: "org.openrewrite.codemods.format.ObjectCurlyNewline"
-      description: "Enforce consistent line breaks after opening and before closing\
-        \ braces\n\nSee [rule details](https://eslint.style/rules/default/object-curly-newline)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/objectcurlynewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ObjectCurlySpacing:
-      name: "org.openrewrite.codemods.format.ObjectCurlySpacing"
-      description: "Enforce consistent spacing inside braces\n\nSee [rule details](https://eslint.style/rules/default/object-curly-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/objectcurlyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.ObjectPropertyNewline:
-      name: "org.openrewrite.codemods.format.ObjectPropertyNewline"
-      description: "Enforce placing object properties on separate lines\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/object-property-newline)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/objectpropertynewline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.OneVarDeclarationPerLine:
-      name: "org.openrewrite.codemods.format.OneVarDeclarationPerLine"
-      description: "Require or disallow newlines around variable declarations\n\n\
-        See [rule details](https://eslint.style/rules/default/one-var-declaration-per-line)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/onevardeclarationperline"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.OperatorLinebreak:
-      name: "org.openrewrite.codemods.format.OperatorLinebreak"
-      description: "Enforce consistent linebreak style for operators\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/operator-linebreak)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/operatorlinebreak"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.PaddedBlocks:
-      name: "org.openrewrite.codemods.format.PaddedBlocks"
-      description: "Require or disallow padding within blocks\n\nSee [rule details](https://eslint.style/rules/default/padded-blocks)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/paddedblocks"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.PaddingLineBetweenStatements:
-      name: "org.openrewrite.codemods.format.PaddingLineBetweenStatements"
-      description: "Require or disallow padding lines between statements\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/padding-line-between-statements)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/paddinglinebetweenstatements"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.QuoteProps:
-      name: "org.openrewrite.codemods.format.QuoteProps"
-      description: "Require quotes around object literal property names\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/quote-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/quoteprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.Quotes:
-      name: "org.openrewrite.codemods.format.Quotes"
-      description: "Enforce the consistent use of either backticks, double, or single\
-        \ quotes\n\nSee [rule details](https://eslint.style/rules/default/quotes)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/quotes"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.RecommendedESLintStyling:
-      name: "org.openrewrite.codemods.format.RecommendedESLintStyling"
-      description: "Collection of stylistic ESLint rules that are recommended by the\
-        \ [ESLint Style.](https://eslint.style/)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/recommendedeslintstyling"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.RestSpreadSpacing:
-      name: "org.openrewrite.codemods.format.RestSpreadSpacing"
-      description: "Enforce spacing between rest and spread operators and their expressions\n\
-        \nSee [rule details](https://eslint.style/rules/default/rest-spread-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/restspreadspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.Semi:
-      name: "org.openrewrite.codemods.format.Semi"
-      description: "Require or disallow semicolons instead of ASI\n\nSee [rule details](https://eslint.style/rules/default/semi)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/semi"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SemiSpacing:
-      name: "org.openrewrite.codemods.format.SemiSpacing"
-      description: "Enforce consistent spacing before and after semicolons\n\nSee\
-        \ [rule details](https://eslint.style/rules/default/semi-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/semispacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SemiStyle:
-      name: "org.openrewrite.codemods.format.SemiStyle"
-      description: "Enforce location of semicolons\n\nSee [rule details](https://eslint.style/rules/default/semi-style)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/semistyle"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SpaceBeforeBlocks:
-      name: "org.openrewrite.codemods.format.SpaceBeforeBlocks"
-      description: "Enforce consistent spacing before blocks\n\nSee [rule details](https://eslint.style/rules/default/space-before-blocks)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/spacebeforeblocks"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SpaceBeforeFunctionParen:
-      name: "org.openrewrite.codemods.format.SpaceBeforeFunctionParen"
-      description: "Enforce consistent spacing before &#x60;function&#x60; definition\
-        \ opening parenthesis\n\nSee [rule details](https://eslint.style/rules/default/space-before-function-paren)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/spacebeforefunctionparen"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SpaceInParens:
-      name: "org.openrewrite.codemods.format.SpaceInParens"
-      description: "Enforce consistent spacing inside parentheses\n\nSee [rule details](https://eslint.style/rules/default/space-in-parens)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/spaceinparens"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SpaceInfixOps:
-      name: "org.openrewrite.codemods.format.SpaceInfixOps"
-      description: "Require spacing around infix operators\n\nSee [rule details](https://eslint.style/rules/default/space-infix-ops)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/spaceinfixops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SpaceUnaryOps:
-      name: "org.openrewrite.codemods.format.SpaceUnaryOps"
-      description: "Enforce consistent spacing before or after unary operators\n\n\
-        See [rule details](https://eslint.style/rules/default/space-unary-ops)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/spaceunaryops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SpacedComment:
-      name: "org.openrewrite.codemods.format.SpacedComment"
-      description: "Enforce consistent spacing after the &#x60;//&#x60; or &#x60;/*&#x60;\
-        \ in a comment\n\nSee [rule details](https://eslint.style/rules/default/spaced-comment)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/spacedcomment"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.SwitchColonSpacing:
-      name: "org.openrewrite.codemods.format.SwitchColonSpacing"
-      description: "Enforce spacing around colons of switch statements\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/switch-colon-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/switchcolonspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.TemplateCurlySpacing:
-      name: "org.openrewrite.codemods.format.TemplateCurlySpacing"
-      description: "Require or disallow spacing around embedded expressions of template\
-        \ strings\n\nSee [rule details](https://eslint.style/rules/default/template-curly-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/templatecurlyspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.TemplateTagSpacing:
-      name: "org.openrewrite.codemods.format.TemplateTagSpacing"
-      description: "Require or disallow spacing between template tags and their literals\n\
-        \nSee [rule details](https://eslint.style/rules/default/template-tag-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/templatetagspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.TypeAnnotationSpacing:
-      name: "org.openrewrite.codemods.format.TypeAnnotationSpacing"
-      description: "Require consistent spacing around type annotations\n\nSee [rule\
-        \ details](https://eslint.style/rules/default/type-annotation-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/typeannotationspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.TypeGenericSpacing:
-      name: "org.openrewrite.codemods.format.TypeGenericSpacing"
-      description: "Enforces consistent spacing inside TypeScript type generics\n\n\
-        See [rule details](https://eslint.style/rules/default/type-generic-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/typegenericspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.TypeNamedTupleSpacing:
-      name: "org.openrewrite.codemods.format.TypeNamedTupleSpacing"
-      description: "Expect space before the type declaration in the named tuple\n\n\
-        See [rule details](https://eslint.style/rules/default/type-named-tuple-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/typenamedtuplespacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.WrapIife:
-      name: "org.openrewrite.codemods.format.WrapIife"
-      description: "Require parentheses around immediate &#x60;function&#x60; invocations\n\
-        \nSee [rule details](https://eslint.style/rules/default/wrap-iife)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/wrapiife"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.WrapRegex:
-      name: "org.openrewrite.codemods.format.WrapRegex"
-      description: "Require parenthesis around regex literals\n\nSee [rule details](https://eslint.style/rules/default/wrap-regex)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/wrapregex"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.format.YieldStarSpacing:
-      name: "org.openrewrite.codemods.format.YieldStarSpacing"
-      description: "Require or disallow spacing around the &#x60;*&#x60; in &#x60;yield*&#x60;\
-        \ expressions\n\nSee [rule details](https://eslint.style/rules/default/yield-star-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/format/yieldstarspacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.lodash.LodashUnderscoreArray:
-      name: "org.openrewrite.codemods.migrate.lodash.LodashUnderscoreArray"
-      description: "- `_.head(x)` -> `x[0]`\n- `_.head(x, n)` -> `x.slice(n)`\n- `_.first`\
-        \ (alias for `_.head`)\n- `_.tail(x)` -> `x.slice(1)`\n- `_.tail(x, n)` ->\
-        \ `x.slice(n)`\n- `_.rest` (alias for `_.tail`)\n- `_.last(x)` -> `x[x.length\
-        \ - 1]`\n- `_.last(x, n)` -> `x.slice(x.length - n)`."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/lodash/lodashunderscorearray"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.lodash.LodashUnderscoreFunction:
-      name: "org.openrewrite.codemods.migrate.lodash.LodashUnderscoreFunction"
-      description: "- `_.bind(fn, obj, ...x)` -> `fn.bind(obj, ...x)`\n- `_.partial(fn,\
-        \ a, b);` -> `(...args) => fn(a, b, ...args)`."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/lodash/lodashunderscorefunction"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.lodash.LodashUnderscoreObjects:
-      name: "org.openrewrite.codemods.migrate.lodash.LodashUnderscoreObjects"
-      description: "- `_.clone(x)` -> `{ ...x }`\n- `_.extend({}, x, y)` -> `{ ...x,\
-        \ ...y }`\n- `_.extend(obj, x, y)` -> `Object.assign(obj, x, y)`\n- `_.keys(x)`\
-        \ -> `Object.keys(x)`\n- `_.pairs(x)` -> `Object.entries(x)`\n- `_.values(x)`\
-        \ -> `Object.values(x)`."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/lodash/lodashunderscoreobjects"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.lodash.LodashUnderscoreUtil:
-      name: "org.openrewrite.codemods.migrate.lodash.LodashUnderscoreUtil"
-      description: "- `_.isArray(x)` -> `Array.isArray(x)`\n- `_.isBoolean(x)` ->\
-        \ `typeof(x) === 'boolean'`\n- `_.isFinite(x)` -> `Number.isFinite(x)`\n-\
-        \ `_.isFunction(x)` -> `typeof(x) === 'function'`\n- `_.isNull(x)` -> `x ===\
-        \ null`\n- `_.isString(x)` -> `typeof(x) === 'string'`\n- `_.isUndefined(x)`\
-        \ -> `typeof(x) === 'undefined'`."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/lodash/lodashunderscoreutil"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.AdapterV:
-      name: "org.openrewrite.codemods.migrate.mui.AdapterV"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#adapter-v4)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/adapterv"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.All:
-      name: "org.openrewrite.codemods.migrate.mui.All"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#all)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/all"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.AutocompleteRenameCloseicon:
-      name: "org.openrewrite.codemods.migrate.mui.AutocompleteRenameCloseicon"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#autocomplete-rename-closeicon)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/autocompleterenamecloseicon"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.AutocompleteRenameOption:
-      name: "org.openrewrite.codemods.migrate.mui.AutocompleteRenameOption"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#autocomplete-rename-option)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/autocompleterenameoption"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.AvatarCircleCircular:
-      name: "org.openrewrite.codemods.migrate.mui.AvatarCircleCircular"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#avatar-circle-circular)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/avatarcirclecircular"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BadgeOverlapValue:
-      name: "org.openrewrite.codemods.migrate.mui.BadgeOverlapValue"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#badge-overlap-value)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/badgeoverlapvalue"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BaseHookImports:
-      name: "org.openrewrite.codemods.migrate.mui.BaseHookImports"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-hook-imports)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/basehookimports"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BaseRemoveComponentProp:
-      name: "org.openrewrite.codemods.migrate.mui.BaseRemoveComponentProp"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-remove-component-prop)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/baseremovecomponentprop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BaseRemoveUnstyledSuffix:
-      name: "org.openrewrite.codemods.migrate.mui.BaseRemoveUnstyledSuffix"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-remove-unstyled-suffix)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/baseremoveunstyledsuffix"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BaseRenameComponentsToSlots:
-      name: "org.openrewrite.codemods.migrate.mui.BaseRenameComponentsToSlots"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-rename-components-to-slots)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/baserenamecomponentstoslots"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BaseUseNamedExports:
-      name: "org.openrewrite.codemods.migrate.mui.BaseUseNamedExports"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#base-use-named-exports)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/baseusenamedexports"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BoxBorderradiusValues:
-      name: "org.openrewrite.codemods.migrate.mui.BoxBorderradiusValues"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-borderradius-values)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/boxborderradiusvalues"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BoxRenameCss:
-      name: "org.openrewrite.codemods.migrate.mui.BoxRenameCss"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-rename-css)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/boxrenamecss"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BoxRenameGap:
-      name: "org.openrewrite.codemods.migrate.mui.BoxRenameGap"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-rename-gap)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/boxrenamegap"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.BoxSxProp:
-      name: "org.openrewrite.codemods.migrate.mui.BoxSxProp"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#box-sx-prop)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/boxsxprop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ButtonColorProp:
-      name: "org.openrewrite.codemods.migrate.mui.ButtonColorProp"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#button-color-prop)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/buttoncolorprop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ChipVariantProp:
-      name: "org.openrewrite.codemods.migrate.mui.ChipVariantProp"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#chip-variant-prop)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/chipvariantprop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.CircularprogressVariant:
-      name: "org.openrewrite.codemods.migrate.mui.CircularprogressVariant"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#circularprogress-variant)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/circularprogressvariant"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.CollapseRenameCollapsedheight:
-      name: "org.openrewrite.codemods.migrate.mui.CollapseRenameCollapsedheight"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#collapse-rename-collapsedheight)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/collapserenamecollapsedheight"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ComponentRenameProp:
-      name: "org.openrewrite.codemods.migrate.mui.ComponentRenameProp"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#component-rename-prop)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/componentrenameprop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.CoreStylesImport:
-      name: "org.openrewrite.codemods.migrate.mui.CoreStylesImport"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#core-styles-import)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/corestylesimport"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.CreateTheme:
-      name: "org.openrewrite.codemods.migrate.mui.CreateTheme"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#create-theme)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/createtheme"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.DatePickersMovedToX:
-      name: "org.openrewrite.codemods.migrate.mui.DatePickersMovedToX"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#date-pickers-moved-to-x)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/datepickersmovedtox"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.DialogProps:
-      name: "org.openrewrite.codemods.migrate.mui.DialogProps"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#dialog-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/dialogprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.DialogTitleProps:
-      name: "org.openrewrite.codemods.migrate.mui.DialogTitleProps"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#dialog-title-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/dialogtitleprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.EmotionPrependCache:
-      name: "org.openrewrite.codemods.migrate.mui.EmotionPrependCache"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#emotion-prepend-cache)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/emotionprependcache"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ExpansionPanelComponent:
-      name: "org.openrewrite.codemods.migrate.mui.ExpansionPanelComponent"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#expansion-panel-component)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/expansionpanelcomponent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.FabVariant:
-      name: "org.openrewrite.codemods.migrate.mui.FabVariant"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#fab-variant)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/fabvariant"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.FadeRenameAlpha:
-      name: "org.openrewrite.codemods.migrate.mui.FadeRenameAlpha"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#fade-rename-alpha)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/faderenamealpha"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.GridJustifyJustifycontent:
-      name: "org.openrewrite.codemods.migrate.mui.GridJustifyJustifycontent"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-justify-justifycontent)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/gridjustifyjustifycontent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.GridListComponent:
-      name: "org.openrewrite.codemods.migrate.mui.GridListComponent"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-list-component)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/gridlistcomponent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.GridVProps:
-      name: "org.openrewrite.codemods.migrate.mui.GridVProps"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#grid-v2-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/gridvprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.HiddenDownProps:
-      name: "org.openrewrite.codemods.migrate.mui.HiddenDownProps"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#hidden-down-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/hiddendownprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.IconButtonSize:
-      name: "org.openrewrite.codemods.migrate.mui.IconButtonSize"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#icon-button-size)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/iconbuttonsize"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.JoyAvatarRemoveImgprops:
-      name: "org.openrewrite.codemods.migrate.mui.JoyAvatarRemoveImgprops"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-avatar-remove-imgProps)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/joyavatarremoveimgprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.JoyRenameClassnamePrefix:
-      name: "org.openrewrite.codemods.migrate.mui.JoyRenameClassnamePrefix"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-classname-prefix)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/joyrenameclassnameprefix"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.JoyRenameComponentsToSlots:
-      name: "org.openrewrite.codemods.migrate.mui.JoyRenameComponentsToSlots"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-components-to-slots)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/joyrenamecomponentstoslots"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.JoyRenameRowProp:
-      name: "org.openrewrite.codemods.migrate.mui.JoyRenameRowProp"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-rename-row-prop)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/joyrenamerowprop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.JoyTextFieldToInput:
-      name: "org.openrewrite.codemods.migrate.mui.JoyTextFieldToInput"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#joy-text-field-to-input)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/joytextfieldtoinput"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.JssToStyled:
-      name: "org.openrewrite.codemods.migrate.mui.JssToStyled"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#jss-to-styled)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/jsstostyled"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.JssToTssReact:
-      name: "org.openrewrite.codemods.migrate.mui.JssToTssReact"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#jss-to-tss-react)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/jsstotssreact"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.LinkUnderlineHover:
-      name: "org.openrewrite.codemods.migrate.mui.LinkUnderlineHover"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#link-underline-hover)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/linkunderlinehover"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.MaterialUiStyles:
-      name: "org.openrewrite.codemods.migrate.mui.MaterialUiStyles"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#material-ui-styles)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/materialuistyles"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.MaterialUiTypes:
-      name: "org.openrewrite.codemods.migrate.mui.MaterialUiTypes"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#material-ui-types)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/materialuitypes"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ModalProps:
-      name: "org.openrewrite.codemods.migrate.mui.ModalProps"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#modal-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/modalprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.MovedLabModules:
-      name: "org.openrewrite.codemods.migrate.mui.MovedLabModules"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#moved-lab-modules)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/movedlabmodules"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.MuiReplace:
-      name: "org.openrewrite.codemods.migrate.mui.MuiReplace"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#mui-replace)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/muireplace"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.OptimalImports:
-      name: "org.openrewrite.codemods.migrate.mui.OptimalImports"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#optimal-imports)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/optimalimports"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.PaginationRoundCircular:
-      name: "org.openrewrite.codemods.migrate.mui.PaginationRoundCircular"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#pagination-round-circular)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/paginationroundcircular"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.PresetSafe:
-      name: "org.openrewrite.codemods.migrate.mui.PresetSafe"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#preset-safe)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/presetsafe"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.RenameCssVariables:
-      name: "org.openrewrite.codemods.migrate.mui.RenameCssVariables"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#rename-css-variables)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/renamecssvariables"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.RootRef:
-      name: "org.openrewrite.codemods.migrate.mui.RootRef"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#root-ref)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/rootref"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.SkeletonVariant:
-      name: "org.openrewrite.codemods.migrate.mui.SkeletonVariant"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#skeleton-variant)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/skeletonvariant"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.Styled:
-      name: "org.openrewrite.codemods.migrate.mui.Styled"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#styled)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/styled"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.StyledEngineProvider:
-      name: "org.openrewrite.codemods.migrate.mui.StyledEngineProvider"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#styled-engine-provider)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/styledengineprovider"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.SxProp:
-      name: "org.openrewrite.codemods.migrate.mui.SxProp"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#sx-prop)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/sxprop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.SystemProps:
-      name: "org.openrewrite.codemods.migrate.mui.SystemProps"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#system-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/systemprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.TableProps:
-      name: "org.openrewrite.codemods.migrate.mui.TableProps"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#table-props)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/tableprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.TabsScrollButtons:
-      name: "org.openrewrite.codemods.migrate.mui.TabsScrollButtons"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#tabs-scroll-buttons)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/tabsscrollbuttons"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.TextareaMinmaxRows:
-      name: "org.openrewrite.codemods.migrate.mui.TextareaMinmaxRows"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#textarea-minmax-rows)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/textareaminmaxrows"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeAugment:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeAugment"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-augment)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themeaugment"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeBreakpoints:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeBreakpoints"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-breakpoints)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themebreakpoints"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeBreakpointsWidth:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeBreakpointsWidth"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-breakpoints-width)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themebreakpointswidth"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeOptions:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeOptions"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-options)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themeoptions"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemePaletteMode:
-      name: "org.openrewrite.codemods.migrate.mui.ThemePaletteMode"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-palette-mode)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themepalettemode"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeProvider:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeProvider"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-provider)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themeprovider"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeSpacing:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeSpacing"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-spacing)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themespacing"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeSpacingApi:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeSpacingApi"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-spacing-api)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themespacingapi"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeTypographyRound:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeTypographyRound"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-typography-round)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themetypographyround"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.ThemeV:
-      name: "org.openrewrite.codemods.migrate.mui.ThemeV"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#theme-v6)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/themev"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.TopLevelImports:
-      name: "org.openrewrite.codemods.migrate.mui.TopLevelImports"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#top-level-imports)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/toplevelimports"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.Transitions:
-      name: "org.openrewrite.codemods.migrate.mui.Transitions"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#transitions)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/transitions"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.TreeViewMovedToX:
-      name: "org.openrewrite.codemods.migrate.mui.TreeViewMovedToX"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#tree-view-moved-to-x)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/treeviewmovedtox"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.UseAutocomplete:
-      name: "org.openrewrite.codemods.migrate.mui.UseAutocomplete"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#use-autocomplete)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/useautocomplete"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.UseTransitionprops:
-      name: "org.openrewrite.codemods.migrate.mui.UseTransitionprops"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#use-transitionprops)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/usetransitionprops"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.VariantProp:
-      name: "org.openrewrite.codemods.migrate.mui.VariantProp"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#variant-prop)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/variantprop"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.WithMobileDialog:
-      name: "org.openrewrite.codemods.migrate.mui.WithMobileDialog"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#with-mobile-dialog)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/withmobiledialog"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.mui.WithWidth:
-      name: "org.openrewrite.codemods.migrate.mui.WithWidth"
-      description: "See Material UI codemod projects for more [details](https://github.com/mui/material-ui/tree/master/packages/mui-codemod#with-width)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/mui/withwidth"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.NextJsCodemods:
-      name: "org.openrewrite.codemods.migrate.nextjs.NextJsCodemods"
-      description: "Next.js provides Codemod transformations to help upgrade your\
-        \ [Next.js](https://nextjs.org/) codebase when an API is updated or deprecated."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/nextjscodemods"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v10.AddMissingReactImport:
-      name: "org.openrewrite.codemods.migrate.nextjs.v10.AddMissingReactImport"
-      description: "Transforms files that do not import `React` to include the import\
-        \ in order for the new React JSX transform to work."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v10/addmissingreactimport"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v11.CraToNext:
-      name: "org.openrewrite.codemods.migrate.nextjs.v11.CraToNext"
-      description: "Safely renames `next/image` imports in existing Next.js `10` `11`\
-        \ or `12` applications to `next/legacy/image` in Next.js 13. Also renames\
-        \ `next/future/image` to `next/image`."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v11/cratonext"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v13_0.NewLink:
-      name: "org.openrewrite.codemods.migrate.nextjs.v13_0.NewLink"
-      description: "Remove `&lt;a&gt;` tags inside Link Components or add a `legacyBehavior`\
-        \ prop to Links that cannot be auto-fixed."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v13_0/newlink"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v13_0.NextImageExperimental:
-      name: "org.openrewrite.codemods.migrate.nextjs.v13_0.NextImageExperimental"
-      description: "Dangerously migrates from `next/legacy/image` to the new `next/image`\
-        \ by adding inline styles and removing unused props."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v13_0/nextimageexperimental"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v13_0.NextImageToLegacyImage:
-      name: "org.openrewrite.codemods.migrate.nextjs.v13_0.NextImageToLegacyImage"
-      description: "Safely renames `next/image` imports in existing Next.js `10` `11`\
-        \ or `12` applications to `next/legacy/image` in Next.js 13. Also renames\
-        \ `next/future/image` to `next/image`."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v13_0/nextimagetolegacyimage"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v13_2.BuiltInNextFont:
-      name: "org.openrewrite.codemods.migrate.nextjs.v13_2.BuiltInNextFont"
-      description: "This codemod uninstalls the `@next/font` package and transforms\
-        \ `@next/font` imports into the built-in `next/font`."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v13_2/builtinnextfont"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v14_0.MetadataToViewportExport:
-      name: "org.openrewrite.codemods.migrate.nextjs.v14_0.MetadataToViewportExport"
-      description: "This codemod migrates certain viewport metadata to `viewport`\
-        \ export."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v14_0/metadatatoviewportexport"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v14_0.NextOgImport:
-      name: "org.openrewrite.codemods.migrate.nextjs.v14_0.NextOgImport"
-      description: "This codemod moves transforms imports from `next/server` to `next/og`\
-        \ for usage of Dynamic OG Image Generation."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v14_0/nextogimport"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v6.UrlToWithrouter:
-      name: "org.openrewrite.codemods.migrate.nextjs.v6.UrlToWithrouter"
-      description: "Transforms the deprecated automatically injected url property\
-        \ on top-level pages to using `withRouter` and the `router` property it injects.\
-        \ Read more [here](https://nextjs.org/docs/messages/url-deprecated)."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v6/urltowithrouter"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v8.WithampToConfig:
-      name: "org.openrewrite.codemods.migrate.nextjs.v8.WithampToConfig"
-      description: "Transforms the `withAmp` HOC into Next.js 9 page configuration."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v8/withamptoconfig"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
-    org.openrewrite.codemods.migrate.nextjs.v9.NameDefaultComponent:
-      name: "org.openrewrite.codemods.migrate.nextjs.v9.NameDefaultComponent"
-      description: "Transforms anonymous components into named components to make\
-        \ sure they work with Fast Refresh. The component will have a camel-cased\
-        \ name based on the name of the file, and it also works with arrow functions."
-      docLink: "https://docs.openrewrite.org/recipes/codemods/migrate/nextjs/v9/namedefaultcomponent"
-      options: []
-      isImperative: false
-      artifactId: "rewrite-codemods"
 rewrite-core:
   artifactId: "rewrite-core"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.AddToGitignore:
       name: "org.openrewrite.AddToGitignore"
@@ -5171,7 +1647,7 @@ rewrite-core:
       artifactId: "rewrite-core"
 rewrite-cucumber-jvm:
   artifactId: "rewrite-cucumber-jvm"
-  version: "2.12.4"
+  version: "2.13.0"
   markdownRecipeDescriptors:
     org.openrewrite.cucumber.jvm.CucumberAnnotationToSuite:
       name: "org.openrewrite.cucumber.jvm.CucumberAnnotationToSuite"
@@ -5250,7 +1726,7 @@ rewrite-cucumber-jvm:
       artifactId: "rewrite-cucumber-jvm"
 rewrite-docker:
   artifactId: "rewrite-docker"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.docker.AddAptGetCleanup:
       name: "org.openrewrite.docker.AddAptGetCleanup"
@@ -5527,7 +2003,7 @@ rewrite-docker:
       artifactId: "rewrite-docker"
 rewrite-feature-flags:
   artifactId: "rewrite-feature-flags"
-  version: "1.22.1"
+  version: "1.23.0"
   markdownRecipeDescriptors:
     org.openrewrite.featureflags.RemoveBooleanFlag:
       name: "org.openrewrite.featureflags.RemoveBooleanFlag"
@@ -5954,7 +2430,7 @@ rewrite-feature-flags:
       artifactId: "rewrite-feature-flags"
 rewrite-github-actions:
   artifactId: "rewrite-github-actions"
-  version: "3.27.0"
+  version: "3.28.0"
   markdownRecipeDescriptors:
     org.openrewrite.github.AddCronTrigger:
       name: "org.openrewrite.github.AddCronTrigger"
@@ -6601,7 +3077,7 @@ rewrite-github-actions:
       artifactId: "rewrite-github-actions"
 rewrite-gitlab:
   artifactId: "rewrite-gitlab"
-  version: "0.23.3"
+  version: "0.24.0"
   markdownRecipeDescriptors:
     org.openrewrite.gitlab.AddArtifactsExpireIn:
       name: "org.openrewrite.gitlab.AddArtifactsExpireIn"
@@ -6910,7 +3386,7 @@ rewrite-gitlab:
       artifactId: "rewrite-gitlab"
 rewrite-go:
   artifactId: "rewrite-go"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.golang.RegenerateGoSum:
       name: "org.openrewrite.golang.RegenerateGoSum"
@@ -6925,7 +3401,7 @@ rewrite-go:
       artifactId: "rewrite-go"
 rewrite-gradle:
   artifactId: "rewrite-gradle"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.gradle.AddDependency:
       name: "org.openrewrite.gradle.AddDependency"
@@ -7390,6 +3866,17 @@ rewrite-gradle:
       - name: "groupId"
         type: "String"
         required: true
+      isImperative: true
+      artifactId: "rewrite-gradle"
+    org.openrewrite.gradle.RemoveEmptyBuildscriptBlock:
+      name: "org.openrewrite.gradle.RemoveEmptyBuildscriptBlock"
+      description: "Removes a `buildscript` block from `build.gradle(.kts)` or `settings.gradle(.kts)`\
+        \ when it contributes nothing to the build. A block containing only other\
+        \ empty blocks, such as an empty `dependencies` or `repositories` block, is\
+        \ also considered empty. A block containing a comment is left alone, so that\
+        \ no comment is silently deleted."
+      docLink: "https://docs.openrewrite.org/recipes/gradle/removeemptybuildscriptblock"
+      options: []
       isImperative: true
       artifactId: "rewrite-gradle"
     org.openrewrite.gradle.RemoveEnableFeaturePreview:
@@ -7882,6 +4369,32 @@ rewrite-gradle:
         required: true
       isImperative: true
       artifactId: "rewrite-gradle"
+    org.openrewrite.gradle.plugins.SetDevelocityProjectId:
+      name: "org.openrewrite.gradle.plugins.SetDevelocityProjectId"
+      description: "Sets the `projectId` in the `develocity` block of a Gradle settings\
+        \ file, adding it after the `server` assignment when absent or updating it\
+        \ when it differs. The `projectId` is used by newer Develocity servers to\
+        \ associate build scans with a project."
+      docLink: "https://docs.openrewrite.org/recipes/gradle/plugins/setdevelocityprojectid"
+      options:
+      - name: "projectId"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-gradle"
+    org.openrewrite.gradle.plugins.SetDevelocityServer:
+      name: "org.openrewrite.gradle.plugins.SetDevelocityServer"
+      description: "Sets the `server` in the `develocity` block of a Gradle settings\
+        \ file, adding it as the first statement when absent or updating it when it\
+        \ differs. Use this to point builds at a different Develocity server, for\
+        \ example when migrating between servers."
+      docLink: "https://docs.openrewrite.org/recipes/gradle/plugins/setdevelocityserver"
+      options:
+      - name: "server"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-gradle"
     org.openrewrite.gradle.plugins.UpgradePluginVersion:
       name: "org.openrewrite.gradle.plugins.UpgradePluginVersion"
       description: "Update a Gradle plugin by id to a later version defined by the\
@@ -8139,7 +4652,7 @@ rewrite-gradle:
       artifactId: "rewrite-gradle"
 rewrite-groovy:
   artifactId: "rewrite-groovy"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.groovy.format.AutoFormat:
       name: "org.openrewrite.groovy.format.AutoFormat"
@@ -8175,7 +4688,7 @@ rewrite-groovy:
       artifactId: "rewrite-groovy"
 rewrite-hcl:
   artifactId: "rewrite-hcl"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.hcl.DeleteContent:
       name: "org.openrewrite.hcl.DeleteContent"
@@ -8288,7 +4801,7 @@ rewrite-hcl:
       artifactId: "rewrite-hcl"
 rewrite-hibernate:
   artifactId: "rewrite-hibernate"
-  version: "2.23.1"
+  version: "2.24.0"
   markdownRecipeDescriptors:
     org.openrewrite.hibernate.AddScalarPreferStandardBasicTypes:
       name: "org.openrewrite.hibernate.AddScalarPreferStandardBasicTypes"
@@ -8513,7 +5026,7 @@ rewrite-hibernate:
       artifactId: "rewrite-hibernate"
 rewrite-jackson:
   artifactId: "rewrite-jackson"
-  version: "1.27.0"
+  version: "1.28.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.jackson.AddJsonCreatorToPrivateConstructors:
       name: "org.openrewrite.java.jackson.AddJsonCreatorToPrivateConstructors"
@@ -8962,7 +5475,7 @@ rewrite-jackson:
       artifactId: "rewrite-jackson"
 rewrite-java:
   artifactId: "rewrite-java"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.AddApache2LicenseHeader:
       name: "org.openrewrite.java.AddApache2LicenseHeader"
@@ -10260,7 +6773,7 @@ rewrite-java:
       artifactId: "rewrite-java"
 rewrite-java-dependencies:
   artifactId: "rewrite-java-dependencies"
-  version: "1.58.0"
+  version: "1.60.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.dependencies.AddDependency:
       name: "org.openrewrite.java.dependencies.AddDependency"
@@ -10490,8 +7003,8 @@ rewrite-java-dependencies:
         \ dependency's POM to determine its true transitive dependencies, allowing\
         \ it to detect redundancies even when both dependencies are explicitly declared.\
         \ A direct dependency is only removed when the transitive one provides it\
-        \ at the exact same scope and with the same exclusions, so that removing it\
-        \ does not change the effective classpath."
+        \ at the exact same scope and with the same declared exclusions, so that removing\
+        \ it does not change the effective classpath."
       docLink: "https://docs.openrewrite.org/recipes/java/dependencies/removeredundantdependencies"
       options:
       - name: "artifactId"
@@ -10713,7 +7226,7 @@ rewrite-java-dependencies:
       artifactId: "rewrite-java-dependencies"
 rewrite-javascript:
   artifactId: "rewrite-javascript"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.javascript.AddDependency:
       name: "org.openrewrite.javascript.AddDependency"
@@ -10966,7 +7479,7 @@ rewrite-javascript:
       artifactId: "rewrite-javascript"
 rewrite-jenkins:
   artifactId: "rewrite-jenkins"
-  version: "0.36.3"
+  version: "0.37.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.testing.htmlunit.UpgradeHtmlUnit_3:
       name: "org.openrewrite.java.testing.htmlunit.UpgradeHtmlUnit_3"
@@ -11160,7 +7673,7 @@ rewrite-jenkins:
       artifactId: "rewrite-jenkins"
 rewrite-joda:
   artifactId: "rewrite-joda"
-  version: "0.9.3"
+  version: "0.10.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.joda.time.JodaAbstractInstantToJavaTime:
       name: "org.openrewrite.java.joda.time.JodaAbstractInstantToJavaTime"
@@ -11263,7 +7776,7 @@ rewrite-joda:
       artifactId: "rewrite-joda"
 rewrite-json:
   artifactId: "rewrite-json"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.json.AddKeyValue:
       name: "org.openrewrite.json.AddKeyValue"
@@ -11398,7 +7911,7 @@ rewrite-json:
       artifactId: "rewrite-json"
 rewrite-kotlin:
   artifactId: "rewrite-kotlin"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.kotlin.FindKotlinSources:
       name: "org.openrewrite.kotlin.FindKotlinSources"
@@ -11516,7 +8029,7 @@ rewrite-kotlin:
       artifactId: "rewrite-kotlin"
 rewrite-liberty:
   artifactId: "rewrite-liberty"
-  version: "1.25.0"
+  version: "1.26.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.liberty.MigrateFromWebSphereToLiberty:
       name: "org.openrewrite.java.liberty.MigrateFromWebSphereToLiberty"
@@ -11624,7 +8137,7 @@ rewrite-liberty:
       artifactId: "rewrite-liberty"
 rewrite-logging-frameworks:
   artifactId: "rewrite-logging-frameworks"
-  version: "3.30.0"
+  version: "3.31.0"
   markdownRecipeDescriptors:
     org.apache.logging.log4j.InlineLog4jApiMethods:
       name: "org.apache.logging.log4j.InlineLog4jApiMethods"
@@ -12830,7 +9343,7 @@ rewrite-logging-frameworks:
       artifactId: "rewrite-logging-frameworks"
 rewrite-maven:
   artifactId: "rewrite-maven"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.maven.AddAnnotationProcessor:
       name: "org.openrewrite.maven.AddAnnotationProcessor"
@@ -14026,9 +10539,13 @@ rewrite-maven:
     org.openrewrite.maven.UpgradeTransitiveDependencyVersion:
       name: "org.openrewrite.maven.UpgradeTransitiveDependencyVersion"
       description: "Upgrades the version of a transitive dependency in a Maven pom\
-        \ file. Leaves direct dependencies unmodified. Can be paired with the regular\
-        \ Upgrade Dependency Version recipe to upgrade a dependency everywhere, regardless\
-        \ of whether it is direct or transitive."
+        \ file. Leaves direct dependencies unmodified. When the transitive dependency's\
+        \ version is already governed by a plain `<dependencyManagement>` entry in\
+        \ the project, that entry is upgraded in place rather than adding a duplicate;\
+        \ otherwise (including a version supplied by an imported BOM) a new managed\
+        \ dependency is added. Can be paired with the regular Upgrade Dependency Version\
+        \ recipe to upgrade a dependency everywhere, regardless of whether it is direct\
+        \ or transitive."
       docLink: "https://docs.openrewrite.org/recipes/maven/upgradetransitivedependencyversion"
       options:
       - name: "addToRootPom"
@@ -14426,7 +10943,7 @@ rewrite-maven:
       artifactId: "rewrite-maven"
 rewrite-micrometer:
   artifactId: "rewrite-micrometer"
-  version: "0.29.3"
+  version: "0.30.0"
   markdownRecipeDescriptors:
     org.openrewrite.micrometer.MicrometerBestPractices:
       name: "org.openrewrite.micrometer.MicrometerBestPractices"
@@ -14486,7 +11003,7 @@ rewrite-micrometer:
       artifactId: "rewrite-micrometer"
 rewrite-micronaut:
   artifactId: "rewrite-micronaut"
-  version: "2.34.4"
+  version: "2.35.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.micronaut.AddAnnotationProcessorPath:
       name: "org.openrewrite.java.micronaut.AddAnnotationProcessorPath"
@@ -14857,7 +11374,7 @@ rewrite-micronaut:
       artifactId: "rewrite-micronaut"
 rewrite-migrate-java:
   artifactId: "rewrite-migrate-java"
-  version: "3.40.0"
+  version: "3.41.0"
   markdownRecipeDescriptors:
     com.google.guava.InlineGuavaMethods:
       name: "com.google.guava.InlineGuavaMethods"
@@ -14961,6 +11478,15 @@ rewrite-migrate-java:
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/addlombokmapstructbindingmavendependencyonly"
       options: []
       isImperative: false
+      artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.AddMapstructAnnotationProcessorPath:
+      name: "org.openrewrite.java.migrate.AddMapstructAnnotationProcessorPath"
+      description: "Add the `mapstruct-processor` annotation processor path, matching\
+        \ the version of the `mapstruct` dependency, so that MapStruct mappers are\
+        \ generated when annotation processing is configured explicitly."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/addmapstructannotationprocessorpath"
+      options: []
+      isImperative: true
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.AddMissingMethodImplementation:
       name: "org.openrewrite.java.migrate.AddMissingMethodImplementation"
@@ -16386,16 +12912,14 @@ rewrite-migrate-java:
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferIntegerCompareUnsigned:
       name: "org.openrewrite.java.migrate.guava.PreferIntegerCompareUnsigned"
-      description: "Prefer `java.lang.Integer#compareUnsigned` instead of using `com.google.common.primitives.UnsignedInts#compare`\
-        \ or `com.google.common.primitives.UnsignedInts#compareUnsigned`."
+      description: "Prefer `java.lang.Integer#compareUnsigned` instead of using `com.google.common.primitives.UnsignedInts#compare`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/preferintegercompareunsigned"
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferIntegerDivideUnsigned:
       name: "org.openrewrite.java.migrate.guava.PreferIntegerDivideUnsigned"
-      description: "Prefer `java.lang.Integer#divideUnsigned` instead of using `com.google.common.primitives.UnsignedInts#divide`\
-        \ or `com.google.common.primitives.UnsignedInts#divideUnsigned`."
+      description: "Prefer `java.lang.Integer#divideUnsigned` instead of using `com.google.common.primitives.UnsignedInts#divide`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/preferintegerdivideunsigned"
       options: []
       isImperative: false
@@ -16410,7 +12934,7 @@ rewrite-migrate-java:
     org.openrewrite.java.migrate.guava.PreferIntegerRemainderUnsigned:
       name: "org.openrewrite.java.migrate.guava.PreferIntegerRemainderUnsigned"
       description: "Prefer `java.lang.Integer#remainderUnsigned` instead of using\
-        \ `com.google.common.primitives.UnsignedInts#remainderUnsigned`."
+        \ `com.google.common.primitives.UnsignedInts#remainder`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/preferintegerremainderunsigned"
       options: []
       isImperative: false
@@ -16521,38 +13045,35 @@ rewrite-migrate-java:
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferLongCompareUnsigned:
       name: "org.openrewrite.java.migrate.guava.PreferLongCompareUnsigned"
-      description: "Prefer `java.lang.Long#compareUnsigned` instead of using `com.google.common.primitives.UnsignedLongs#compare`\
-        \ or `com.google.common.primitives.UnsignedLongs#compareUnsigned`."
+      description: "Prefer `java.lang.Long#compareUnsigned` instead of using `com.google.common.primitives.UnsignedLongs#compare`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/preferlongcompareunsigned"
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferLongDivideUnsigned:
       name: "org.openrewrite.java.migrate.guava.PreferLongDivideUnsigned"
-      description: "Prefer `java.lang.Long#divideUnsigned` instead of using `com.google.common.primitives.UnsignedLongs#divide`\
-        \ or `com.google.common.primitives.UnsignedLongs#divideUnsigned`."
+      description: "Prefer `java.lang.Long#divideUnsigned` instead of using `com.google.common.primitives.UnsignedLongs#divide`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/preferlongdivideunsigned"
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferLongParseUnsignedLong:
       name: "org.openrewrite.java.migrate.guava.PreferLongParseUnsignedLong"
-      description: "Prefer `java.lang.Long#parseUnsignedInt` instead of using `com.google.common.primitives.UnsignedLongs#parseUnsignedInt`."
+      description: "Prefer `java.lang.Long#parseUnsignedLong` instead of using `com.google.common.primitives.UnsignedLongs#parseUnsignedLong`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/preferlongparseunsignedlong"
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferLongRemainderUnsigned:
       name: "org.openrewrite.java.migrate.guava.PreferLongRemainderUnsigned"
-      description: "Prefer `java.lang.Long#remainderUnsigned` instead of using `com.google.common.primitives.UnsignedLongs#remainderUnsigned`."
+      description: "Prefer `java.lang.Long#remainderUnsigned` instead of using `com.google.common.primitives.UnsignedLongs#remainder`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/preferlongremainderunsigned"
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferMathAddExact:
       name: "org.openrewrite.java.migrate.guava.PreferMathAddExact"
-      description: "Prefer `java.lang.Math#addExact` instead of using `com.google.common.math.IntMath#checkedAdd`\
-        \ or `com.google.common.math.IntMath#addExact`."
+      description: "Prefer `java.lang.Math#addExact` instead of using `com.google.common.math.IntMath#checkedAdd`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/prefermathaddexact"
       options: []
       isImperative: false
@@ -16566,16 +13087,14 @@ rewrite-migrate-java:
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferMathMultiplyExact:
       name: "org.openrewrite.java.migrate.guava.PreferMathMultiplyExact"
-      description: "Prefer `java.lang.Math#multiplyExact` instead of using `com.google.common.primitives.IntMath#checkedMultiply`\
-        \ or `com.google.common.primitives.IntMath#multiplyExact`."
+      description: "Prefer `java.lang.Math#multiplyExact` instead of using `com.google.common.math.IntMath#checkedMultiply`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/prefermathmultiplyexact"
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
     org.openrewrite.java.migrate.guava.PreferMathSubtractExact:
       name: "org.openrewrite.java.migrate.guava.PreferMathSubtractExact"
-      description: "Prefer `java.lang.Math#subtractExact` instead of using `com.google.common.primitives.IntMath#checkedSubtract`\
-        \ or `com.google.common.primitives.IntMath#subtractExact`."
+      description: "Prefer `java.lang.Math#subtractExact` instead of using `com.google.common.math.IntMath#checkedSubtract`."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/guava/prefermathsubtractexact"
       options: []
       isImperative: false
@@ -17520,6 +14039,13 @@ rewrite-migrate-java:
         \ instead of the Apache BVal implementation which was used for Bean Validation\
         \ 1.0 and 1.1."
       docLink: "https://docs.openrewrite.org/recipes/java/migrate/javaee8/apachedefaultprovider"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-migrate-java"
+    org.openrewrite.java.migrate.javaee8.MigrateToServlet3x:
+      name: "org.openrewrite.java.migrate.javaee8.MigrateToServlet3x"
+      description: "Update Java EE Servlet Dependencies to 3.x."
+      docLink: "https://docs.openrewrite.org/recipes/java/migrate/javaee8/migratetoservlet3x"
       options: []
       isImperative: false
       artifactId: "rewrite-migrate-java"
@@ -18994,7 +15520,7 @@ rewrite-migrate-java:
       artifactId: "rewrite-migrate-java"
 rewrite-netty:
   artifactId: "rewrite-netty"
-  version: "0.10.3"
+  version: "0.11.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.netty.EventLoopGroupToMultiThreadIoEventLoopGroupRecipes:
       name: "org.openrewrite.java.netty.EventLoopGroupToMultiThreadIoEventLoopGroupRecipes"
@@ -19072,7 +15598,7 @@ rewrite-netty:
       artifactId: "rewrite-netty"
 rewrite-okhttp:
   artifactId: "rewrite-okhttp"
-  version: "0.23.3"
+  version: "0.24.0"
   markdownRecipeDescriptors:
     org.openrewrite.okhttp.ReorderRequestBodyCreateArguments:
       name: "org.openrewrite.okhttp.ReorderRequestBodyCreateArguments"
@@ -19153,7 +15679,7 @@ rewrite-okhttp:
       artifactId: "rewrite-okhttp"
 rewrite-openapi:
   artifactId: "rewrite-openapi"
-  version: "0.32.3"
+  version: "0.33.0"
   markdownRecipeDescriptors:
     org.openrewrite.openapi.swagger.ConvertApiResponseCodesToStrings:
       name: "org.openrewrite.openapi.swagger.ConvertApiResponseCodesToStrings"
@@ -19292,7 +15818,7 @@ rewrite-openapi:
       artifactId: "rewrite-openapi"
 rewrite-prethink:
   artifactId: "rewrite-prethink"
-  version: "1.1.0"
+  version: "1.1.1"
   markdownRecipeDescriptors:
     org.openrewrite.prethink.ExportContext:
       name: "org.openrewrite.prethink.ExportContext"
@@ -19369,7 +15895,7 @@ rewrite-prethink:
       artifactId: "rewrite-prethink"
 rewrite-properties:
   artifactId: "rewrite-properties"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.properties.AddProperty:
       name: "org.openrewrite.properties.AddProperty"
@@ -19533,7 +16059,7 @@ rewrite-properties:
       artifactId: "rewrite-properties"
 rewrite-quarkus:
   artifactId: "rewrite-quarkus"
-  version: "2.33.3"
+  version: "2.34.0"
   markdownRecipeDescriptors:
     org.openrewrite.quarkus.AddQuarkusProperty:
       name: "org.openrewrite.quarkus.AddQuarkusProperty"
@@ -19801,7 +16327,7 @@ rewrite-quarkus:
       artifactId: "rewrite-quarkus"
 rewrite-rewrite:
   artifactId: "rewrite-rewrite"
-  version: "0.28.0"
+  version: "0.29.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.jspecify.MigrateFromOpenRewriteAnnotations:
       name: "org.openrewrite.java.jspecify.MigrateFromOpenRewriteAnnotations"
@@ -20149,7 +16675,7 @@ rewrite-rewrite:
       artifactId: "rewrite-rewrite"
 rewrite-spring:
   artifactId: "rewrite-spring"
-  version: "6.35.0"
+  version: "6.36.0"
   markdownRecipeDescriptors:
     org.openrewrite.gradle.spring.AddSpringDependencyManagementPlugin:
       name: "org.openrewrite.gradle.spring.AddSpringDependencyManagementPlugin"
@@ -20984,6 +17510,19 @@ rewrite-spring:
       options: []
       isImperative: false
       artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot2.RemoveStaleMockitoVersionProperty:
+      name: "org.openrewrite.java.spring.boot2.RemoveStaleMockitoVersionProperty"
+      description: "Spring Boot 2.7 switched to importing `org.mockito:mockito-bom:${mockito.version}`.\
+        \ A stale `mockito.version` override predating the Mockito BOM (before 4.3.0)\
+        \ resolves to a non-existent POM, which breaks dependency resolution and silently\
+        \ stalls later upgrades such as Spring Cloud. Only remove the property when\
+        \ it still points at such an older Mockito version, so that deliberate overrides\
+        \ on newer versions are preserved when this recipe is chained into later Spring\
+        \ Boot upgrades."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot2/removestalemockitoversionproperty"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
     org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils:
       name: "org.openrewrite.java.spring.boot2.ReplaceDeprecatedEnvironmentTestUtils"
       description: "Replaces any references to the deprecated `EnvironmentTestUtils`\
@@ -21750,6 +18289,24 @@ rewrite-spring:
       options: []
       isImperative: true
       artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.AddSpringBootStarterDataMongoDbReactiveTest:
+      name: "org.openrewrite.java.spring.boot4.AddSpringBootStarterDataMongoDbReactiveTest"
+      description: "Adds the dedicated Spring Boot 4.0 reactive Spring Data MongoDB\
+        \ test starter when the application directly uses the reactive Spring Data\
+        \ MongoDB starter and MongoDB test slices."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/addspringbootstarterdatamongodbreactivetest"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.AddSpringBootStarterDataMongoDbTest:
+      name: "org.openrewrite.java.spring.boot4.AddSpringBootStarterDataMongoDbTest"
+      description: "Adds the dedicated Spring Boot 4.0 imperative Spring Data MongoDB\
+        \ test starter when the application directly uses the imperative Spring Data\
+        \ MongoDB starter and MongoDB test slices."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/addspringbootstarterdatamongodbtest"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
     org.openrewrite.java.spring.boot4.AddSpringBootStarterFlyway:
       name: "org.openrewrite.java.spring.boot4.AddSpringBootStarterFlyway"
       description: "Adds the necessary Spring Boot 4.0 Flyway starter for autoconfiguration\
@@ -21766,6 +18323,40 @@ rewrite-spring:
       options: []
       isImperative: false
       artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.MigrateJacksonBomProperty:
+      name: "org.openrewrite.java.spring.boot4.MigrateJacksonBomProperty"
+      description: "In Spring Boot 4 `jackson-bom.version` controls the Jackson 3\
+        \ (`tools.jackson`) BOM, while the Jackson 2 BOM is controlled by `jackson-2-bom.version`.\
+        \ A Spring Boot 3 override pins a Jackson 2 version, so rename it to keep\
+        \ managing Jackson 2. Gated on a Spring Boot 3 parent so a deliberate Jackson\
+        \ 3 override on an already-Spring-Boot-4 project is left untouched."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/migratejacksonbomproperty"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.MigrateJsonschema2PojoToSpringBoot4:
+      name: "org.openrewrite.java.spring.boot4.MigrateJsonschema2PojoToSpringBoot4"
+      description: "Update `jsonschema2pojo-maven-plugin` to generate Jackson 3 and\
+        \ Jakarta Validation annotations compatible with Spring Boot 4. The `jackson3`\
+        \ annotation style was introduced in jsonschema2pojo 1.3.0, so the plugin\
+        \ is upgraded to at least that version first."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/migratejsonschema2pojotospringboot4"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.MigrateOpenApiGeneratorToSpringBoot4:
+      name: "org.openrewrite.java.spring.boot4.MigrateOpenApiGeneratorToSpringBoot4"
+      description: "Update `openapi-generator-maven-plugin` executions using the `spring`\
+        \ generator to generate Spring Boot 4 and Jackson 3 sources. Replaces the\
+        \ deprecated `useSpringBoot3` option with `useSpringBoot4` and enables `useJackson3`,\
+        \ matching the Jackson 3 baseline of Spring Boot 4. Enabling `useSpringBoot4`\
+        \ also enables `useJakartaEe`, so it is left implicit. The `useSpringBoot4`/`useJackson3`\
+        \ options were introduced in OpenAPI Generator 7.16.0, so the plugin is upgraded\
+        \ to at least that version first."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/migrateopenapigeneratortospringboot4"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-spring"
     org.openrewrite.java.spring.boot4.MigrateToModularStarters:
       name: "org.openrewrite.java.spring.boot4.MigrateToModularStarters"
       description: "Adds the necessary Spring Boot 4.0 starter dependencies based\
@@ -21775,6 +18366,18 @@ rewrite-spring:
         \ (like data-jpa) include lower-level ones (like jdbc) transitively, so only\
         \ the highest-level detected starter is added for each technology."
       docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/migratetomodularstarters-community-edition"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.RelocateWebServerClasses:
+      name: "org.openrewrite.java.spring.boot4.RelocateWebServerClasses"
+      description: "Spring Boot 4.0 relocated the embedded web server (Tomcat, Jetty)\
+        \ and web server application context classes into dedicated modular packages.\
+        \ This recipe updates references to the relocated classes' new fully-qualified\
+        \ names, including the servlet and reactive `WebServerFactory` variants, which\
+        \ moved into `servlet` and `reactive` subpackages. Undertow support was removed\
+        \ in Spring Boot 4.0 and is intentionally not handled here."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/relocatewebserverclasses"
       options: []
       isImperative: false
       artifactId: "rewrite-spring"
@@ -21799,6 +18402,13 @@ rewrite-spring:
       name: "org.openrewrite.java.spring.boot4.SpringBootProperties_4_0"
       description: "Migrate properties found in `application.properties` and `application.yml`."
       docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/springbootproperties_4_0"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.boot4.SpringBootProperties_4_1:
+      name: "org.openrewrite.java.spring.boot4.SpringBootProperties_4_1"
+      description: "Migrate properties found in `application.properties` and `application.yml`."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/boot4/springbootproperties_4_1-community-edition"
       options: []
       isImperative: false
       artifactId: "rewrite-spring"
@@ -22035,6 +18645,15 @@ rewrite-spring:
       options: []
       isImperative: true
       artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.data.UpgradeSpringDataMongoDb_5_0:
+      name: "org.openrewrite.java.spring.data.UpgradeSpringDataMongoDb_5_0"
+      description: "Align explicitly versioned Spring Data MongoDB and supported MongoDB\
+        \ JVM driver dependencies with Spring Data MongoDB 5.0. Managed, versionless\
+        \ dependencies remain managed."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/data/upgradespringdatamongodb_5_0"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
     org.openrewrite.java.spring.data.UpgradeSpringData_2_3:
       name: "org.openrewrite.java.spring.data.UpgradeSpringData_2_3"
       description: "Migrate applications to the latest Spring Data 2.3 release."
@@ -22069,6 +18688,14 @@ rewrite-spring:
       name: "org.openrewrite.java.spring.data.UpgradeSpringData_3_4"
       description: "Migrate applications to the latest Spring Data JPA 3.4 release."
       docLink: "https://docs.openrewrite.org/recipes/java/spring/data/upgradespringdata_3_4"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.data.UpgradeSpringData_4_0:
+      name: "org.openrewrite.java.spring.data.UpgradeSpringData_4_0"
+      description: "Migrate applications to the Spring Data 2025.1 release train.\
+        \ Datastore-specific migration support is added incrementally."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/data/upgradespringdata_4_0"
       options: []
       isImperative: false
       artifactId: "rewrite-spring"
@@ -22431,6 +19058,14 @@ rewrite-spring:
       docLink: "https://docs.openrewrite.org/recipes/java/spring/http/springwebdependency"
       options: []
       isImperative: false
+      artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.kafka.DefaultErrorHandlerSetBackOffToConstructor:
+      name: "org.openrewrite.java.spring.kafka.DefaultErrorHandlerSetBackOffToConstructor"
+      description: "`DefaultErrorHandler` does not have a `setBackOff(BackOff)` method;\
+        \ pass the `BackOff` to the constructor instead."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/kafka/defaulterrorhandlersetbackofftoconstructor"
+      options: []
+      isImperative: true
       artifactId: "rewrite-spring"
     org.openrewrite.java.spring.kafka.KafkaOperationsSendReturnType:
       name: "org.openrewrite.java.spring.kafka.KafkaOperationsSendReturnType"
@@ -22937,6 +19572,16 @@ rewrite-spring:
       options: []
       isImperative: true
       artifactId: "rewrite-spring"
+    org.openrewrite.java.spring.util.concurrent.ListenableToCompletableFuture:
+      name: "org.openrewrite.java.spring.util.concurrent.ListenableToCompletableFuture"
+      description: "Spring Framework 6.0 removed `org.springframework.util.concurrent.ListenableFuture`\
+        \ in favor of `java.util.concurrent.CompletableFuture`. This recipe migrates\
+        \ `ListenableFuture` types, along with their `addCallback` invocations and\
+        \ `ListenableFutureCallback` implementations, to `CompletableFuture`."
+      docLink: "https://docs.openrewrite.org/recipes/java/spring/util/concurrent/listenabletocompletablefuture"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-spring"
     org.openrewrite.java.spring.ws.MigrateAxiomToSaaj:
       name: "org.openrewrite.java.spring.ws.MigrateAxiomToSaaj"
       description: "Migrate from Apache Axiom SOAP message handling to SAAJ (SOAP\
@@ -23056,7 +19701,7 @@ rewrite-spring:
       artifactId: "rewrite-spring"
 rewrite-spring-to-quarkus:
   artifactId: "rewrite-spring-to-quarkus"
-  version: "0.10.3"
+  version: "0.11.0"
   markdownRecipeDescriptors:
     org.openrewrite.quarkus.spring.AddQuarkusMavenPlugin:
       name: "org.openrewrite.quarkus.spring.AddQuarkusMavenPlugin"
@@ -23583,7 +20228,7 @@ rewrite-spring-to-quarkus:
       artifactId: "rewrite-spring-to-quarkus"
 rewrite-static-analysis:
   artifactId: "rewrite-static-analysis"
-  version: "2.39.0"
+  version: "2.40.0"
   markdownRecipeDescriptors:
     org.openrewrite.recipe.rewrite-static-analysis.InlineDeprecatedMethods:
       name: "org.openrewrite.recipe.rewrite-static-analysis.InlineDeprecatedMethods"
@@ -24067,6 +20712,27 @@ rewrite-static-analysis:
       options: []
       isImperative: true
       artifactId: "rewrite-static-analysis"
+    org.openrewrite.staticanalysis.FindMissingJavadocOnPublicMethods:
+      name: "org.openrewrite.staticanalysis.FindMissingJavadocOnPublicMethods"
+      description: "Locates `public` method declarations that are not documented with\
+        \ a Javadoc comment, marks them with a search result, and records them in\
+        \ a data table."
+      docLink: "https://docs.openrewrite.org/recipes/staticanalysis/findmissingjavadoconpublicmethods"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-static-analysis"
+    org.openrewrite.staticanalysis.FindNewExceptionWithoutCause:
+      name: "org.openrewrite.staticanalysis.FindNewExceptionWithoutCause"
+      description: "Finds `catch` blocks that throw a newly created exception without\
+        \ referencing the caught exception, which discards the original exception's\
+        \ stack trace and message. Data flow (taint) tracking is used to establish\
+        \ whether the caught exception—or any value derived from it—reaches the thrown\
+        \ exception, so indirect references through local variables and string concatenation\
+        \ are not falsely reported. This mirrors PMD's `PreserveStackTrace` rule."
+      docLink: "https://docs.openrewrite.org/recipes/staticanalysis/findnewexceptionwithoutcause"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-static-analysis"
     org.openrewrite.staticanalysis.FixStringFormatExpressions:
       name: "org.openrewrite.staticanalysis.FixStringFormatExpressions"
       description: "Fix `String#format` and `String#formatted` expressions by replacing\
@@ -24289,6 +20955,18 @@ rewrite-static-analysis:
         type: "Boolean"
         required: false
       isImperative: true
+      artifactId: "rewrite-static-analysis"
+    org.openrewrite.staticanalysis.ModernizeCollections:
+      name: "org.openrewrite.staticanalysis.ModernizeCollections"
+      description: "Replace the legacy synchronized types `Hashtable`, `Vector`, `Stack`,\
+        \ and `StringBuffer` with their modern unsynchronized counterparts `HashMap`,\
+        \ `ArrayList`, `Deque`/`ArrayDeque`, and `StringBuilder`. Each replacement\
+        \ is only applied when data flow analysis can prove the instance is a local\
+        \ variable that never escapes its method, so the synchronization it provided\
+        \ is redundant."
+      docLink: "https://docs.openrewrite.org/recipes/staticanalysis/modernizecollections"
+      options: []
+      isImperative: false
       artifactId: "rewrite-static-analysis"
     org.openrewrite.staticanalysis.ModifierOrder:
       name: "org.openrewrite.staticanalysis.ModifierOrder"
@@ -24888,6 +21566,20 @@ rewrite-static-analysis:
         required: false
       isImperative: true
       artifactId: "rewrite-static-analysis"
+    org.openrewrite.staticanalysis.ReplaceHashtableWithHashMap:
+      name: "org.openrewrite.staticanalysis.ReplaceHashtableWithHashMap"
+      description: "`Hashtable` synchronizes every operation, which adds overhead\
+        \ in the common single-threaded case. This recipe replaces a local `Hashtable`\
+        \ with a `HashMap` when data flow analysis can prove the `Hashtable` never\
+        \ escapes its method (it is not returned, assigned to a field, or passed as\
+        \ an argument), so no other thread can observe it and the synchronization\
+        \ is redundant. Fields, escaping variables, and `Hashtable`-specific method\
+        \ usages (`contains`, `elements`, `keys`) are left untouched. `HashMap` permits\
+        \ `null` keys and values, so it accepts every input `Hashtable` did."
+      docLink: "https://docs.openrewrite.org/recipes/staticanalysis/replacehashtablewithhashmap"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-static-analysis"
     org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference:
       name: "org.openrewrite.staticanalysis.ReplaceLambdaWithMethodReference"
       description: "Replaces the single statement lambdas `o -> o instanceOf X`, `o\
@@ -24926,6 +21618,19 @@ rewrite-static-analysis:
         \ in single-threaded contexts and exposes non-stack operations like random\
         \ index access."
       docLink: "https://docs.openrewrite.org/recipes/staticanalysis/replacestackwithdeque"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-static-analysis"
+    org.openrewrite.staticanalysis.ReplaceStringBufferWithStringBuilder:
+      name: "org.openrewrite.staticanalysis.ReplaceStringBufferWithStringBuilder"
+      description: "`StringBuffer` synchronizes every operation, which adds overhead\
+        \ in the common single-threaded case. `StringBuilder` exposes the identical\
+        \ API without the synchronization. This recipe replaces a local `StringBuffer`\
+        \ with a `StringBuilder` when data flow analysis can prove the `StringBuffer`\
+        \ never escapes its method (it is not returned, assigned to a field, or passed\
+        \ as an argument), so no other thread can observe it and the synchronization\
+        \ is redundant. Fields and escaping variables are left untouched."
+      docLink: "https://docs.openrewrite.org/recipes/staticanalysis/replacestringbufferwithstringbuilder"
       options: []
       isImperative: true
       artifactId: "rewrite-static-analysis"
@@ -24980,6 +21685,19 @@ rewrite-static-analysis:
       description: "Replace `org.apache.commons.lang3.Validate.notNull(Object, String,\
         \ Object[])` with `Objects.requireNonNull(Object, String)`."
       docLink: "https://docs.openrewrite.org/recipes/staticanalysis/replacevalidatenotnullhavingvarargswithobjectsrequirenonnull"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-static-analysis"
+    org.openrewrite.staticanalysis.ReplaceVectorWithArrayList:
+      name: "org.openrewrite.staticanalysis.ReplaceVectorWithArrayList"
+      description: "`Vector` synchronizes every operation, which adds overhead in\
+        \ the common single-threaded case. This recipe replaces a local `Vector` with\
+        \ an `ArrayList` when data flow analysis can prove the `Vector` never escapes\
+        \ its method (it is not returned, assigned to a field, or passed as an argument),\
+        \ so no other thread can observe it and the synchronization is redundant.\
+        \ Fields, escaping variables, `Vector`-specific method usages (like `elementAt`\
+        \ or `addElement`), and the `Vector(int, int)` constructor are left untouched."
+      docLink: "https://docs.openrewrite.org/recipes/staticanalysis/replacevectorwitharraylist"
       options: []
       isImperative: true
       artifactId: "rewrite-static-analysis"
@@ -25288,10 +22006,15 @@ rewrite-static-analysis:
         \ remove unused, checked exceptions if:\n\n - The declaring class or the method\
         \ declaration is `final`.\n - The method declaration is `static` or `private`.\n\
         \ - The method overrides a method declaration in a super class and the super\
-        \ class does not throw the exception.\n - The method is `public` or `protected`\
-        \ and the exception is not documented via a JavaDoc as a `@throws` tag.\n\n\
-        Declaring exceptions that are never thrown misleads callers into writing unnecessary\
-        \ error-handling code and obscures the method's true behavior."
+        \ class does not throw the exception.\n - The method is `public` and the exception\
+        \ is not documented via a JavaDoc as a `@throws` tag.\n\nThe `throws` declaration\
+        \ is retained on overridable methods (package-private and `protected` methods\
+        \ on non-`final` classes), and on `public` methods overridden within the same\
+        \ source file, so that a subclass override which does throw the exception\
+        \ keeps compiling. Overrides in other source files cannot be detected without\
+        \ a scanning recipe and are therefore not accounted for.\n\nDeclaring exceptions\
+        \ that are never thrown misleads callers into writing unnecessary error-handling\
+        \ code and obscures the method's true behavior."
       docLink: "https://docs.openrewrite.org/recipes/staticanalysis/unnecessarythrows"
       options: []
       isImperative: true
@@ -25524,7 +22247,7 @@ rewrite-static-analysis:
       artifactId: "rewrite-static-analysis"
 rewrite-testing-frameworks:
   artifactId: "rewrite-testing-frameworks"
-  version: "3.42.0"
+  version: "3.43.0"
   markdownRecipeDescriptors:
     org.openrewrite.java.testing.archunit.ArchUnit0to1Migration:
       name: "org.openrewrite.java.testing.archunit.ArchUnit0to1Migration"
@@ -26101,6 +22824,18 @@ rewrite-testing-frameworks:
       options: []
       isImperative: false
       artifactId: "rewrite-testing-frameworks"
+    org.openrewrite.java.testing.assertj.SimplifyAssertJEqualityAssertion:
+      name: "org.openrewrite.java.testing.assertj.SimplifyAssertJEqualityAssertion"
+      description: "Replace `assertThat(x == y).isTrue()` and its variants with the\
+        \ dedicated assertion for whatever `==` actually compares: `assertThat(x).isNull()`\
+        \ against the `null` literal, `assertThat(x).isEqualTo(y)` when either operand\
+        \ is a primitive and the comparison is therefore by value, and `assertThat(x).isSameAs(y)`\
+        \ when both operands are reference types. Floating point operands are left\
+        \ alone, as `==` and `isEqualTo` disagree on `NaN` and `-0.0`."
+      docLink: "https://docs.openrewrite.org/recipes/java/testing/assertj/simplifyassertjequalityassertion"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-testing-frameworks"
     org.openrewrite.java.testing.assertj.SimplifyAssertJInstanceOfAssertion:
       name: "org.openrewrite.java.testing.assertj.SimplifyAssertJInstanceOfAssertion"
       description: "Replace `assertThat(x instanceof Type).isTrue()` with the dedicated\
@@ -26108,17 +22843,6 @@ rewrite-testing-frameworks:
         \ variants with `isNotInstanceOf`, so failures describe the actual type rather\
         \ than just `expected true but was false`."
       docLink: "https://docs.openrewrite.org/recipes/java/testing/assertj/simplifyassertjinstanceofassertion"
-      options: []
-      isImperative: true
-      artifactId: "rewrite-testing-frameworks"
-    org.openrewrite.java.testing.assertj.SimplifyAssertJNullRelatedAssertion:
-      name: "org.openrewrite.java.testing.assertj.SimplifyAssertJNullRelatedAssertion"
-      description: "Replace `assertThat(x == null).isTrue()` and its variants with\
-        \ the dedicated `assertThat(x).isNull()` / `assertThat(x).isNotNull()`. Beyond\
-        \ being more expressive, this avoids the compilation error that results when\
-        \ the `null` literal ends up as the `assertThat` argument (e.g. `assertThat(null\
-        \ == x).isTrue()` becoming `assertThat(null).isSameAs(x)`)."
-      docLink: "https://docs.openrewrite.org/recipes/java/testing/assertj/simplifyassertjnullrelatedassertion"
       options: []
       isImperative: true
       artifactId: "rewrite-testing-frameworks"
@@ -27788,6 +24512,23 @@ rewrite-testing-frameworks:
       options: []
       isImperative: true
       artifactId: "rewrite-testing-frameworks"
+    org.openrewrite.java.testing.testng.TestNgAssertionToAssertJ:
+      name: "org.openrewrite.java.testing.testng.TestNgAssertionToAssertJ"
+      description: "Convert TestNG-style hard assertions on `org.testng.asserts.Assertion`\
+        \ instances to static AssertJ `assertThat(...)`, removing the now-unused local\
+        \ `Assertion` instance."
+      docLink: "https://docs.openrewrite.org/recipes/java/testing/testng/testngassertiontoassertj"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-testing-frameworks"
+    org.openrewrite.java.testing.testng.TestNgSoftAssertToAssertJ:
+      name: "org.openrewrite.java.testing.testng.TestNgSoftAssertToAssertJ"
+      description: "Convert TestNG-style soft assertions (`org.testng.asserts.SoftAssert`)\
+        \ to AssertJ soft assertions (`org.assertj.core.api.SoftAssertions`)."
+      docLink: "https://docs.openrewrite.org/recipes/java/testing/testng/testngsoftasserttoassertj"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-testing-frameworks"
     org.openrewrite.java.testing.testng.TestNgToAssertj:
       name: "org.openrewrite.java.testing.testng.TestNgToAssertj"
       description: "Convert assertions from `org.testng.Assert` to `org.assertj.core.api.Assertions`."
@@ -27846,7 +24587,7 @@ rewrite-testing-frameworks:
       artifactId: "rewrite-testing-frameworks"
 rewrite-third-party:
   artifactId: "rewrite-third-party"
-  version: "0.43.0"
+  version: "0.44.0"
   markdownRecipeDescriptors:
     ai.timefold.solver.migration.ChangeVersion:
       name: "ai.timefold.solver.migration.ChangeVersion"
@@ -28990,10 +25731,24 @@ rewrite-third-party:
       options: []
       isImperative: false
       artifactId: "rewrite-third-party"
+    io.quarkus.updates.camel.camel418_3.CamelQuarkusMigrationRecipe:
+      name: "io.quarkus.updates.camel.camel418_3.CamelQuarkusMigrationRecipe"
+      description: "Migrates `camel 4.18` Quarkus application to `camel 4.18.3`."
+      docLink: "https://docs.openrewrite.org/recipes/quarkus/updates/camel/camel418_3/camelquarkusmigrationrecipe"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
     io.quarkus.updates.camel.camel420.CamelQuarkusMigrationRecipe:
       name: "io.quarkus.updates.camel.camel420.CamelQuarkusMigrationRecipe"
       description: "Migrates `camel 4.18` Quarkus application to `camel 4.20`."
       docLink: "https://docs.openrewrite.org/recipes/quarkus/updates/camel/camel420/camelquarkusmigrationrecipe"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    io.quarkus.updates.camel.camel421.CamelQuarkusMigrationRecipe:
+      name: "io.quarkus.updates.camel.camel421.CamelQuarkusMigrationRecipe"
+      description: "Migrates `camel 4.20` Quarkus application to `camel 4.21`."
+      docLink: "https://docs.openrewrite.org/recipes/quarkus/updates/camel/camel421/camelquarkusmigrationrecipe"
       options: []
       isImperative: false
       artifactId: "rewrite-third-party"
@@ -29798,6 +26553,14 @@ rewrite-third-party:
       options: []
       isImperative: false
       artifactId: "rewrite-third-party"
+    io.quarkus.updates.core.quarkus338.ElasticsearchRestClientMigration:
+      name: "io.quarkus.updates.core.quarkus338.ElasticsearchRestClientMigration"
+      description: "Migrate Elasticsearch low-level REST client from org.elasticsearch.client\
+        \ to co.elastic.clients.transport.rest5_client.low_level."
+      docLink: "https://docs.openrewrite.org/recipes/quarkus/updates/core/quarkus338/elasticsearchrestclientmigration"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
     io.quarkus.updates.core.quarkus35.MutinyUniAndGroupCombinedWith:
       name: "io.quarkus.updates.core.quarkus35.MutinyUniAndGroupCombinedWith"
       description: ""
@@ -30112,9 +26875,17 @@ rewrite-third-party:
       options: []
       isImperative: false
       artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.Camel418LTSMigrationRecipe:
+      name: "org.apache.camel.upgrade.Camel418LTSMigrationRecipe"
+      description: "Migrates Apache Camel application to 4.18 LTS. This recipe aggregates\
+        \ all migration steps from 4.0 to 4.18.3."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418ltsmigrationrecipe"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.CamelMigrationRecipe"
-      description: "Migrates Apache Camel application to 4.20.0."
+      description: "Migrates Apache Camel application to 4.21.0."
       docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camelmigrationrecipe"
       options: []
       isImperative: false
@@ -30562,6 +27333,336 @@ rewrite-third-party:
       options: []
       isImperative: false
       artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418.upgradeDnsHeaders:
+      name: "org.apache.camel.upgrade.camel418.upgradeDnsHeaders"
+      description: "Renames DNS header constants from dns.* pattern to CamelDns* pattern\
+        \ only if camel-dns dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418/upgradednsheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418.upgradeKafkaRecipes:
+      name: "org.apache.camel.upgrade.camel418.upgradeKafkaRecipes"
+      description: "Renames Kafka header constants only if camel-kafka dependency\
+        \ is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418/upgradekafkarecipes"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418.upgradeSalesforceHeaders:
+      name: "org.apache.camel.upgrade.camel418.upgradeSalesforceHeaders"
+      description: "Renames Salesforce-specific header constants to CamelSalesforce*\
+        \ pattern when camel-salesforce is present. Only migrates headers with Salesforce-specific\
+        \ terminology (sObject*, apex*, pkChunking*) to minimize false positives.\
+        \ Generic headers like 'limit', 'contentType', 'jobId' are excluded as they\
+        \ could conflict with other components."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418/upgradesalesforceheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_1.CamelMigrationRecipe:
+      name: "org.apache.camel.upgrade.camel418_1.CamelMigrationRecipe"
+      description: "Migrates `camel 4.18.0` application to `camel 4.18.1`."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_1/camelmigrationrecipe"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_1.XmlDsl418_1SagaRecipe:
+      name: "org.apache.camel.upgrade.camel418_1.XmlDsl418_1SagaRecipe"
+      description: "Apache Camel XML DSL migration from version 4.18 to 4.19. Converts\
+        \ saga compensation and completion child elements to attributes."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_1/xmldsl418_1sagarecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_1.YamlDsl418_1SagaRecipe:
+      name: "org.apache.camel.upgrade.camel418_1.YamlDsl418_1SagaRecipe"
+      description: "Apache Camel YAML DSL migration from version 4.18 to 4.19. Flattens\
+        \ saga compensation and completion nested uri to direct values."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_1/yamldsl418_1sagarecipe"
+      options: []
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_1.routePolicy:
+      name: "org.apache.camel.upgrade.camel418_1.routePolicy"
+      description: "Renamed routePolicy to routePolicyRef on the route node."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_1/routepolicy"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_1.saga:
+      name: "org.apache.camel.upgrade.camel418_1.saga"
+      description: "The Saga EIP has fixed the model for how to configure completion\
+        \ and compensation URIs."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_1/saga"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.CamelMigrationRecipe:
+      name: "org.apache.camel.upgrade.camel418_3.CamelMigrationRecipe"
+      description: "Migrates `camel 4.18.1` application to `camel 4.18.3`."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/camelmigrationrecipe"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderInJavaMethod:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderInJavaMethod"
+      description: "Renames header references in Message.setHeader() and Message.getHeader()\
+        \ method calls. Only migrates string literals in safe contexts. Does NOT migrate\
+        \ dynamic header names or Map.get() calls."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderinjavamethod"
+      options:
+      - name: "newHeaderName"
+        type: "String"
+        required: true
+      - name: "oldHeaderName"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderInSimpleExpression:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderInSimpleExpression"
+      description: "Renames header references in Simple expressions like ${header.oldName}\
+        \ → ${header.newName}. Only migrates expressions inside simple() method calls."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderinsimpleexpression"
+      options:
+      - name: "newHeaderName"
+        type: "String"
+        required: true
+      - name: "oldHeaderName"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderInXmlDsl:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderInXmlDsl"
+      description: "Renames header references in XML DSL <setHeader name=\"...\">,\
+        \ <header name=\"...\">, and <removeHeader name=\"...\"> elements."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderinxmldsl"
+      options:
+      - name: "newHeaderName"
+        type: "String"
+        required: true
+      - name: "oldHeaderName"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderInYamlDsl:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderInYamlDsl"
+      description: "Renames header references in YAML DSL setHeader.name, header.name,\
+        \ and removeHeader.name entries."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderinyamldsl"
+      options:
+      - name: "newHeaderName"
+        type: "String"
+        required: true
+      - name: "oldHeaderName"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixInJavaMethod:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixInJavaMethod"
+      description: "Renames header prefixes in Message.setHeader() and Message.getHeader()\
+        \ method calls. Only migrates string literals in safe contexts. Does NOT migrate\
+        \ dynamic header names or Map.get() calls."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderprefixinjavamethod"
+      options:
+      - name: "newPrefix"
+        type: "String"
+        required: true
+      - name: "oldPrefix"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixInSimpleExpression:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixInSimpleExpression"
+      description: "Renames header prefixes in Simple expressions like ${header.SolrField.id}\
+        \ → ${header.CamelSolrField.id}. Only migrates expressions inside simple()\
+        \ method calls."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderprefixinsimpleexpression"
+      options:
+      - name: "newPrefix"
+        type: "String"
+        required: true
+      - name: "oldPrefix"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixInXmlDsl:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixInXmlDsl"
+      description: "Renames header prefixes in XML DSL <setHeader name=\"...\">, <header\
+        \ name=\"...\">, and <removeHeader name=\"...\"> elements."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderprefixinxmldsl"
+      options:
+      - name: "newPrefix"
+        type: "String"
+        required: true
+      - name: "oldPrefix"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixInYamlDsl:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixInYamlDsl"
+      description: "Renames header prefixes in YAML DSL setHeader.name, header.name,\
+        \ and removeHeader.name entries."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderprefixinyamldsl"
+      options:
+      - name: "newPrefix"
+        type: "String"
+        required: true
+      - name: "oldPrefix"
+        type: "String"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixes:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaderPrefixes"
+      description: "Renames Camel header prefixes across all DSL types: Java method\
+        \ calls (.setHeader, .getHeader), Simple expressions (${header.name}), XML\
+        \ DSL (<setHeader name=\"...\">), and YAML DSL (setHeader.name). Any header\
+        \ starting with an old prefix gets that prefix replaced with the new prefix.\
+        \ Only migrates safe contexts to avoid false positives."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaderprefixes"
+      options:
+      - name: "prefixMappings"
+        type: "Map"
+        required: true
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.RenameHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.RenameHeaders"
+      description: "Renames Camel header(s) from old name(s) to new name(s) across\
+        \ all DSL types: Java method calls (.setHeader, .getHeader), Simple expressions\
+        \ (${header.name}), XML DSL (<setHeader name=\"...\">), and YAML DSL (setHeader.name).\
+        \ Supports both single header rename (oldHeaderName/newHeaderName) and bulk\
+        \ rename (headerMappings). Only migrates safe contexts to avoid false positives."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/renameheaders"
+      options:
+      - name: "headerMappings"
+        type: "Map"
+        required: false
+      - name: "newHeaderName"
+        type: "String"
+        required: false
+      - name: "oldHeaderName"
+        type: "String"
+        required: false
+      isImperative: true
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeGitHub2Headers:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeGitHub2Headers"
+      description: "Renames GitHub2 producer header constants to CamelGitHub* pattern\
+        \ only if camel-github dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradegithub2headers"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeGoogleCloudHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeGoogleCloudHeaders"
+      description: "Renames Google Cloud header constants to CamelGoogleCloud* pattern\
+        \ only if camel-google-functions dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradegooglecloudheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeGoogleSecretManagerHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeGoogleSecretManagerHeaders"
+      description: "Renames Google Secret Manager header constants to CamelGoogleSecretManager*\
+        \ pattern only if camel-google-secret-manager dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradegooglesecretmanagerheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeJGroupsHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeJGroupsHeaders"
+      description: "Renames JGroups header constants from JGROUPS_* to CamelJGroups*\
+        \ pattern only if camel-jgroups dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradejgroupsheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeJGroupsRaftHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeJGroupsRaftHeaders"
+      description: "Renames JGroups Raft header constants from JGROUPSRAFT_* to CamelJGroupsRaft*\
+        \ pattern only if camel-jgroups-raft dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradejgroupsraftheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeJiraHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeJiraHeaders"
+      description: "Renames JIRA header constants to CamelJira* pattern only if camel-jira\
+        \ dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradejiraheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeLuceneHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeLuceneHeaders"
+      description: "Renames Lucene-specific header constants to CamelLucene* pattern\
+        \ only if camel-lucene dependency is present. Generic header 'QUERY' is excluded\
+        \ to prevent false positives. Note - DSL accessor methods (returnLuceneDocs()\
+        \ → luceneReturnLuceneDocs()) are NOT migrated and require manual update."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradeluceneheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeMongoDbGridFsHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeMongoDbGridFsHeaders"
+      description: "Renames MongoDB GridFS header constants to CamelGridFs* pattern\
+        \ only if camel-mongodb-gridfs dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgrademongodbgridfsheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeOpenstackHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeOpenstackHeaders"
+      description: "Renames OpenStack-specific header constants to CamelOpenstack*\
+        \ pattern only if camel-openstack dependency is present. Generic headers (*Id,\
+        \ *Name, containerName, objectName, imageRef, interfaceType, ipVersion) are\
+        \ excluded to prevent false positives."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradeopenstackheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeShiroHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeShiroHeaders"
+      description: "Renames Shiro security header constants from SHIRO_SECURITY_*\
+        \ to CamelShiroSecurity* pattern only if camel-shiro dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradeshiroheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeSolrHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeSolrHeaders"
+      description: "Renames Solr header prefixes SolrField. and SolrParam. to CamelSolrField.\
+        \ and CamelSolrParam. when camel-solr dependency is present. Routes that reference\
+        \ constants symbolically continue to work without changes. Note - Because\
+        \ the renamed prefixes now begin with Camel, they are stripped by HeaderFilterStrategy\
+        \ when crossing transport boundaries. Routes that bridge external transports\
+        \ and want to drive Solr fields/params from headers must carry values in non-Camel-prefixed\
+        \ headers and map them in the route."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradesolrheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel418_3.upgradeWeb3jHeaders:
+      name: "org.apache.camel.upgrade.camel418_3.upgradeWeb3jHeaders"
+      description: "Renames Web3j-specific header constants to CamelWeb3j* pattern\
+        \ only if camel-web3j dependency is present. Generic headers without clear\
+        \ blockchain context (ADDRESS, ADDRESSES, POSITION, SOURCE_CODE, DATABASE_NAME,\
+        \ KEY_NAME, CLIENT_ID, PRIORITY, TTL, ERROR_CODE, ERROR_DATA, ERROR_MESSAGE,\
+        \ TOPICS, FILTER_ID) are excluded to prevent false positives. Note - DSL accessor\
+        \ renames and operation semantics still require manual review."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel418_3/upgradeweb3jheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel419.CamelMigrationRecipe:
       name: "org.apache.camel.upgrade.camel419.CamelMigrationRecipe"
       description: "Migrates `camel 4.18` application to `camel 4.19`."
@@ -30577,27 +27678,11 @@ rewrite-third-party:
       options: []
       isImperative: true
       artifactId: "rewrite-third-party"
-    org.apache.camel.upgrade.camel419.XmlDsl419SagaRecipe:
-      name: "org.apache.camel.upgrade.camel419.XmlDsl419SagaRecipe"
-      description: "Apache Camel XML DSL migration from version 4.18 to 4.19. Converts\
-        \ saga compensation and completion child elements to attributes."
-      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel419/xmldsl419sagarecipe"
-      options: []
-      isImperative: true
-      artifactId: "rewrite-third-party"
     org.apache.camel.upgrade.camel419.YamlDsl419RoutePolicyRecipe:
       name: "org.apache.camel.upgrade.camel419.YamlDsl419RoutePolicyRecipe"
       description: "Apache Camel YAML DSL migration from version 4.18 to 4.19. Renames\
         \ routePolicy to routePolicyRef."
       docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel419/yamldsl419routepolicyrecipe"
-      options: []
-      isImperative: true
-      artifactId: "rewrite-third-party"
-    org.apache.camel.upgrade.camel419.YamlDsl419SagaRecipe:
-      name: "org.apache.camel.upgrade.camel419.YamlDsl419SagaRecipe"
-      description: "Apache Camel YAML DSL migration from version 4.18 to 4.19. Flattens\
-        \ saga compensation and completion nested uri to direct values."
-      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel419/yamldsl419sagarecipe"
       options: []
       isImperative: true
       artifactId: "rewrite-third-party"
@@ -30646,6 +27731,209 @@ rewrite-third-party:
         URIs with slashes in topic names are left unchanged to avoid ambiguity between\
         \ V1 and V2 formats.\nWorks across Java, XML DSL, and YAML DSL.\n"
       docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel420/migratepulsaruris"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.CamelMigrationRecipe:
+      name: "org.apache.camel.upgrade.camel421.CamelMigrationRecipe"
+      description: "Migrates `camel 4.20` application to `camel 4.21`."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/camelmigrationrecipe"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.migrateAws2S3ListObjectsApi:
+      name: "org.apache.camel.upgrade.camel421.migrateAws2S3ListObjectsApi"
+      description: "Migrates ListObjectsRequest/Response to ListObjectsV2Request/Response\
+        \ for the listObjects operation (pojoRequest=true only)."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/migrateaws2s3listobjectsapi"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.migrateErrorRegistryProperties:
+      name: "org.apache.camel.upgrade.camel421.migrateErrorRegistryProperties"
+      description: "Migrates Error Registry configuration from camel.main.errorRegistryXxx\
+        \ to camel.errorRegistry.* pattern in .properties files. Note - errorRegistryStackTraceEnabled\
+        \ is removed (always captures full exception now). YAML files require manual\
+        \ migration."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/migrateerrorregistryproperties"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.removeCamelAwsXrayDependency:
+      name: "org.apache.camel.upgrade.camel421.removeCamelAwsXrayDependency"
+      description: "Removes the camel-aws-xray dependency which was removed in Camel\
+        \ 4.21 (deprecated since 4.17, AWS X-Ray service in maintenance mode)."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/removecamelawsxraydependency"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.removeCamelElytronDependency:
+      name: "org.apache.camel.upgrade.camel421.removeCamelElytronDependency"
+      description: "Removes the camel-elytron dependency which was removed in Camel\
+        \ 4.21 (deprecated since 4.0)."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/removecamelelytrondependency"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.removeCamelGithubDependency:
+      name: "org.apache.camel.upgrade.camel421.removeCamelGithubDependency"
+      description: "Removes the camel-github dependency which was removed in Camel\
+        \ 4.21 (deprecated in 4.18, replaced by camel-github2)."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/removecamelgithubdependency"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.removeCamelGrapeDependency:
+      name: "org.apache.camel.upgrade.camel421.removeCamelGrapeDependency"
+      description: "Removes the camel-grape dependency which was removed in Camel\
+        \ 4.21 (deprecated since 4.1)."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/removecamelgrapedependency"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.removeCamelGuavaEventbusDependency:
+      name: "org.apache.camel.upgrade.camel421.removeCamelGuavaEventbusDependency"
+      description: "Removes the camel-guava-eventbus dependency which was removed\
+        \ in Camel 4.21 (deprecated since 4.6)."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/removecamelguavaeventbusdependency"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.removeCamelStompDependency:
+      name: "org.apache.camel.upgrade.camel421.removeCamelStompDependency"
+      description: "Removes the camel-stomp dependency which was removed in Camel\
+        \ 4.21 (deprecated since 4.17)."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/removecamelstompdependency"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeArangoDbHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeArangoDbHeaders"
+      description: "Renames ArangoDB header constants to CamelArangoDb* pattern only\
+        \ if camel-arangodb dependency is present. Note - DSL accessor methods (key()\
+        \ → arangoDbKey(), resultClassType() → arangoDbResultClassType()) are NOT\
+        \ migrated and require manual update."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradearangodbheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeCouchbaseHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeCouchbaseHeaders"
+      description: "Renames Couchbase header constants to CamelCouchbase* pattern\
+        \ only if camel-couchbase dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradecouchbaseheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeCouchdbHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeCouchdbHeaders"
+      description: "Renames CouchDB header constants to CamelCouchDb* pattern only\
+        \ if camel-couchdb dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradecouchdbheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeDnsHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeDnsHeaders"
+      description: "Renames DNS header constants from dns.* pattern to CamelDns* pattern\
+        \ only if camel-dns dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradednsheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeGitHub2Headers:
+      name: "org.apache.camel.upgrade.camel421.upgradeGitHub2Headers"
+      description: "Renames GitHub2 producer header constants to CamelGitHub* pattern\
+        \ only if camel-github dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradegithub2headers"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeGoogleCloudSpeechToTextHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeGoogleCloudSpeechToTextHeaders"
+      description: "Renames Google Vision header constants to CamelGoogleCloud* pattern\
+        \ only if camel-google-functions dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradegooglecloudspeechtotextheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeGoogleCloudTextToSpeechHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeGoogleCloudTextToSpeechHeaders"
+      description: "Renames Google Vision header constants to CamelGoogleCloud* pattern\
+        \ only if camel-google-functions dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradegooglecloudtexttospeechheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeGoogleCloudVisionHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeGoogleCloudVisionHeaders"
+      description: "Renames Google Vision header constants to CamelGoogleCloud* pattern\
+        \ only if camel-google-functions dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradegooglecloudvisionheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeIrcHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeIrcHeaders"
+      description: "Renames IRC header constants from irc.* to CamelIrc* pattern only\
+        \ if camel-irc dependency is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradeircheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeJt400Headers:
+      name: "org.apache.camel.upgrade.camel421.upgradeJt400Headers"
+      description: "Renames JT400 header constants to CamelJt400* pattern only if\
+        \ camel-jt400 dependency is present. Note - DSL accessor methods (kEY() →\
+        \ jt400Key(), senderInformation() → jt400SenderInformation()) are NOT migrated\
+        \ and require manual update."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradejt400headers"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeKafkaRecipes:
+      name: "org.apache.camel.upgrade.camel421.upgradeKafkaRecipes"
+      description: "Renames Kafka header constants only if camel-kafka dependency\
+        \ is present."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradekafkarecipes"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeMailHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeMailHeaders"
+      description: "Renames Mail consumer dispatch header constants to CamelMail*\
+        \ pattern only if camel-mail dependency is present. Note - DSL accessor methods\
+        \ (copyTo() → mailCopyTo(), moveTo() → mailMoveTo(), delete() → mailDelete())\
+        \ are NOT migrated and require manual update."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgrademailheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeMiloHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeMiloHeaders"
+      description: "Renames Milo header constants to CamelMilo* pattern only if camel-milo\
+        \ dependency is present. Note - DSL accessor method (await() → miloAwait())\
+        \ is NOT migrated and requires manual update."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgrademiloheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradeOpensearchHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradeOpensearchHeaders"
+      description: "Renames OpenSearch header constants to CamelOpensearch* pattern\
+        \ only if camel-opensearch dependency is present. Note - DSL accessor methods\
+        \ (operation() → opensearchOperation(), indexId() → opensearchIndexId(), etc.)\
+        \ are NOT migrated and require manual update."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradeopensearchheaders"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.apache.camel.upgrade.camel421.upgradePdfHeaders:
+      name: "org.apache.camel.upgrade.camel421.upgradePdfHeaders"
+      description: "Renames PDF header constants to CamelPdf* pattern only if camel-pdf\
+        \ dependency is present. Note - DSL accessor methods (protectionPolicy() →\
+        \ pdfProtectionPolicy(), etc.) are NOT migrated and require manual update."
+      docLink: "https://docs.openrewrite.org/recipes/apache/camel/upgrade/camel421/upgradepdfheaders"
       options: []
       isImperative: false
       artifactId: "rewrite-third-party"
@@ -31276,10 +28564,24 @@ rewrite-third-party:
       options: []
       isImperative: false
       artifactId: "rewrite-third-party"
+    org.openrewrite.quarkus.MigrateToQuarkus_v3_33_1:
+      name: "org.openrewrite.quarkus.MigrateToQuarkus_v3_33_1"
+      description: "Quarkus update recipes to upgrade your application to 3.33.1."
+      docLink: "https://docs.openrewrite.org/recipes/quarkus/migratetoquarkus_v3_33_1"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
     org.openrewrite.quarkus.MigrateToQuarkus_v3_37_0:
       name: "org.openrewrite.quarkus.MigrateToQuarkus_v3_37_0"
       description: "Quarkus update recipes to upgrade your application to 3.37.0."
       docLink: "https://docs.openrewrite.org/recipes/quarkus/migratetoquarkus_v3_37_0"
+      options: []
+      isImperative: false
+      artifactId: "rewrite-third-party"
+    org.openrewrite.quarkus.MigrateToQuarkus_v3_38_0:
+      name: "org.openrewrite.quarkus.MigrateToQuarkus_v3_38_0"
+      description: "Quarkus update recipes to upgrade your application to 3.38.0."
+      docLink: "https://docs.openrewrite.org/recipes/quarkus/migratetoquarkus_v3_38_0"
       options: []
       isImperative: false
       artifactId: "rewrite-third-party"
@@ -40102,7 +37404,7 @@ rewrite-third-party:
       artifactId: "rewrite-third-party"
 rewrite-toml:
   artifactId: "rewrite-toml"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.toml.ChangeKey:
       name: "org.openrewrite.toml.ChangeKey"
@@ -40261,7 +37563,7 @@ rewrite-toml:
       artifactId: "rewrite-toml"
 rewrite-xml:
   artifactId: "rewrite-xml"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.xml.AddCommentToXmlTag:
       name: "org.openrewrite.xml.AddCommentToXmlTag"
@@ -40621,7 +37923,7 @@ rewrite-xml:
       artifactId: "rewrite-xml"
 rewrite-yaml:
   artifactId: "rewrite-yaml"
-  version: "8.87.0"
+  version: "8.88.0"
   markdownRecipeDescriptors:
     org.openrewrite.yaml.AddCommentToProperty:
       name: "org.openrewrite.yaml.AddCommentToProperty"


### PR DESCRIPTION
Records the descriptor state after the 8.88.0 docs regeneration, so the next run can produce an accurate added/changed/removed list in the CHANGELOG.

Paired with:
- openrewrite/rewrite-docs#524
- moderneinc/moderne-docs#904

Regenerated against rewrite-react v0.4.1 ([rewrite-react#18](https://github.com/moderneinc/rewrite-react/pull/18)), which fixed `@openrewrite/recipes-react` failing to install against 8.88.0.

## Diff shape
924 insertions / 3,622 deletions, fully accounted for:
- **`rewrite-codemods` removed** (3,524 lines, 454 recipes) — deliberate, per #355
- `rewrite-react` correctly contributes **0** entries here, matching `origin/main`: it is proprietary and so is excluded from these OSS descriptors. (While `recipes-react` was failing to install, its Java-jar `react/19` recipes were misclassified as OSS and leaked ~36 entries in; regenerating against 0.4.1 removes that leak.)

## Gap worth a follow-up
The `requireAllRecipeSources` guard from #357 (`RecipeLoader.kt:112-150`) only trips when a language yields **zero** descriptors, so partial per-module failures pass as `BUILD SUCCESSFUL`. Two examples from this release:
- `recipes-react` failed to install, but TypeScript still had Angular/Node → no trip
- Python fell back to 8 built-ins after `pip install` failed, but 8 > 0 → no trip

That run would have silently deleted 214 Python + 94 React pages — exactly the "mass page deletion" the comment at `RecipeLoader.kt:326` warns about. A per-module check (each configured module yields >=1 recipe) would catch it.

Separately, the local-run instructions could note that Homebrew Python needs a venv, since the generator shells out to `python3 -m pip install` and PEP 668 blocks it with `externally-managed-environment` — the failure only surfaces as a warning.