### PR TITLE
Cut dependency resolution cost of latest-versions-only runs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,25 +17,30 @@ dependencyCheck {
 group = "org.example"
 version = "1.0-SNAPSHOT"
 
+// Either `latest.release` or `latest.integration`
+val rewriteVersion = "latest.release"
+
+// Each repository here is probed for maven-metadata.xml on every dynamic coordinate below, so one
+// that hosts nothing this build resolves costs a round trip per module.
 repositories {
     mavenLocal()
     mavenCentral()
-    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
-    maven { url = uri("https://maven.diffblue.com/snapshot") }
+    if (rewriteVersion == "latest.integration") {
+        maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
+    }
+    // Hosts org.openrewrite:plugin, which is not on Maven Central.
     gradlePluginPortal()
 }
 
 configurations.all {
     resolutionStrategy {
         cacheChangingModulesFor(0, TimeUnit.SECONDS)
-        cacheDynamicVersionsFor(0, TimeUnit.SECONDS)
+        // Far short of the daily cadence of the scheduled doc builds, so they still see each release.
+        cacheDynamicVersionsFor(1, TimeUnit.HOURS)
     }
 }
 
 val recipeConf = configurations.create("recipe")
-
-// Either `latest.release` or `latest.integration`
-val rewriteVersion = "latest.release"
 
 dependencies {
     // Platform dependencies (BOMs)
@@ -202,15 +207,20 @@ tasks.named<JavaExec>("run").configure {
     val latestVersionsOnly = providers.gradleProperty("latestVersionsOnly").getOrElse("").equals("true")
 
     // Collect all of the dependencies from recipeConf, then stuff them into a string representation
-    val recipeModules = recipeConf.resolvedConfiguration.firstLevelModuleDependencies.flatMap { dep ->
-        dep.moduleArtifacts.map { artifact ->
-            "${dep.moduleGroup}:${dep.moduleName}:${dep.moduleVersion}:${artifact.file}"
-        }
+    val firstLevelArtifacts = recipeConf.resolvedConfiguration.firstLevelModuleDependencies.flatMap { dep ->
+        dep.moduleArtifacts.map { artifact -> dep to artifact }
+    }
+    val recipeModules = firstLevelArtifacts.joinToString(";") { (dep, artifact) ->
+        "${dep.moduleGroup}:${dep.moduleName}:${dep.moduleVersion}:${artifact.file}"
+    }
+    // recipeModules doesn't include transitive dependencies, but those are needed to load recipes and their descriptors.
+    // A --latest-versions-only run reads only each recipe module's own MANIFEST.MF, so resolving the transitive
+    // closure there downloads the whole recipe classpath to read nothing from it.
+    val recipeClasspath = if (latestVersionsOnly) {
+        firstLevelArtifacts.map { (_, artifact) -> artifact.file.absolutePath }
+    } else {
+        recipeConf.incoming.files.map { it.absolutePath }
     }.joinToString(";")
-    // recipeModules doesn't include transitive dependencies, but those are needed to load recipes and their descriptors
-    val recipeClasspath = recipeConf.incoming.files.asSequence()
-        .map { it.absolutePath }
-        .joinToString(";")
 
     description = "Writes generated markdown docs to $targetDir and $moderneTargetDir"
     val arguments = mutableListOf(


### PR DESCRIPTION
The scheduled doc builds in [`rewrite-docs`](https://github.com/openrewrite/rewrite-docs/blob/master/.github/workflows/update-docs.yml) and [`moderne-docs`](https://github.com/moderneinc/moderne-docs/blob/main/.github/workflows/update-docs.yml) both run with `-PlatestVersionsOnly=true`, which returns before `loadRecipes()`. That path still paid for a full recipe classpath it never opens.

Measured on the `rewrite-docs` nightly, the whole `Generate Markdown` step is Gradle configuration — the first `> Task :` line lands 27 minutes after the step starts ([run 30597155828](https://github.com/openrewrite/rewrite-docs/actions/runs/30597155828)).

### Changes

**Only resolve what a latest-versions-only run reads.** It reads License and Module-Origin out of each recipe module's own `MANIFEST.MF` and stops, so it now gets the first-level jars instead of the transitive closure:

| | jars | bytes |
|---|---|---|
| transitive closure (was) | 200 | 232 MB |
| first-level only (now) | 85 | 80 MB |

**Drop repositories that host nothing this build resolves.** Every dynamic `latest.*` coordinate — there are ~90 — is probed against each repository. `maven.diffblue.com` was only ever needed by the commented-out `rewrite-diffblue` dependency, and the snapshot repository can only miss under `latest.release`, so it's now gated on `latest.integration`.

`gradlePluginPortal()` looked prunable but isn't: `org.openrewrite:plugin` is published there, not to Maven Central. Noted in a comment so the next reader doesn't repeat the experiment.

**Give dynamic versions a 1h cache** instead of none. That's far short of the daily cadence of the scheduled builds, which still see each day's releases, while back-to-back local runs stop re-resolving.

### Verification

Matched pair with `--refresh-dependencies` (fully expired caches, the CI condition): **4m36s → 55s**. A repeat run inside the new version cache is 15s.

Both generated output trees are byte-identical before and after (`diff -r` on `build/docs` and `build/moderne-docs`), and license resolution is unchanged — zero `Unable to determine License` warnings either way.

### Follow-up

Companion PRs skip the Go/Python/.NET toolchain setup on nightlies that never load an RPC-backed recipe.