### PR TITLE
Drop dangling suppressionFile config for deleted suppressions.xml

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 dependencyCheck {
     analyzers.assemblyEnabled = false
-    suppressionFile = "suppressions.xml"
     scanConfigurations = listOf("runtimeClasspath")
     nvd.apiKey = System.getenv("NVD_API_KEY")
     analyzers.centralEnabled = System.getenv("CENTRAL_ANALYZER_ENABLED").toBoolean()


### PR DESCRIPTION
- Refs https://github.com/moderneinc/dependency-vulnerability-reports/issues/1151

The nightly OWASP scan for this repo has failed since 2026-08-17. It passed in [run 32028511198](https://github.com/moderneinc/dependency-vulnerability-reports/actions/runs/32028511198) (12:10 UTC) and failed in [run 32525588076](https://github.com/moderneinc/dependency-vulnerability-reports/actions/runs/32525588076):

```
Created CPE Index (3 seconds)
Unable to read suppression file [suppressions.xml]
Exception occurred initializing CPE Analyzer.
...
> Task :dependencyCheckAggregate FAILED
> Analysis failed.
```

### Cause

`suppressions.xml` was removed in `Delete empty suppressions.xml` (12:46 UTC on 2026-08-17, just after that day's successful scan), but the `dependencyCheck { suppressionFile = "suppressions.xml" }` config was left pointing at it. dependency-check-gradle 13.0.0 treats an unreadable suppression file as fatal — it aborts the CPE Analyzer and fails the task.

The plugin version is unchanged between the two runs (13.0.0 in both), so this is the dangling config, not an upstream behaviour change.

This repo applies `org.owasp.dependencycheck` directly rather than inheriting it from `rewrite-build-gradle-plugin`, so it does not get the plugin's `if (file.exists())` guard around suppression files.

### Fix

Drop the dangling line. The deleted file was empty, so this repo had no active suppressions and none are lost. If one is ever needed, re-add both the file and this config line together.

Verified `./gradlew help` evaluates the build script cleanly. The full `dependencyCheckAggregate` needs an `NVD_API_KEY`, so end-to-end validation is a rerun of the vulnerability scan once this merges.
