### PR TITLE
Document Go recipes in the Moderne docs only

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project generates recipe documentation in markdown format for all recipes o
 
 Proprietary recipes (those with a `Proprietary` license or loaded via TypeScript/Python) are written only to the Moderne docs output. Open-source recipes are written to both.
 
+Go recipes are written only to the Moderne docs too, `rewrite-go`'s open-source license notwithstanding, so the whole Go catalog is documented in one place.
+
 ### Changelog
 
 This project also builds up a CHANGELOG to track what has changed over time. The way this works is that, every time

--- a/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
+++ b/src/main/kotlin/org/openrewrite/RecipeMarkdownGenerator.kt
@@ -435,9 +435,11 @@ class RecipeMarkdownGenerator : Runnable {
         /**
          * Modules whose docs should only appear in Moderne docs, regardless of license. Go recipe modules
          * are listed structurally rather than relying on their jar manifest: the Maven artifact is only a
-         * version/license carrier, and the recipes themselves are Moderne proprietary.
+         * version/license carrier, and the recipes themselves are Moderne proprietary. `rewrite-go` is
+         * open source, but its recipes belong with the rest of the Go catalog on docs.moderne.io.
          */
-        private val MODERNE_DOCS_ONLY_MODULES = setOf("rewrite-devcenter") + GoRecipeLoader.GO_RECIPE_MODULES.keys
+        private val MODERNE_DOCS_ONLY_MODULES =
+            setOf("rewrite-devcenter", "rewrite-go") + GoRecipeLoader.GO_RECIPE_MODULES.keys
 
         internal fun isModerneDocsOnly(origin: RecipeOrigin): Boolean =
             origin.license == Licenses.Proprietary || origin.artifactId in MODERNE_DOCS_ONLY_MODULES

--- a/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
+++ b/src/test/kotlin/org/openrewrite/RecipeMarkdownGeneratorTest.kt
@@ -148,10 +148,9 @@ class RecipeMarkdownGeneratorTest {
 
     @Test
     fun goModulesAreModerneDocsOnlyRegardlessOfManifestLicense() {
-        // Go recipes are Moderne proprietary and must never reach docs.openrewrite.org. The exclusion keys
-        // off the module list rather than the jar manifest, so a mis-stamped License-Url on the (metadata
-        // only) Maven artifact cannot leak a whole ecosystem into the open-source docs.
-        for (artifactId in GoRecipeLoader.GO_RECIPE_MODULES.keys) {
+        // Keys off the module list rather than the jar manifest, so neither a mis-stamped License-Url on
+        // the (metadata only) Maven artifact nor rewrite-go's open-source license leaks a Go recipe here.
+        for (artifactId in GoRecipeLoader.GO_RECIPE_MODULES.keys + "rewrite-go") {
             val origin = RecipeOrigin("org.openrewrite.recipe", artifactId, "0.5.3", URI.create("file:///$artifactId.jar"))
                 .apply { license = Licenses.Apache2 }
             assertThat(RecipeMarkdownGenerator.isModerneDocsOnly(origin))


### PR DESCRIPTION
`rewrite-go`'s `RegenerateGoSum` was the one Go recipe with a page in the OpenRewrite docs; every other Go recipe comes from `recipes-go`, which is already Moderne-docs-only and surfaces there as a `moderne-recipes.md` entry linking to docs.moderne.io.

Add `rewrite-go` to `MODERNE_DOCS_ONLY_MODULES` so it's treated the same: written to the Moderne docs, listed among the Moderne-only recipes in the OpenRewrite docs, and redirected from its old `/recipes/golang/regenerategosum` URL. Go loading is unchanged — the moderne-docs run still needs the Go toolchain.

Side effect: as a Moderne-docs-only module, `rewrite-go` also drops out of the OpenRewrite docs' `latest-versions-of-every-openrewrite-module.md` table and `jar install` command, while staying in the Moderne docs version table.

Paired with openrewrite/rewrite-docs#525.