### PR TITLE
Show both install commands for dual-published Python recipes

### DIFF
--- a/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
@@ -60,6 +60,29 @@ class PythonRecipeLoader(
         val INDEPENDENT_PIP_VERSIONING = setOf(
             "rewrite-static-analysis-python"
         )
+
+        /**
+         * Modules that publish recipes to both PyPI and Maven Central, with no recipe in both halves.
+         * The two are coupled at runtime: `openrewrite-migrate-python`'s `UpgradeToPython3XX` composites
+         * end in an `RpcRecipe` that resolves against the `rewrite-migrate-python` jar, and the jar's
+         * `UpgradePythonVersionTo3XX` recipes are what those composites reach for. Whichever half a
+         * recipe page is generated from, it needs both install commands: install only one and the
+         * delegated steps resolve against nothing, silently skipping their changes.
+         *
+         * A recipe only picks up the second install command when its origin also carries real Maven
+         * coordinates, so a module here that has no published jar still documents pip alone.
+         */
+        val DUAL_PUBLISHED_MODULES = setOf(
+            "rewrite-migrate-python"
+        )
+
+        /**
+         * True when [origin] belongs to a dual-published module that really has a jar to install.
+         * Synthetic origins stand in for pip packages with no Maven artifact and are recognizable by
+         * their `python-search://` jarLocation; a `jar install` of one would install nothing.
+         */
+        fun publishesCompanionJar(origin: RecipeOrigin): Boolean =
+            origin.artifactId in DUAL_PUBLISHED_MODULES && origin.jarLocation.scheme != "python-search"
     }
 
     data class PythonRecipeResult(

--- a/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/PythonRecipeLoader.kt
@@ -62,24 +62,17 @@ class PythonRecipeLoader(
         )
 
         /**
-         * Modules that publish recipes to both PyPI and Maven Central, with no recipe in both halves.
-         * The two are coupled at runtime: `openrewrite-migrate-python`'s `UpgradeToPython3XX` composites
-         * end in an `RpcRecipe` that resolves against the `rewrite-migrate-python` jar, and the jar's
-         * `UpgradePythonVersionTo3XX` recipes are what those composites reach for. Whichever half a
-         * recipe page is generated from, it needs both install commands: install only one and the
-         * delegated steps resolve against nothing, silently skipping their changes.
-         *
-         * A recipe only picks up the second install command when its origin also carries real Maven
-         * coordinates, so a module here that has no published jar still documents pip alone.
+         * Modules that split their recipes across a PyPI package and a Maven jar, where the pip
+         * composites delegate to jar recipes over RPC. Installing only one half silently skips the
+         * delegated steps, so recipe pages document both install commands.
          */
         val DUAL_PUBLISHED_MODULES = setOf(
             "rewrite-migrate-python"
         )
 
         /**
-         * True when [origin] belongs to a dual-published module that really has a jar to install.
-         * Synthetic origins stand in for pip packages with no Maven artifact and are recognizable by
-         * their `python-search://` jarLocation; a `jar install` of one would install nothing.
+         * True when [origin] belongs to a dual-published module that really has a jar to install;
+         * synthetic origins for pip-only packages carry a `python-search://` jarLocation.
          */
         fun publishesCompanionJar(origin: RecipeOrigin): Boolean =
             origin.artifactId in DUAL_PUBLISHED_MODULES && origin.jarLocation.scheme != "python-search"

--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -41,6 +41,9 @@ data class RecipeLoadResult(
     val crossCategoryPaths: Map<String, List<String>> = emptyMap()
 )
 
+private fun MutableMap<String, URI>.putAllIfAbsent(sources: Map<String, URI>) =
+    sources.forEach { (name, source) -> putIfAbsent(name, source) }
+
 /**
  * Responsible for loading recipes from JAR files and classpaths
  */
@@ -149,20 +152,17 @@ class RecipeLoader {
 
         reportEmptyRecipeSources(emptyRecipeSources, requireAllRecipeSources)
 
-        // Merge TypeScript, Python, C#, and Go results with Java/YAML results. Sources are merged
-        // first-wins to match the descriptor deduplication below, which keeps the first (jar) descriptor:
-        // putAll would keep the last (RPC) source URI instead, so a recipe name published in both a jar
-        // and a pip/npm/NuGet package would be documented from the jar's descriptor under the other
-        // ecosystem's install instructions.
+        // Merge TypeScript, Python, C#, and Go results with Java/YAML results. Sources merge first-wins
+        // to match the descriptor deduplication below, which keeps the first (jar) descriptor.
         val allDescriptors = environmentData.flatMap { it.recipeDescriptors }.toMutableList()
-        for (result in listOf(typeScriptResult.recipeToSource, pythonResult.recipeToSource,
-            csharpResult.recipeToSource, goResult.recipeToSource)) {
-            result.forEach { (name, source) -> recipeToSource.putIfAbsent(name, source) }
-        }
         allDescriptors.addAll(typeScriptResult.descriptors)
+        recipeToSource.putAllIfAbsent(typeScriptResult.recipeToSource)
         allDescriptors.addAll(pythonResult.descriptors)
+        recipeToSource.putAllIfAbsent(pythonResult.recipeToSource)
         allDescriptors.addAll(csharpResult.descriptors)
+        recipeToSource.putAllIfAbsent(csharpResult.recipeToSource)
         allDescriptors.addAll(goResult.descriptors)
+        recipeToSource.putAllIfAbsent(goResult.recipeToSource)
 
         // Deduplicate recipes by name (same recipe may be discovered from multiple JARs
         // when scanJar is called with the full classpath as dependencies)

--- a/src/main/kotlin/org/openrewrite/RecipeLoader.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeLoader.kt
@@ -149,16 +149,20 @@ class RecipeLoader {
 
         reportEmptyRecipeSources(emptyRecipeSources, requireAllRecipeSources)
 
-        // Merge TypeScript, Python, C#, and Go results with Java/YAML results
+        // Merge TypeScript, Python, C#, and Go results with Java/YAML results. Sources are merged
+        // first-wins to match the descriptor deduplication below, which keeps the first (jar) descriptor:
+        // putAll would keep the last (RPC) source URI instead, so a recipe name published in both a jar
+        // and a pip/npm/NuGet package would be documented from the jar's descriptor under the other
+        // ecosystem's install instructions.
         val allDescriptors = environmentData.flatMap { it.recipeDescriptors }.toMutableList()
+        for (result in listOf(typeScriptResult.recipeToSource, pythonResult.recipeToSource,
+            csharpResult.recipeToSource, goResult.recipeToSource)) {
+            result.forEach { (name, source) -> recipeToSource.putIfAbsent(name, source) }
+        }
         allDescriptors.addAll(typeScriptResult.descriptors)
-        recipeToSource.putAll(typeScriptResult.recipeToSource)
         allDescriptors.addAll(pythonResult.descriptors)
-        recipeToSource.putAll(pythonResult.recipeToSource)
         allDescriptors.addAll(csharpResult.descriptors)
-        recipeToSource.putAll(csharpResult.recipeToSource)
         allDescriptors.addAll(goResult.descriptors)
-        recipeToSource.putAll(goResult.recipeToSource)
 
         // Deduplicate recipes by name (same recipe may be discovered from multiple JARs
         // when scanJar is called with the full classpath as dependencies)

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -553,10 +553,8 @@ import RunRecipe from '@site/src/components/RunRecipe';
 
     /**
      * Gets the pip package name for a Python recipe module.
-     * Uses the single source of truth from PythonRecipeLoader.
-     *
-     * Unregistered artifacts fail rather than falling back to the artifactId: that fallback published a
-     * `pip install` command for a PyPI package that need not exist.
+     * Uses the single source of truth from PythonRecipeLoader; unregistered artifacts fail rather than
+     * falling back to the artifactId, which named PyPI packages that need not exist.
      */
     private fun getPipPackageName(origin: RecipeOrigin): String {
         return PythonRecipeLoader.PYTHON_RECIPE_MODULES[origin.artifactId]
@@ -626,8 +624,7 @@ import RunRecipe from '@site/src/components/RunRecipe';
         }
 
         // Handle Python recipes. Unlike buildUsageJson this never adds the jar half of a dual-published
-        // module: every such module is Moderne proprietary, so its recipes are filtered out of the
-        // OpenRewrite docs that this method writes.
+        // module: those are all proprietary, so they never reach these OpenRewrite docs.
         if (isPythonRecipe(recipeDescriptor)) {
             val pipPackageName = getPipPackageName(origin)
             val props = StringBuilder()
@@ -1303,8 +1300,7 @@ ${props.toString().trimEnd()}
                 usageMap["versionKey"] = origin.versionPlaceholderKey()
                 usageMap["requiresConfiguration"] = requiresConfiguration
                 // The jar half of a dual-published Python module lands here, since only the pip half
-                // carries a `python-search://` source URI. Its readers arrive from the pip composites
-                // that delegate to it, so the pip command belongs alongside the Maven coordinates.
+                // carries a `python-search://` source URI, yet it too needs the pip command.
                 if (PythonRecipeLoader.publishesCompanionJar(origin)) {
                     usageMap["pipPackage"] = getPipPackageName(origin)
                     addPythonCoreCompanionJar(usageMap, origin)
@@ -1330,14 +1326,9 @@ ${props.toString().trimEnd()}
     }
 
     /**
-     * Names the core Python language module as a companion install.
-     *
-     * Recipes in `org.openrewrite.python.*` delegate into its `UpgradeDependencyVersion` /
-     * `ChangeDependency` recipes at runtime. The CLI resolves delegates eagerly, so a marketplace
-     * without this module fails the whole run — `IllegalStateException: Remote declared delegatesTo
-     * org.openrewrite.python.UpgradeDependencyVersion but no recipe found in marketplace` — rather than
-     * quietly skipping the step. Recipes that already ship in this module are skipped: for them the
-     * module's own coordinates are the install command.
+     * Names the core Python language module as a companion install. Python recipes delegate into its
+     * `UpgradeDependencyVersion` / `ChangeDependency` recipes, and the CLI resolves delegates eagerly, so
+     * a marketplace without it fails the whole run. Recipes shipping in the module itself need no entry.
      */
     private fun addPythonCoreCompanionJar(usageMap: MutableMap<String, Any?>, origin: RecipeOrigin) {
         if (origin.artifactId == PYTHON_CORE_ARTIFACT_ID) return
@@ -1410,7 +1401,6 @@ ${props.toString().trimEnd()}
         // Stateless + thread-safe; one instance for the whole run rather than per writer.
         private val mapper = jacksonObjectMapper()
 
-        // The core Python language module, which every org.openrewrite.python.* recipe delegates into.
         private const val PYTHON_CORE_GROUP_ID = "org.openrewrite"
         private const val PYTHON_CORE_ARTIFACT_ID = "rewrite-python"
 

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -554,10 +554,17 @@ import RunRecipe from '@site/src/components/RunRecipe';
     /**
      * Gets the pip package name for a Python recipe module.
      * Uses the single source of truth from PythonRecipeLoader.
+     *
+     * Unregistered artifacts fail rather than falling back to the artifactId: that fallback published a
+     * `pip install` command for a PyPI package that need not exist.
      */
     private fun getPipPackageName(origin: RecipeOrigin): String {
         return PythonRecipeLoader.PYTHON_RECIPE_MODULES[origin.artifactId]
-            ?: origin.artifactId
+            ?: error(
+                "No pip package configured for artifact ${origin.artifactId}. Register it in " +
+                        "PythonRecipeLoader.PYTHON_RECIPE_MODULES; otherwise its recipe pages advertise a " +
+                        "pip install of a package that may not exist."
+            )
     }
 
     /**
@@ -618,7 +625,9 @@ import RunRecipe from '@site/src/components/RunRecipe';
             return
         }
 
-        // Handle Python recipes
+        // Handle Python recipes. Unlike buildUsageJson this never adds the jar half of a dual-published
+        // module: every such module is Moderne proprietary, so its recipes are filtered out of the
+        // OpenRewrite docs that this method writes.
         if (isPythonRecipe(recipeDescriptor)) {
             val pipPackageName = getPipPackageName(origin)
             val props = StringBuilder()
@@ -1275,6 +1284,7 @@ ${props.toString().trimEnd()}
                 if (origin.artifactId !in PythonRecipeLoader.INDEPENDENT_PIP_VERSIONING) {
                     usageMap["versionKey"] = origin.versionPlaceholderKey()
                 }
+                addDualPublishedJarCoordinates(usageMap, origin)
             }
             isCSharpRecipe(recipeDescriptor) -> usageMap["nugetPackage"] = getNuGetPackageName(origin)
             isGoRecipe(recipeDescriptor) -> {
@@ -1291,6 +1301,12 @@ ${props.toString().trimEnd()}
                 usageMap["artifactId"] = origin.artifactId
                 usageMap["versionKey"] = origin.versionPlaceholderKey()
                 usageMap["requiresConfiguration"] = requiresConfiguration
+                // The jar half of a dual-published Python module lands here, since only the pip half
+                // carries a `python-search://` source URI. Its readers arrive from the pip composites
+                // that delegate to it, so the pip command belongs alongside the Maven coordinates.
+                if (PythonRecipeLoader.publishesCompanionJar(origin)) {
+                    usageMap["pipPackage"] = getPipPackageName(origin)
+                }
 
                 // cliOptions shares the per-option example formatting with writeUsage.
                 val cliOptions = if (requiresConfiguration) {
@@ -1309,6 +1325,21 @@ ${props.toString().trimEnd()}
         }
 
         return mapper.writeValueAsString(usageMap)
+    }
+
+    /**
+     * Adds the Maven coordinates of a dual-published Python module's jar next to its pip package, pinned
+     * to the same version key the pip command already resolves.
+     */
+    private fun addDualPublishedJarCoordinates(usageMap: MutableMap<String, Any?>, origin: RecipeOrigin) {
+        if (!PythonRecipeLoader.publishesCompanionJar(origin)) return
+        check(origin.artifactId !in PythonRecipeLoader.INDEPENDENT_PIP_VERSIONING) {
+            "${origin.artifactId} is both dual-published and independently versioned, so its pip and jar " +
+                    "install commands need different versions — which a single versionKey cannot express."
+        }
+        usageMap["groupId"] = origin.groupId
+        usageMap["artifactId"] = origin.artifactId
+        usageMap["versionKey"] = origin.versionPlaceholderKey()
     }
 
     /**

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownWriter.kt
@@ -1285,6 +1285,7 @@ ${props.toString().trimEnd()}
                     usageMap["versionKey"] = origin.versionPlaceholderKey()
                 }
                 addDualPublishedJarCoordinates(usageMap, origin)
+                addPythonCoreCompanionJar(usageMap, origin)
             }
             isCSharpRecipe(recipeDescriptor) -> usageMap["nugetPackage"] = getNuGetPackageName(origin)
             isGoRecipe(recipeDescriptor) -> {
@@ -1306,6 +1307,7 @@ ${props.toString().trimEnd()}
                 // that delegate to it, so the pip command belongs alongside the Maven coordinates.
                 if (PythonRecipeLoader.publishesCompanionJar(origin)) {
                     usageMap["pipPackage"] = getPipPackageName(origin)
+                    addPythonCoreCompanionJar(usageMap, origin)
                 }
 
                 // cliOptions shares the per-option example formatting with writeUsage.
@@ -1325,6 +1327,27 @@ ${props.toString().trimEnd()}
         }
 
         return mapper.writeValueAsString(usageMap)
+    }
+
+    /**
+     * Names the core Python language module as a companion install.
+     *
+     * Recipes in `org.openrewrite.python.*` delegate into its `UpgradeDependencyVersion` /
+     * `ChangeDependency` recipes at runtime. The CLI resolves delegates eagerly, so a marketplace
+     * without this module fails the whole run — `IllegalStateException: Remote declared delegatesTo
+     * org.openrewrite.python.UpgradeDependencyVersion but no recipe found in marketplace` — rather than
+     * quietly skipping the step. Recipes that already ship in this module are skipped: for them the
+     * module's own coordinates are the install command.
+     */
+    private fun addPythonCoreCompanionJar(usageMap: MutableMap<String, Any?>, origin: RecipeOrigin) {
+        if (origin.artifactId == PYTHON_CORE_ARTIFACT_ID) return
+        usageMap["companionJars"] = listOf(
+            mapOf(
+                "groupId" to PYTHON_CORE_GROUP_ID,
+                "artifactId" to PYTHON_CORE_ARTIFACT_ID,
+                "versionKey" to RecipeOrigin.versionPlaceholderKey(PYTHON_CORE_GROUP_ID, PYTHON_CORE_ARTIFACT_ID)
+            )
+        )
     }
 
     /**
@@ -1386,6 +1409,10 @@ ${props.toString().trimEnd()}
     companion object {
         // Stateless + thread-safe; one instance for the whole run rather than per writer.
         private val mapper = jacksonObjectMapper()
+
+        // The core Python language module, which every org.openrewrite.python.* recipe delegates into.
+        private const val PYTHON_CORE_GROUP_ID = "org.openrewrite"
+        private const val PYTHON_CORE_ARTIFACT_ID = "rewrite-python"
 
         private const val MODERNE_DOCS_MARKDOWN_BASE_URL =
             "https://raw.githubusercontent.com/moderneinc/moderne-docs/refs/heads/main/docs/user-documentation/recipes/recipe-catalog/"

--- a/src/main/kotlin/org/openrewrite/RecipeOrigin.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeOrigin.kt
@@ -123,8 +123,8 @@ class RecipeOrigin(
         private val parsePattern = Pattern.compile("([^:]+):([^:]+):([^:]+):(.+)")
 
         /**
-         * The `{{VERSION_…}}` token the docs resolve to a module's version. Exposed for coordinates named
-         * without a [RecipeOrigin] to hand, so the token cannot drift from the instance form.
+         * The `{{VERSION_…}}` token the docs resolve to a module's version, for coordinates named without
+         * a [RecipeOrigin] to hand.
          */
         fun versionPlaceholderKey(groupId: String, artifactId: String) = "VERSION_${groupId}_${artifactId}"
             .uppercase()

--- a/src/main/kotlin/org/openrewrite/RecipeOrigin.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeOrigin.kt
@@ -114,16 +114,22 @@ class RecipeOrigin(
         }
     }
 
-    fun versionPlaceholderKey() = "VERSION_${groupId}_${artifactId}"
-        .uppercase()
-        .replace('-', '_')
-        .replace('.', '_')
+    fun versionPlaceholderKey() = versionPlaceholderKey(groupId, artifactId)
 
     fun issueTrackerUrl() = repositoryUrl.replace(Regex("/blob/main/.*"), "/issues")
     fun releaseUrl(version: String) = repositoryUrl.replace(Regex("/blob/main/.*"), "/releases/tag/${version}")
 
     companion object {
         private val parsePattern = Pattern.compile("([^:]+):([^:]+):([^:]+):(.+)")
+
+        /**
+         * The `{{VERSION_…}}` token the docs resolve to a module's version. Exposed for coordinates named
+         * without a [RecipeOrigin] to hand, so the token cannot drift from the instance form.
+         */
+        fun versionPlaceholderKey(groupId: String, artifactId: String) = "VERSION_${groupId}_${artifactId}"
+            .uppercase()
+            .replace('-', '_')
+            .replace('.', '_')
 
         fun fromString(encoded: String): RecipeOrigin {
             val m = parsePattern.matcher(encoded)

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -107,6 +107,12 @@ class VersionWriter {
                         val pipPackage = PythonRecipeLoader.PYTHON_RECIPE_MODULES.getValue(origin.artifactId)
                         cliInstallPipPinned += "$pipPackage==$versionPlaceholder "
                         cliInstallPipLatest += "$pipPackage "
+                        // A dual-published module splits its recipes across the wheel and the jar, so the
+                        // pip command alone installs only half of them.
+                        if (PythonRecipeLoader.publishesCompanionJar(origin)) {
+                            cliInstallJarPinned += "${origin.groupId}:${origin.artifactId}:$versionPlaceholder "
+                            cliInstallJarLatest += "${origin.groupId}:${origin.artifactId}:LATEST "
+                        }
                     }
                     in TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES -> {
                         val npmPackage = TypeScriptRecipeLoader.TYPESCRIPT_RECIPE_MODULES.getValue(origin.artifactId)

--- a/src/main/kotlin/org/openrewrite/VersionWriter.kt
+++ b/src/main/kotlin/org/openrewrite/VersionWriter.kt
@@ -107,8 +107,7 @@ class VersionWriter {
                         val pipPackage = PythonRecipeLoader.PYTHON_RECIPE_MODULES.getValue(origin.artifactId)
                         cliInstallPipPinned += "$pipPackage==$versionPlaceholder "
                         cliInstallPipLatest += "$pipPackage "
-                        // A dual-published module splits its recipes across the wheel and the jar, so the
-                        // pip command alone installs only half of them.
+                        // Dual-published modules split their recipes across the wheel and the jar.
                         if (PythonRecipeLoader.publishesCompanionJar(origin)) {
                             cliInstallJarPinned += "${origin.groupId}:${origin.artifactId}:$versionPlaceholder "
                             cliInstallJarLatest += "${origin.groupId}:${origin.artifactId}:LATEST "

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -176,10 +176,70 @@ class RecipeMarkdownWriterModerneDocsTest {
             .writeRecipe(recipe, dir, pythonOrigin)
         val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
 
-        // Python recipes install from pip with an explicit version, not Maven/Gradle coordinates.
+        // Python recipes install from pip with an explicit version.
         assertThat(out).contains("\"pipPackage\":\"openrewrite-migrate-python\"")
         assertThat(out).contains("\"versionKey\":\"VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON\"")
+        // `rewrite-migrate-python` is dual-published: its pip composites delegate to jar recipes over RPC,
+        // so the jar coordinates ride along, pinned to the same version key.
+        assertThat(out).contains("\"groupId\":\"org.openrewrite.recipe\"")
+        assertThat(out).contains("\"artifactId\":\"rewrite-migrate-python\"")
+    }
+
+    @Test
+    fun moderneDocsEmitsPipInstallForJarSourcedPythonRecipe(@TempDir dir: Path) {
+        // The jar half of `rewrite-migrate-python` is discovered by the JVM loader, so it carries no
+        // `python-search://` source URI. Its page still needs the pip command: readers reach it from the
+        // pip-published `UpgradeToPython3XX` composite that delegates to it (moderne-docs#900).
+        val pythonOrigin = RecipeOrigin("org.openrewrite.recipe", "rewrite-migrate-python", "0.10.1", jar)
+            .apply { license = Licenses.Proprietary }
+        val recipe = descriptor(
+            "org.openrewrite.python.migrate.UpgradePythonVersionTo314",
+            "Upgrade Python version in project files to 3.14", "Upgrades project files to Python 3.14.",
+        )
+        RecipeMarkdownWriter(mutableMapOf(), emptyMap(), setOf(recipe.name), forModerneDocs = true)
+            .writeRecipe(recipe, dir, pythonOrigin)
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        assertThat(out).contains("\"pipPackage\":\"openrewrite-migrate-python\"")
+        assertThat(out).contains("\"groupId\":\"org.openrewrite.recipe\"")
+        assertThat(out).contains("\"artifactId\":\"rewrite-migrate-python\"")
+        assertThat(out).contains("\"versionKey\":\"VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON\"")
+    }
+
+    @Test
+    fun moderneDocsOmitsJarInstallForPythonModuleWithoutMavenArtifact(@TempDir dir: Path) {
+        // PythonRecipeLoader invents an origin for a pip package with no Maven artifact, marking it with a
+        // `python-search://` jarLocation. Advertising a `jar install` for one would install nothing.
+        val syntheticOrigin = RecipeOrigin(
+            "org.openrewrite.recipe", "rewrite-migrate-python", "0.10.1",
+            URI.create("python-search://rewrite-migrate-python")
+        ).apply { license = Licenses.Proprietary }
+        val recipe = descriptor(
+            "org.openrewrite.python.migrate.UpgradeToPython314",
+            "Upgrade to Python 3.14", "Migrates to Python 3.14.",
+        )
+        val recipeToSource = mapOf(recipe.name to URI.create("python-search://rewrite-migrate-python/upgrade-to-python-314"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, setOf(recipe.name), forModerneDocs = true)
+            .writeRecipe(recipe, dir, syntheticOrigin)
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        assertThat(out).contains("\"pipPackage\":\"openrewrite-migrate-python\"")
         assertThat(out).doesNotContain("\"groupId\":")
+        assertThat(out).doesNotContain("\"artifactId\":")
+    }
+
+    @Test
+    fun unregisteredPipModuleFailsRatherThanGuessingAPackageName(@TempDir dir: Path) {
+        // Falling back to the artifactId published a `pip install` for a PyPI package that need not exist.
+        val unknownOrigin = RecipeOrigin("org.openrewrite.recipe", "rewrite-unregistered-python", "1.0.0", jar)
+            .apply { license = Licenses.Proprietary }
+        val recipe = descriptor("org.openrewrite.python.Unknown", "Unknown", "An unregistered module.")
+        val recipeToSource = mapOf(recipe.name to URI.create("python-search://rewrite-unregistered-python/unknown"))
+        val writer = RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = true)
+
+        assertThatThrownBy { writer.writeRecipe(recipe, dir, unknownOrigin) }
+            .isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("rewrite-unregistered-python")
     }
 
     @Test

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -1,5 +1,6 @@
 package org.openrewrite
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
@@ -61,6 +62,19 @@ class RecipeMarkdownWriterModerneDocsTest {
     ).withPreconditions(
         listOf(descriptor("org.openrewrite.java.search.FindFoo", "Find foo", "Finds foo."))
     )
+
+    /**
+     * The top-level `usage={…}` object from the emitted `<UsageList>`. Assertions about a key being
+     * *absent* need this: a bare `doesNotContain("\"groupId\":")` also matches the nested companion-jar
+     * entries, so it would fail for reasons that have nothing to do with what the test is checking.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun usageJson(out: String): Map<String, Any?> {
+        val json = out.lineSequence().first { it.startsWith("<UsageList usage={") }
+            .substringAfter("<UsageList usage={")
+            .substringBeforeLast("}>")
+        return jacksonObjectMapper().readValue(json, Map::class.java) as Map<String, Any?>
+    }
 
     private fun generate(
         recipe: RecipeDescriptor,
@@ -183,6 +197,27 @@ class RecipeMarkdownWriterModerneDocsTest {
         // so the jar coordinates ride along, pinned to the same version key.
         assertThat(out).contains("\"groupId\":\"org.openrewrite.recipe\"")
         assertThat(out).contains("\"artifactId\":\"rewrite-migrate-python\"")
+        // ...as do the coordinates of the core language module those jar recipes delegate into.
+        assertThat(out).contains("\"companionJars\":[{\"groupId\":\"org.openrewrite\",\"artifactId\":\"rewrite-python\"")
+        assertThat(out).contains("\"versionKey\":\"VERSION_ORG_OPENREWRITE_REWRITE_PYTHON\"")
+    }
+
+    @Test
+    fun moderneDocsOmitsCoreCompanionJarForRewritePythonsOwnRecipes(@TempDir dir: Path) {
+        // A recipe that ships in rewrite-python already installs rewrite-python; naming it again as a
+        // companion would render the same coordinates twice.
+        val coreOrigin = RecipeOrigin("org.openrewrite", "rewrite-python", "8.88.0", jar)
+        val recipe = descriptor(
+            "org.openrewrite.python.AddDependency",
+            "Add Python dependency", "Adds a dependency to a Python project.",
+        )
+        val recipeToSource = mapOf(recipe.name to URI.create("python-search://rewrite-python/add-dependency"))
+        RecipeMarkdownWriter(mutableMapOf(), recipeToSource, emptySet(), forModerneDocs = true)
+            .writeRecipe(recipe, dir, coreOrigin)
+        val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
+
+        assertThat(out).contains("\"pipPackage\":\"openrewrite\"")
+        assertThat(out).doesNotContain("companionJars")
     }
 
     @Test
@@ -204,6 +239,7 @@ class RecipeMarkdownWriterModerneDocsTest {
         assertThat(out).contains("\"groupId\":\"org.openrewrite.recipe\"")
         assertThat(out).contains("\"artifactId\":\"rewrite-migrate-python\"")
         assertThat(out).contains("\"versionKey\":\"VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON\"")
+        assertThat(out).contains("\"companionJars\":[{\"groupId\":\"org.openrewrite\",\"artifactId\":\"rewrite-python\"")
     }
 
     @Test
@@ -224,8 +260,7 @@ class RecipeMarkdownWriterModerneDocsTest {
         val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
 
         assertThat(out).contains("\"pipPackage\":\"openrewrite-migrate-python\"")
-        assertThat(out).doesNotContain("\"groupId\":")
-        assertThat(out).doesNotContain("\"artifactId\":")
+        assertThat(usageJson(out)).doesNotContainKeys("groupId", "artifactId")
     }
 
     @Test
@@ -258,7 +293,7 @@ class RecipeMarkdownWriterModerneDocsTest {
         val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
 
         assertThat(out).contains("\"pipPackage\":\"openrewrite-static-analysis\"")
-        assertThat(out).doesNotContain("\"versionKey\":")
+        assertThat(usageJson(out)).doesNotContainKey("versionKey")
     }
 
     @Test

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownWriterModerneDocsTest.kt
@@ -64,9 +64,8 @@ class RecipeMarkdownWriterModerneDocsTest {
     )
 
     /**
-     * The top-level `usage={…}` object from the emitted `<UsageList>`. Assertions about a key being
-     * *absent* need this: a bare `doesNotContain("\"groupId\":")` also matches the nested companion-jar
-     * entries, so it would fail for reasons that have nothing to do with what the test is checking.
+     * The top-level `usage={…}` object from the emitted `<UsageList>`. Absence assertions need this, as a
+     * bare `doesNotContain("\"groupId\":")` also matches the nested companion-jar entries.
      */
     @Suppress("UNCHECKED_CAST")
     private fun usageJson(out: String): Map<String, Any?> {
@@ -190,22 +189,18 @@ class RecipeMarkdownWriterModerneDocsTest {
             .writeRecipe(recipe, dir, pythonOrigin)
         val out = Files.readString(Files.walk(dir).filter { it.toString().endsWith(".md") }.findFirst().orElseThrow())
 
-        // Python recipes install from pip with an explicit version.
         assertThat(out).contains("\"pipPackage\":\"openrewrite-migrate-python\"")
         assertThat(out).contains("\"versionKey\":\"VERSION_ORG_OPENREWRITE_RECIPE_REWRITE_MIGRATE_PYTHON\"")
-        // `rewrite-migrate-python` is dual-published: its pip composites delegate to jar recipes over RPC,
-        // so the jar coordinates ride along, pinned to the same version key.
+        // `rewrite-migrate-python` is dual-published, so the jar coordinates ride along on the same key,
+        // as do those of the core language module the jar recipes delegate into.
         assertThat(out).contains("\"groupId\":\"org.openrewrite.recipe\"")
         assertThat(out).contains("\"artifactId\":\"rewrite-migrate-python\"")
-        // ...as do the coordinates of the core language module those jar recipes delegate into.
         assertThat(out).contains("\"companionJars\":[{\"groupId\":\"org.openrewrite\",\"artifactId\":\"rewrite-python\"")
         assertThat(out).contains("\"versionKey\":\"VERSION_ORG_OPENREWRITE_REWRITE_PYTHON\"")
     }
 
     @Test
     fun moderneDocsOmitsCoreCompanionJarForRewritePythonsOwnRecipes(@TempDir dir: Path) {
-        // A recipe that ships in rewrite-python already installs rewrite-python; naming it again as a
-        // companion would render the same coordinates twice.
         val coreOrigin = RecipeOrigin("org.openrewrite", "rewrite-python", "8.88.0", jar)
         val recipe = descriptor(
             "org.openrewrite.python.AddDependency",
@@ -222,9 +217,8 @@ class RecipeMarkdownWriterModerneDocsTest {
 
     @Test
     fun moderneDocsEmitsPipInstallForJarSourcedPythonRecipe(@TempDir dir: Path) {
-        // The jar half of `rewrite-migrate-python` is discovered by the JVM loader, so it carries no
-        // `python-search://` source URI. Its page still needs the pip command: readers reach it from the
-        // pip-published `UpgradeToPython3XX` composite that delegates to it (moderne-docs#900).
+        // Discovered by the JVM loader, so no `python-search://` source URI; readers still reach it from
+        // the pip-published `UpgradeToPython3XX` composite that delegates to it (moderne-docs#900).
         val pythonOrigin = RecipeOrigin("org.openrewrite.recipe", "rewrite-migrate-python", "0.10.1", jar)
             .apply { license = Licenses.Proprietary }
         val recipe = descriptor(
@@ -244,8 +238,8 @@ class RecipeMarkdownWriterModerneDocsTest {
 
     @Test
     fun moderneDocsOmitsJarInstallForPythonModuleWithoutMavenArtifact(@TempDir dir: Path) {
-        // PythonRecipeLoader invents an origin for a pip package with no Maven artifact, marking it with a
-        // `python-search://` jarLocation. Advertising a `jar install` for one would install nothing.
+        // PythonRecipeLoader marks origins it invents for pip-only packages with a `python-search://`
+        // jarLocation; a `jar install` of one would install nothing.
         val syntheticOrigin = RecipeOrigin(
             "org.openrewrite.recipe", "rewrite-migrate-python", "0.10.1",
             URI.create("python-search://rewrite-migrate-python")
@@ -265,7 +259,6 @@ class RecipeMarkdownWriterModerneDocsTest {
 
     @Test
     fun unregisteredPipModuleFailsRatherThanGuessingAPackageName(@TempDir dir: Path) {
-        // Falling back to the artifactId published a `pip install` for a PyPI package that need not exist.
         val unknownOrigin = RecipeOrigin("org.openrewrite.recipe", "rewrite-unregistered-python", "1.0.0", jar)
             .apply { license = Licenses.Proprietary }
         val recipe = descriptor("org.openrewrite.python.Unknown", "Unknown", "An unregistered module.")


### PR DESCRIPTION
Fixes moderneinc/moderne-docs#900. Docs half: moderneinc/moderne-docs#906.

## Problem

Python recipes delegate across packages at runtime, and the CLI resolves those delegates **before the run starts** — so a package missing from the marketplace fails the whole run rather than skipping the step that needed it. The generator emitted exactly one install command per page, keyed off which loader discovered the recipe.

Verified against Moderne CLI 4.4.3 in an isolated `MODERNE_CLI_HOME`, adding one artifact at a time:

| marketplace | `mod run --recipe UpgradeToPython314` |
| --- | --- |
| pip `openrewrite-migrate-python` only — *what the page used to say* | ❌ `delegatesTo org.openrewrite.python.migrate.UpgradePythonVersionTo314 but no recipe found` |
| + jar `org.openrewrite.recipe:rewrite-migrate-python` | ❌ `delegatesTo org.openrewrite.python.UpgradeDependencyVersion` |
| + jar `org.openrewrite:rewrite-python` | ✅ |

## Change

* `PythonRecipeLoader.DUAL_PUBLISHED_MODULES` records modules published to both PyPI and Maven Central whose recipes call across the two (`rewrite-migrate-python` today). Both coordinate sets are emitted for their recipes, whichever loader found them.
* `companionJars` carries `org.openrewrite:rewrite-python` on every Python recipe page that doesn't already ship in that module.
* `publishesCompanionJar` keeps synthetic origins (a pip package with no Maven artifact) from advertising a `jar install` that would install nothing.
* `VersionWriter` adds the jar line for dual-published modules.
* Issue suggestions 4 and 5: source URIs merge first-wins to match the descriptor dedup; `getPipPackageName` fails on an unregistered artifact rather than guessing the artifactId.
* `RecipeOrigin.versionPlaceholderKey` gains a companion form so coordinates named without an origin can't drift from the instance token.

## Verification

`./gradlew test` green. Beyond unit tests, the fix was validated end-to-end: seeding a marketplace from the curated `recipes-v5.csv` **minus** `rewrite-python` and both migrate-python halves reproduces the broken state observed on a real machine; running the three commands the page now emits gives a green run that changes both files, with `pyproject.toml`'s `requires-python` bump coming solely from the jar half.

## Scope note

On a marketplace kept in sync with the curated `recipes-v5.csv`, all of these are already installed — the CSV ships both migrate-python halves and `rewrite-python`. These commands matter for users who install recipes ad hoc from a catalog page, and for marketplaces that have drifted from the curated set.

`rewrite-static-analysis-python` is deliberately not in `DUAL_PUBLISHED_MODULES`: I could not confirm it publishes a jar. Adding it is a one-line change once confirmed.