### PR TITLE
Resolve org.openrewrite and io.moderne artifacts from the Code Genome Project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ concurrency:
   group: "ci"
   cancel-in-progress: true
 
+env:
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
+
 jobs:
   build:
     name: Generate Latest Versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - main
 
+env:
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The generator loads TypeScript, Python, C#, and Go recipes by spawning external 
 * **.NET SDK** — C# recipes (`recipes-code-quality`, `recipes-migrate-dotnet`, `recipes-tunit`, `recipes-csharp-core`)
 * **Go 1.25+ and the `rewrite-go-rpc` server** — Go recipes (`recipes-go`). Build the server with `go install github.com/openrewrite/rewrite/rewrite-go/cmd/rpc@latest` (ideally pinned to the Go-module tag matching the `rewrite-go` release), then make it discoverable as `rewrite-go-rpc` on `PATH` — the `go install` binary is named `rpc`, so symlink or copy it (e.g. `ln -s "$(go env GOPATH)/bin/rpc" "$(go env GOPATH)/bin/rewrite-go-rpc"`). Installing recipes also requires network access so the server can `go get` the Go recipe module.
 
+OpenRewrite and Moderne artifacts are published to the [Code Genome Project](https://artifacts.codegenomeproject.org/maven) before they reach Maven Central. Set `codegenomeUsername` and `codegenomePassword` in `~/.gradle/gradle.properties` to document the newest releases; without them the build resolves `org.openrewrite` and `io.moderne` from Maven Central and documents whatever has made it there.
+
 If a toolchain is missing, the corresponding loader prints a warning and skips those recipes. The build still succeeds, so a local `./gradlew run` without all four toolchains silently produces incomplete docs. Most contributors don't have all four installed — if you need a complete regeneration, trigger the scheduled workflows above rather than running locally.
 
 ### Generate all docs

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,24 @@ val rewriteVersion = "latest.release"
 // that hosts nothing this build resolves costs a round trip per module.
 repositories {
     mavenLocal()
+    // First publish target for these groups, so consulted ahead of Maven Central. It rejects
+    // anonymous requests, hence only declared when credentials are set.
+    val codegenomeUsername = providers.gradleProperty("codegenomeUsername").getOrElse("")
+    val codegenomePassword = providers.gradleProperty("codegenomePassword").getOrElse("")
+    if (codegenomeUsername.isNotEmpty() && codegenomePassword.isNotEmpty()) {
+        maven {
+            name = "codegenome"
+            url = uri("https://artifacts.codegenomeproject.org/maven")
+            credentials {
+                username = codegenomeUsername
+                password = codegenomePassword
+            }
+            content {
+                includeGroupAndSubgroups("org.openrewrite")
+                includeGroupAndSubgroups("io.moderne")
+            }
+        }
+    }
     mavenCentral()
     if (rewriteVersion == "latest.integration") {
         maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,6 @@ val rewriteVersion = "latest.release"
 // that hosts nothing this build resolves costs a round trip per module.
 repositories {
     mavenLocal()
-    // First publish target for these groups, so consulted ahead of Maven Central. It rejects
-    // anonymous requests, hence only declared when credentials are set.
     val codegenomeUsername = providers.gradleProperty("codegenomeUsername").getOrElse("")
     val codegenomePassword = providers.gradleProperty("codegenomePassword").getOrElse("")
     if (codegenomeUsername.isNotEmpty() && codegenomePassword.isNotEmpty()) {


### PR DESCRIPTION
## Context / Problem Being Solved

The Code Genome Project is the first publish target for `org.openrewrite` and `io.moderne` artifacts, ahead of Maven Central, so a build resolving from Central sees each release later than it needs to. That matters more here than in most repos: every recipe coordinate in this build uses `latest.release`, and whatever this generator resolves is what ends up documented on docs.openrewrite.org and docs.moderne.io.

This repo has none of the three pieces that wire a build to CGP — it doesn't apply `org.openrewrite.build.recipe-repositories` (it declares its own `repositories {}`), and neither of its two Gradle workflows passes credentials.

## Solution

- `build.gradle.kts` declares CGP directly after `mavenLocal()`, mirroring [rewrite-build-gradle-plugin#206](https://github.com/openrewrite/rewrite-build-gradle-plugin/pull/206) and [moderne-build-logic#275](https://github.com/moderneinc/moderne-build-logic/pull/275): gated on `codegenomeUsername`/`codegenomePassword`, and `includeGroupAndSubgroups`-scoped to `org.openrewrite` and `io.moderne` so it isn't probed for anything else — the repository list here is walked for `maven-metadata.xml` on every dynamic coordinate, so an unscoped repository would cost a round trip per module.
- `ci.yml` and `test.yml` export `ORG_GRADLE_PROJECT_codegenome{Username,Password}` from the `CGP_ARTIFACTS_MAVEN_*` secrets, matching what [`gh-automation`](https://github.com/openrewrite/gh-automation/blob/main/.github/workflows/ci-gradle.yml) does for repos on the reusable workflow.
- A README note for contributors regenerating docs locally.

Verified locally against CGP with credentials — `rewrite-core` and friends resolve their metadata from CGP, the content filter keeps third-party lookups off it, and a run with the credentials blanked queries CGP zero times and resolves exactly as it does on `main` today.

## Follow-up, not in this PR

The full catalog is never generated by this repo's own CI — it only runs `-PlatestVersionsOnly=true`. The complete runs happen in [`rewrite-docs`](https://github.com/openrewrite/rewrite-docs/blob/master/.github/workflows/update-docs.yml) and [`moderne-docs`](https://github.com/moderneinc/moderne-docs/blob/main/.github/workflows/update-docs.yml), which check this repo out and run `./gradlew run` in their own workflows. Neither exports the CGP credentials today, so the nightly doc builds keep resolving from Maven Central until those two workflows get the same two env lines. Happy to open those alongside this.

## Notes for review

- **Secrets confirmed.** `CGP_ARTIFACTS_MAVEN_USERNAME` and `CGP_ARTIFACTS_MAVEN_TOKEN` are both visible to this repo at the org level (`/repos/.../actions/organization-secrets`), so the workflows do get real values.
- **Failure mode is quiet by design.** Missing or bad credentials mean Gradle skips (or 401s past) CGP and resolves from Maven Central, which is today's behaviour — no build failure either way. Pull requests from forks get no secrets and so always take that path. `moderneinc/rewrite-recipe-starter` treats the 2026-08-12 cutover as the point to switch to `credentials(PasswordCredentials::class)` and fail fast ([#138](https://github.com/moderneinc/rewrite-recipe-starter/pull/138)); this repo should follow at the same time.

Both checks pass on this PR, though green tells you little either way: the workflows don't run at `--info`, so nothing in the log distinguishes a CGP-backed resolution from a Central one. `rewrite-core` resolved to 8.88.4 in CI, the same version my local CGP-backed run picked. Draft pending a maintainer's read on whether this repo should adopt CGP ahead of the cutover.

